### PR TITLE
ci(security): validate release workflow version

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Image tag to publish (example: v1.2.3)'
+        description: 'Version to publish (vMAJOR.MINOR.PATCH or vMAJOR.MINOR.PATCH-prerelease)'
         required: true
         type: string
 
@@ -23,6 +23,27 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Resolve image metadata
+        id: meta
+        shell: bash
+        env:
+          DISPATCH_VERSION: ${{ inputs.version }}
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            VERSION="${DISPATCH_VERSION}"
+          else
+            VERSION="${GITHUB_REF_NAME}"
+          fi
+
+          if [[ ! "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
+            echo "Invalid version '${VERSION}'. Expected vMAJOR.MINOR.PATCH with an optional prerelease suffix." >&2
+            exit 1
+          fi
+
+          OWNER_LC="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "owner=${OWNER_LC}" >> "${GITHUB_OUTPUT}"
 
       - name: Create Release
         if: github.event_name == 'push'
@@ -42,20 +63,6 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Resolve image metadata
-        id: meta
-        shell: bash
-        run: |
-          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            VERSION="${{ inputs.version }}"
-          else
-            VERSION="${GITHUB_REF_NAME}"
-          fi
-
-          OWNER_LC="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
-          echo "version=${VERSION}" >> "${GITHUB_OUTPUT}"
-          echo "owner=${OWNER_LC}" >> "${GITHUB_OUTPUT}"
 
       - name: Build and push frontend image
         uses: docker/build-push-action@v6

--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       version:
-        description: 'Version to publish (vMAJOR.MINOR.PATCH or vMAJOR.MINOR.PATCH-prerelease)'
+        description: 'Version to publish (vMAJOR.MINOR.PATCH[-prerelease], max 128 characters)'
         required: true
         type: string
 
@@ -36,8 +36,8 @@ jobs:
             VERSION="${GITHUB_REF_NAME}"
           fi
 
-          if [[ ! "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
-            echo "Invalid version '${VERSION}'. Expected vMAJOR.MINOR.PATCH with an optional prerelease suffix." >&2
+          if (( ${#VERSION} > 128 )) || [[ ! "${VERSION}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]; then
+            echo "Invalid version. Expected at most 128 characters in vMAJOR.MINOR.PATCH[-prerelease] format." >&2
             exit 1
           fi
 

--- a/README.md
+++ b/README.md
@@ -103,13 +103,15 @@ For complete customer deployment details, see `deploy/README.md`.
 
 ### Publishing release images
 
-This repository includes GitHub Actions workflow `publish-images.yml` that pushes:
+This repository includes GitHub Actions workflow `create-release.yml` that pushes:
 
 - `ghcr.io/<owner>/praetor-frontend:<version>`
 - `ghcr.io/<owner>/praetor-backend:<version>`
 - `latest` tags for both images
 
-The workflow runs on `v*` git tags and can also be run manually.
+The workflow runs on `v*` git tags and can also be run manually. The resolved version must use
+`vMAJOR.MINOR.PATCH` with an optional `-prerelease` suffix; invalid values stop the workflow before
+release creation or registry authentication.
 
 ## Usage Guide
 

--- a/README.md
+++ b/README.md
@@ -110,8 +110,8 @@ This repository includes GitHub Actions workflow `create-release.yml` that pushe
 - `latest` tags for both images
 
 The workflow runs on `v*` git tags and can also be run manually. The resolved version must use
-`vMAJOR.MINOR.PATCH` with an optional `-prerelease` suffix; invalid values stop the workflow before
-release creation or registry authentication.
+`vMAJOR.MINOR.PATCH` with an optional `-prerelease` suffix and cannot exceed 128 characters; invalid
+values stop the workflow before release creation or registry authentication.
 
 ## Usage Guide
 

--- a/docs/frontend/index.html
+++ b/docs/frontend/index.html
@@ -89,13 +89,15 @@ procedure for an existing volume.</p>
 <p>That deployment also defaults backend <code>TRUST_PROXY=1</code>; override it if your proxy chain differs.</p>
 <p>For complete customer deployment details, see <code>deploy/README.md</code>.</p>
 <h3 id="publishing-release-images" class="tsd-anchor-link">Publishing release images<a href="#publishing-release-images" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="assets/icons.svg#icon-anchor"></use></svg></a></h3>
-<p>This repository includes GitHub Actions workflow <code>publish-images.yml</code> that pushes:</p>
+<p>This repository includes GitHub Actions workflow <code>create-release.yml</code> that pushes:</p>
 <ul>
 <li><code>ghcr.io/&lt;owner&gt;/praetor-frontend:&lt;version&gt;</code></li>
 <li><code>ghcr.io/&lt;owner&gt;/praetor-backend:&lt;version&gt;</code></li>
 <li><code>latest</code> tags for both images</li>
 </ul>
-<p>The workflow runs on <code>v*</code> git tags and can also be run manually.</p>
+<p>The workflow runs on <code>v*</code> git tags and can also be run manually. The resolved version must use
+<code>vMAJOR.MINOR.PATCH</code> with an optional <code>-prerelease</code> suffix and cannot exceed 128 characters; invalid
+values stop the workflow before release creation or registry authentication.</p>
 <h2 id="usage-guide" class="tsd-anchor-link">Usage Guide<a href="#usage-guide" aria-label="Permalink" class="tsd-anchor-icon"><svg viewBox="0 0 24 24" aria-hidden="true"><use href="assets/icons.svg#icon-anchor"></use></svg></a></h2>
 <ul>
 <li>

--- a/test/workflows/create-release.test.ts
+++ b/test/workflows/create-release.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from 'bun:test';
+
+const workflow = await Bun.file(
+  new URL('../../.github/workflows/create-release.yml', import.meta.url),
+).text();
+const metadataStepMarker = '      - name: Resolve image metadata';
+const metadataStepIndex = workflow.indexOf(metadataStepMarker);
+if (metadataStepIndex < 0) throw new Error('Resolve image metadata step not found');
+const nextStepIndex = workflow.indexOf(
+  '\n      - name:',
+  metadataStepIndex + metadataStepMarker.length,
+);
+const metadataStep = workflow.slice(
+  metadataStepIndex,
+  nextStepIndex < 0 ? undefined : nextStepIndex,
+);
+const metadataScript = metadataStep.slice(metadataStep.indexOf('        run: |'));
+
+describe('release workflow image metadata', () => {
+  test('passes the dispatch version through the environment before Bash parses it', () => {
+    expect(metadataStep).toContain(`DISPATCH_VERSION: \${{ inputs.version }}`);
+    expect(metadataScript).not.toContain(`\${{ inputs.version }}`);
+    expect(metadataScript).toContain(`VERSION="\${DISPATCH_VERSION}"`);
+  });
+
+  test('rejects versions outside the supported release-tag format', () => {
+    expect(metadataScript).toContain(
+      `[[ ! "\${VERSION}" =~ ^v[0-9]+\\.[0-9]+\\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]`,
+    );
+    expect(metadataScript).toContain('exit 1');
+  });
+
+  test('validates the version before privileged release and registry steps', () => {
+    expect(metadataStepIndex).toBeLessThan(workflow.indexOf('      - name: Create Release'));
+    expect(metadataStepIndex).toBeLessThan(workflow.indexOf('      - name: Login to GHCR'));
+  });
+});

--- a/test/workflows/create-release.test.ts
+++ b/test/workflows/create-release.test.ts
@@ -24,9 +24,11 @@ describe('release workflow image metadata', () => {
   });
 
   test('rejects versions outside the supported release-tag format', () => {
+    expect(metadataScript).toContain(`(( \${#VERSION} > 128 ))`);
     expect(metadataScript).toContain(
       `[[ ! "\${VERSION}" =~ ^v[0-9]+\\.[0-9]+\\.[0-9]+(-[A-Za-z0-9.-]+)?$ ]]`,
     );
+    expect(metadataScript).not.toContain(`echo "Invalid version '\${VERSION}'`);
     expect(metadataScript).toContain('exit 1');
   });
 


### PR DESCRIPTION
## Summary
- prevents manually dispatched release versions from being interpolated into the Bash script
- validates resolved versions before release creation or GHCR authentication
- documents the supported release-version format

## Changes
- passes `inputs.version` through the step environment and reads `GITHUB_EVENT_NAME` from the runner environment
- accepts only `vMAJOR.MINOR.PATCH` with an optional alphanumeric/dot/hyphen prerelease suffix
- adds regression coverage for the expression boundary, validation guard, and fail-fast step ordering
- corrects the release workflow name and input contract in the README

## Security impact
The previous workflow expanded the manual `version` input while generating an inline Bash script. A dispatcher could inject shell syntax into a job with `contents: write` and `packages: write`. The input is now data in an environment variable, is restricted to safe release-tag characters and shape, and is rejected before privileged release or registry steps.

## Testing
Passed:
- `bun test test/workflows/create-release.test.ts` (3 passed)
- `bun run i18n:check`
- `bun run typecheck`
- `bunx biome check test/workflows/create-release.test.ts`
- workflow YAML parse with `Bun.YAML.parse`
- Bash valid/invalid, quote/semicolon, and newline payload probes
- `git diff --check`
- React Doctor: 80/100 before and 80/100 after (33 unchanged pre-existing findings)

Broader checkout checks:
- `bun run test:frontend`: 2,418 passed; 4 unrelated source-string tests failed because the Windows checkout uses CRLF while their expected literals use LF
- `bun run lint`: i18n and both TypeScript projects passed; repository-wide Biome then reported 1,157 CRLF formatting errors in unchanged files

## Risks / Rollout
- Manual dispatches and `v*` tag runs now fail early unless the resolved version matches the documented format.
- No database, API, application configuration, dependency, or production data changes.
- Rollout is the workflow change on merge; no backfill or compatibility window is required.
- Roll forward by adjusting the allowlist only if a new legitimate tag format is needed. Reverting would restore the command-injection exposure.

## Issues
Issue: Not linked