### PR TITLE
users(fix): enforce deletion management scope

### DIFF
--- a/docs-site/src/content/docs/administration.md
+++ b/docs-site/src/content/docs/administration.md
@@ -13,6 +13,8 @@ La pagina **Utenti** resta focalizzata sull'accesso applicativo: username, ruolo
 
 Le righe di permesso con ambito **All** concedono accesso trasversale a tutti i record della stessa area, ad esempio tutti i clienti, fornitori, progetti, task, consuntivi o Competence Center. L'azione **View** abilita la vista e la consultazione su tutti i record; quando selezionate, anche **Create**, **Update** e **Delete** sono permessi reali e consentono scritture su record non assegnati. I permessi senza **All** mantengono l'ambito assegnato all'utente.
 
+L'eliminazione di un utente richiede il permesso **Delete** adatto al tipo di dipendente. Senza `administration.user_management_all.view`, il chiamante può eliminare soltanto utenti che gestisce tramite un Competence Center condiviso; l'ambito **All** consente invece di eliminare qualsiasi utente idoneo, escluso il proprio account.
+
 Il permesso `timesheets.expired_projects.create` abilita la registrazione di ore su progetti scaduti. I ruoli di sistema **Manager** e **Top Manager** lo ricevono per impostazione predefinita; per gli altri ruoli assegnalo solo quando è necessario consentire consuntivazioni tardive o rettifiche operative su progetti già conclusi.
 
 Il permesso di sola lettura `projects.details.view` separa l'archivio commesse dai dati avanzati della singola commessa. Per aprire il dettaglio servono anche `projects.manage.view` o `projects.manage_all.view`; Manager e Top Manager ricevono il nuovo permesso per impostazione predefinita, mentre User e Admin no. I ruoli personalizzati possono riceverlo manualmente.

--- a/docs-site/src/content/docs/en/administration.md
+++ b/docs-site/src/content/docs/en/administration.md
@@ -13,6 +13,8 @@ The **Users** page stays focused on application access: username, role, permissi
 
 Permission rows marked **All** grant cross-record access for the same area, such as all clients, suppliers, projects, tasks, time entries, or competence centers. **View** opens the matching view and allows reading every matching record; when selected, **Create**, **Update**, and **Delete** are real write permissions and can operate on records that are not assigned to the user. Non-**All** permissions keep the user's assigned-record scope.
 
+Deleting a user requires the **Delete** permission for that employee type. Without `administration.user_management_all.view`, the caller may delete only users they manage through a shared competence center; **All** scope permits deletion of any otherwise eligible user except the caller's own account.
+
 The `timesheets.expired_projects.create` permission allows time entry logging on expired projects. The built-in **Manager** and **Top Manager** roles receive it by default; grant it to other roles only when they need late timesheet corrections or operational logging on completed projects.
 
 The view-only `projects.details.view` permission separates the jobs archive from an individual job's advanced data. Opening the detail also requires `projects.manage.view` or `projects.manage_all.view`; Manager and Top Manager receive the new permission by default, while User and Admin do not. Custom roles can be granted it explicitly.

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4564,6 +4564,7 @@
         "tags": [
           "users"
         ],
