### PR TITLE
security(fix): require sessions for MCP token mutations

### DIFF
--- a/docs-site/src/content/docs/ai-reporting.md
+++ b/docs-site/src/content/docs/ai-reporting.md
@@ -95,6 +95,8 @@ Praetor espone un endpoint MCP remoto su `/api/mcp` per agenti compatibili con M
 
 Il token viene mostrato una sola volta al momento della creazione. Praetor conserva solo un hash, quindi revoca e ricrea il token se viene perso.
 
+La creazione e la revoca dei token MCP richiedono una sessione interattiva attiva: accedi a Praetor dal browser per eseguire queste operazioni. I token di accesso personali (PAT) non possono creare o revocare token MCP.
+
 > Nota di aggiornamento: la release che introduce la separazione delle chiavi crittografiche (issue #416) cambia la chiave HMAC usata per gli hash dei token MCP. Dopo l'aggiornamento i token MCP esistenti smettono di funzionare e vanno rigenerati da Impostazioni > MCP.
 
 Gli strumenti MCP rispettano sempre i permessi del tuo ruolo corrente. La prima versione include strumenti per utente corrente, utenti e gerarchie, clienti, fornitori, progetti, attività, preventivi, offerte, ordini, fatture, consuntivi e notifiche.

--- a/docs-site/src/content/docs/en/ai-reporting.md
+++ b/docs-site/src/content/docs/en/ai-reporting.md
@@ -95,6 +95,8 @@ Praetor exposes a remote MCP endpoint at `/api/mcp` for Model Context Protocol c
 
 The token is shown only once when it is created. Praetor stores only a hash, so revoke and recreate the token if it is lost.
 
+Creating and revoking MCP tokens requires an active interactive session: sign in to Praetor in the browser to perform either operation. Personal access tokens (PATs) cannot create or revoke MCP tokens.
+
 > Upgrade note: the release that introduces cryptographic key separation (issue #416) changes the HMAC key used for MCP-token hashes. After the upgrade, existing MCP tokens stop working and must be regenerated from Settings > MCP.
 
 MCP tools always respect the permissions of your current role. The first release includes tools for the current user, users and hierarchy, clients, suppliers, projects, tasks, quotes, offers, orders, invoices, time entries, and notifications.

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -22819,7 +22819,7 @@
         }
       },
       "post": {
-        "summary": "Create current user MCP token",
+        "summary": "Create current user MCP token (session-only)",
         "tags": [
           "settings"
         ],
@@ -23058,7 +23058,7 @@
     },
     "/api/settings/mcp-tokens/{id}": {
       "delete": {
-        "summary": "Revoke current user MCP token",
+        "summary": "Revoke current user MCP token (session-only)",
         "tags": [
           "settings"
         ],

--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -1,6 +1,10 @@
 import bcrypt from 'bcryptjs';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
-import { authenticateToken, generateTokenWithCurrentIdleTimeout } from '../middleware/auth.ts';
+import {
+  authenticateToken,
+  generateTokenWithCurrentIdleTimeout,
+  requireSessionAuth,
+} from '../middleware/auth.ts';
 import * as mcpTokensRepo from '../repositories/mcpTokensRepo.ts';
 import * as notificationsRepo from '../repositories/notificationsRepo.ts';
 import * as personalAccessTokensRepo from '../repositories/personalAccessTokensRepo.ts';
@@ -279,10 +283,14 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/mcp-tokens',
     {
-      onRequest: [fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT), authenticateToken],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        authenticateToken,
+        requireSessionAuth,
+      ],
       schema: {
         tags: ['settings'],
-        summary: 'Create current user MCP token',
+        summary: 'Create current user MCP token (session-only)',
         body: mcpTokenCreateBodySchema,
         response: {
           201: mcpTokenCreateResponseSchema,
@@ -328,10 +336,14 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.delete(
     '/mcp-tokens/:id',
     {
-      onRequest: [fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT), authenticateToken],
+      onRequest: [
+        fastify.rateLimit(STANDARD_ROUTE_RATE_LIMIT),
+        authenticateToken,
+        requireSessionAuth,
+      ],
       schema: {
         tags: ['settings'],
-        summary: 'Revoke current user MCP token',
+        summary: 'Revoke current user MCP token (session-only)',
         params: {
           type: 'object',
           properties: { id: { type: 'string' } },

--- a/server/test/routes/settings.test.ts
+++ b/server/test/routes/settings.test.ts
@@ -45,8 +45,10 @@ const generateRawMcpTokenMock = mock();
 const createMcpTokenForUserMock = mock();
 const revokeMcpTokenForUserMock = mock();
 const findPersonalAccessTokenByUserIdMock = mock();
+const findPersonalAccessTokenByTokenHashMock = mock();
 const createPersonalAccessTokenIfMissingMock = mock();
 const renewPersonalAccessTokenForUserMock = mock();
+const markPersonalAccessTokenUsedMock = mock(async () => undefined);
 const bcryptCompareMock = mock();
 const bcryptHashMock = mock();
 const logAuditMock = mock(async () => undefined);
@@ -91,8 +93,10 @@ beforeAll(async () => {
   mock.module('../../repositories/personalAccessTokensRepo.ts', () => ({
     ...personalAccessTokensRepoSnap,
     findByUserId: findPersonalAccessTokenByUserIdMock,
+    findByTokenHash: findPersonalAccessTokenByTokenHashMock,
     createForUserIfMissing: createPersonalAccessTokenIfMissingMock,
     renewForUser: renewPersonalAccessTokenForUserMock,
+    markUsed: markPersonalAccessTokenUsedMock,
   }));
   mock.module('../../utils/audit.ts', () => ({
     ...auditSnap,
@@ -130,6 +134,7 @@ const HAPPY_USER = {
   avatarInitials: 'AL',
   isDisabled: false,
   sessionVersion: 1,
+  tokenVersion: 0,
 };
 
 const HAPPY_SETTINGS = {
@@ -164,8 +169,10 @@ const allMocks = [
   createMcpTokenForUserMock,
   revokeMcpTokenForUserMock,
   findPersonalAccessTokenByUserIdMock,
+  findPersonalAccessTokenByTokenHashMock,
   createPersonalAccessTokenIfMissingMock,
   renewPersonalAccessTokenForUserMock,
+  markPersonalAccessTokenUsedMock,
   bcryptCompareMock,
   bcryptHashMock,
   logAuditMock,
@@ -203,6 +210,12 @@ beforeEach(async () => {
   });
   revokeMcpTokenForUserMock.mockResolvedValue(true);
   findPersonalAccessTokenByUserIdMock.mockResolvedValue(HAPPY_PERSONAL_ACCESS_TOKEN);
+  findPersonalAccessTokenByTokenHashMock.mockResolvedValue({
+    userId: 'u1',
+    tokenVersionAtIssue: HAPPY_USER.tokenVersion,
+    lastUsedAt: null,
+    updatedAt: new Date(),
+  });
   createPersonalAccessTokenIfMissingMock.mockResolvedValue({
     record: HAPPY_PERSONAL_ACCESS_TOKEN,
     created: false,
@@ -218,6 +231,7 @@ afterEach(async () => {
 });
 
 const authHeader = () => ({ authorization: `Bearer ${signToken({ userId: 'u1' })}` });
+const patHeader = () => ({ authorization: 'Bearer praetor_pat_forged-test-token' });
 
 describe('GET /api/settings', () => {
   test('200 returns settings via getOrCreateForUser with defaults', async () => {
@@ -485,6 +499,20 @@ describe('MCP token settings routes', () => {
     );
   });
 
+  test('POST /api/settings/mcp-tokens rejects personal access token authentication', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/settings/mcp-tokens',
+      headers: patHeader(),
+      payload: { name: 'Persistence token' },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toBe('Session authentication required');
+    expect(listMcpTokensForUserMock).not.toHaveBeenCalled();
+    expect(createMcpTokenForUserMock).not.toHaveBeenCalled();
+  });
+
   test('POST /api/settings/mcp-tokens defaults scope to full when omitted', async () => {
     const res = await testApp.inject({
       method: 'POST',
@@ -578,6 +606,18 @@ describe('MCP token settings routes', () => {
     expect(res.statusCode).toBe(204);
     expect(res.body).toBe('');
     expect(revokeMcpTokenForUserMock).toHaveBeenCalledWith('mcp-token-1', 'u1');
+  });
+
+  test('DELETE /api/settings/mcp-tokens/:id rejects personal access token authentication', async () => {
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/settings/mcp-tokens/mcp-token-1',
+      headers: patHeader(),
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toBe('Session authentication required');
+    expect(revokeMcpTokenForUserMock).not.toHaveBeenCalled();
   });
 
   test('DELETE /api/settings/mcp-tokens/:id returns 404 for missing token (audits the denial)', async () => {


### PR DESCRIPTION
## Summary
- Require an interactive session to create or revoke MCP tokens.
- Prevent a valid personal access token from minting a separate full-scope MCP credential or revoking MCP credentials.
- Keep MCP token listing available to authenticated API clients.

## Changes
- Add `requireSessionAuth` after `authenticateToken` on `POST /api/settings/mcp-tokens` and `DELETE /api/settings/mcp-tokens/:id`.
- Add valid-PAT route regressions proving both mutations return 403 before repository work runs.
- Mark both mutations as session-only in the route/OpenAPI summaries.
- Document the interactive-session requirement in the Italian and English MCP user guides.

## Security impact
Before this change, a stolen PAT could call the MCP token creation route, omit `scope`, and receive a new full-scope MCP credential. The new guard rejects PAT-authenticated creation and revocation with `403 Session authentication required`, limiting credential mutation to browser-backed sessions.

## Testing
- Vulnerability proof before the route fix: `cd server && bun test ./test/routes/settings.test.ts` — the new regressions failed with POST returning 201 and DELETE returning 204.
- `cd server && bun test ./test/routes/settings.test.ts` — 41 passed, 0 failed.
- `cd server && bun test ./test/routes/settings.test.ts ./test/middleware/auth.test.ts` — 95 passed, 0 failed.
- `bun run test:server` — 4,301 passed, 28 integration tests skipped, 0 failed.
- `bun run docs:api` — passed; regenerated `docs/api/openapi.json`.
- `bun run docs:user` — passed; 22 documentation pages built.
- `bun run test:react-doctor` — 80/100 before and after; unchanged existing error in `components/projects/DashboardGrid.tsx:165`.
- `bun run lint` — i18n and both TypeScript checks passed; the whole-repository Biome step reported 1,157 CRLF-only formatter diagnostics across the Windows checkout. The pre-commit focused Biome task passed for the changed TypeScript/JSON files.
- `git diff --check` — passed.

## Review discipline
Completed three consecutive clean review/simplify cycles covering code reuse, efficiency, and quality/bugs. No additional validated changes were found.

## Risks / Rollout
- Intentional compatibility change: PAT-based automation that creates or revokes MCP tokens will now receive 403 and must use an interactive session.
- No database migration, data backfill, configuration change, dependency change, or deployment ordering requirement.
- Rollback is a code revert; no persisted data shape changes are involved.

## Issues
Issue: Not linked.