+        "description": "Requires delete permission for the target employee type. Callers without administration.user_management_all.view must manage the target through a shared work unit.",
         "parameters": [
           {
             "schema": {

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -1129,6 +1129,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       schema: {
         tags: ['users'],
         summary: 'Delete user',
+        description:
+          'Requires delete permission for the target employee type. Callers without administration.user_management_all.view must manage the target through a shared work unit.',
         params: idParamSchema,
         response: {
           204: { type: 'null' },
@@ -1162,6 +1164,20 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           entityType: 'user',
           entityId: id,
           details: { secondaryLabel: `employee_type_${user.employeeType}` },
+        });
+      }
+
+      if (
+        !hasPermission(request, 'administration.user_management_all.view') &&
+        !(await usersRepo.canManageUser(id, request.user?.id ?? ''))
+      ) {
+        return replyError(request, reply, {
+          statusCode: 403,
+          message: 'Insufficient permissions',
+          action: 'user.delete.denied',
+          entityType: 'user',
+          entityId: id,
+          details: { secondaryLabel: 'cannot_manage_user' },
         });
       }
 

--- a/server/test/routes/users.test.ts
+++ b/server/test/routes/users.test.ts
@@ -1320,6 +1320,7 @@ describe('DELETE /api/users/:id', () => {
     expect(res.statusCode).toBe(204);
     expect(res.body).toBe('');
     expect(deleteByIdMock).toHaveBeenCalledWith('u-target');
+    expect(canManageUserMock).not.toHaveBeenCalled();
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'user.deleted', entityId: 'u-target' }),
     );
@@ -1336,6 +1337,50 @@ describe('DELETE /api/users/:id', () => {
     });
 
     expect(res.statusCode).toBe(204);
+    expect(deleteByIdMock).toHaveBeenCalledWith('u-target');
+  });
+
+  test('403 scoped user manager cannot delete an unmanaged app user', async () => {
+    findAuthUserByIdMock.mockResolvedValue(MANAGER_USER);
+    getRolePermissionsMock.mockResolvedValue(['administration.user_management.delete']);
+    findCoreByIdMock.mockResolvedValue(SAMPLE_USER_CORE);
+    canManageUserMock.mockResolvedValue(false);
+    deleteByIdMock.mockResolvedValue(true);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/users/u-target',
+      headers: managerAuth(),
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(canManageUserMock).toHaveBeenCalledWith('u-target', MANAGER_USER.id);
+    expect(deleteByIdMock).not.toHaveBeenCalled();
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'user.delete.denied',
+        entityType: 'user',
+        entityId: 'u-target',
+        details: { secondaryLabel: 'cannot_manage_user' },
+      }),
+    );
+  });
+
+  test('204 scoped user manager deletes a managed app user', async () => {
+    findAuthUserByIdMock.mockResolvedValue(MANAGER_USER);
+    getRolePermissionsMock.mockResolvedValue(['administration.user_management.delete']);
+    findCoreByIdMock.mockResolvedValue(SAMPLE_USER_CORE);
+    canManageUserMock.mockResolvedValue(true);
+    deleteByIdMock.mockResolvedValue(true);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/users/u-target',
+      headers: managerAuth(),
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(canManageUserMock).toHaveBeenCalledWith('u-target', MANAGER_USER.id);
     expect(deleteByIdMock).toHaveBeenCalledWith('u-target');
   });
 


### PR DESCRIPTION
## Summary
- Prevents scoped user managers from deleting application or employee accounts outside the work units they manage.
- Preserves deletion for callers with `administration.user_management_all.view` and for scoped callers who manage the target.
- Documents the authorization boundary in Italian, English, and generated OpenAPI output.

## Changes
- Adds the established `administration.user_management_all.view` / `usersRepo.canManageUser` target-scope guard before `deleteById`.
- Audits out-of-scope attempts as `user.delete.denied` with the existing `cannot_manage_user` detail.
- Adds route regressions for unmanaged denial, managed deletion, and all-scope query bypass.

## Security impact
Before this change, a custom/scoped caller with the target employee type's delete permission could delete any eligible account, including an account outside the caller's managed work units. The route now returns 403 unless the caller has all-user scope or manages the target through a shared work unit.

## Testing
- Pre-fix exploit proof: `cd server && bun test ./test/routes/users.test.ts` — 154 passed and the new regression failed as expected with 204 instead of 403.
- `cd server && bun test ./test/routes/users.test.ts` — 156 passed, 0 failed.
- `bun run test:server` — 4,306 passed, 28 integration tests skipped, 0 failed.
- `bun run typecheck` — passed.
- `bun run docs:api` — passed; regenerated `docs/api/openapi.json`.
- `bun run docs:user` — passed; 22 documentation pages built.
- `bunx biome check --formatter-enabled=false server/routes/users.ts server/test/routes/users.test.ts docs/api/openapi.json` — passed.
- `git diff --check origin/main` — passed.
- React Doctor with isolated cache/temp: 80/100 before and 80/100 after; unchanged pre-existing error in `components/projects/DashboardGrid.tsx:165` and 32 warnings.

## Review discipline
Completed three consecutive clean review/simplify cycles on the final current-main diff, separately covering code reuse, efficiency, and quality/bugs. No additional validated changes were found.

## Risks / Rollout
- Intentional authorization compatibility change: callers with delete permission but neither all-user scope nor a managed-work-unit relationship now receive 403.
- No database migration, backfill, seed, configuration, dependency, or deployment-order change.
- Normal application deployment is sufficient; rollback is a code revert with no persisted data-shape change.

## Issues
Issue: Not linked.