### PR TITLE
webhooks(security): harden outbound dispatch

### DIFF
--- a/components/administration/WebhooksView.tsx
+++ b/components/administration/WebhooksView.tsx
@@ -74,7 +74,7 @@ const asSingleValue = (value: string | string[]): string =>
 const isValidWebhookUrl = (value: string): boolean => {
   try {
     const url = new URL(value);
-    return url.protocol === 'http:' || url.protocol === 'https:';
+    return url.protocol === 'https:' && !url.username && !url.password;
   } catch {
     return false;
   }

--- a/docs-site/src/content/docs/administration.md
+++ b/docs-site/src/content/docs/administration.md
@@ -136,12 +136,12 @@ La coda PostgreSQL conserva gli eventi durante errori o riavvii e ritenta con at
 
 ## Webhook
 
-I webhook consentono agli amministratori di registrare destinazioni HTTP in uscita che Praetor può chiamare per notificare sistemi esterni. La pagina **Webhook** elenca tutte le destinazioni configurate ed è disponibile agli amministratori con i permessi `administration.webhooks` corrispondenti.
+I webhook consentono agli amministratori di registrare destinazioni HTTPS pubbliche in uscita che Praetor può chiamare per notificare sistemi esterni. La pagina **Webhook** elenca tutte le destinazioni configurate ed è disponibile agli amministratori con i permessi `administration.webhooks` corrispondenti.
 
 Ogni destinazione definisce:
 
 - **Nome** e una **Descrizione** facoltativa per identificare l'integrazione.
-- **URL** — l'endpoint che Praetor chiama. Sono accettati solo URL `http` e `https`.
+- **URL** — l'endpoint HTTPS pubblico che Praetor chiama. Non sono accettati URL con credenziali incorporate né destinazioni loopback, private, link-local o riservate. Praetor risolve e vincola l'indirizzo prima della connessione e non segue i reindirizzamenti.
 - **Metodo HTTP** — `GET`, `POST` (predefinito), `PUT`, `PATCH` o `DELETE`.
 - **Autenticazione** — come Praetor si autentica verso la destinazione: **Nessuna**, **Bearer token**, **Basic** (nome utente e password) o **Chiave API** (un valore inviato in un header personalizzato che assegni). La credenziale segreta è cifrata a riposo e non viene mai restituita al browser; in modifica mostra un badge **Memorizzato — Sostituisci**, e lo stesso comportamento Mantieni / Sostituisci degli altri campi segreti la preserva finché non la sostituisci o la rimuovi esplicitamente.
 - **Header personalizzati** — coppie chiave/valore facoltative allegate a ogni richiesta, sovrapposte all'header di autenticazione. Usali per valori di instradamento non segreti come un id tenant.
@@ -150,3 +150,5 @@ Ogni destinazione definisce:
 Le azioni di creazione, modifica ed eliminazione sono regolate rispettivamente dai permessi create, update e delete, e ogni modifica viene scritta nel log di audit.
 
 Questa pagina configura solo le destinazioni; gli eventi che attivano ciascun webhook vengono collegati separatamente, ad esempio nelle azioni delle regole commessa.
+
+> Nota di aggiornamento: le destinazioni `http://` salvate da versioni precedenti non vengono più inviate. Modificale con un endpoint HTTPS pubblico prima di riabilitare le regole che le usano.

--- a/docs-site/src/content/docs/en/administration.md
+++ b/docs-site/src/content/docs/en/administration.md
@@ -136,12 +136,12 @@ The PostgreSQL queue preserves events across failures and restarts and retries w
 
 ## Webhooks
 
-Webhooks let administrators register outbound HTTP targets that Praetor can call to notify external systems. The **Webhooks** page lists every configured target and is available to administrators with the matching `administration.webhooks` permissions.
+Webhooks let administrators register public outbound HTTPS targets that Praetor can call to notify external systems. The **Webhooks** page lists every configured target and is available to administrators with the matching `administration.webhooks` permissions.
 
 Each target defines:
 
 - **Name** and an optional **Description** to identify the integration.
-- **URL** — the endpoint Praetor calls. Only `http` and `https` URLs are accepted.
+- **URL** — the public HTTPS endpoint Praetor calls. URLs with embedded credentials and loopback, private, link-local, or reserved destinations are rejected. Praetor resolves and pins the address before connecting and does not follow redirects.
 - **HTTP method** — `GET`, `POST` (default), `PUT`, `PATCH`, or `DELETE`.
 - **Authentication** — how Praetor authenticates to the target: **None**, **Bearer token**, **Basic** (username and password), or **API key** (a value sent under a custom header you name). The secret credential is encrypted at rest and never returned to the browser; when editing it shows a **Stored — Replace** badge, and the same Keep / Replace behavior as the other secret fields preserves it unless you explicitly replace or clear it.
 - **Custom headers** — optional key/value pairs attached to every request, layered on top of the authentication header. Use these for non-secret routing values such as a tenant id.
@@ -150,3 +150,5 @@ Each target defines:
 Create, edit, and delete actions are gated by the create, update, and delete permissions respectively, and every change is written to the audit log.
 
 This page configures targets only; the events that trigger each webhook are wired up separately, for example in job-rule actions.
+
+> Upgrade note: `http://` targets saved by earlier versions are no longer dispatched. Update them to a public HTTPS endpoint before re-enabling rules that use them.

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -58000,7 +58000,8 @@
                   },
                   "url": {
                     "type": "string",
-                    "maxLength": 2000
+                    "maxLength": 2000,
+                    "description": "HTTPS target URL without embedded credentials"
                   },
                   "httpMethod": {
                     "type": "string",
@@ -58577,7 +58578,8 @@
                   },
                   "url": {
                     "type": "string",
-                    "maxLength": 2000
+                    "maxLength": 2000,
+                    "description": "HTTPS target URL without embedded credentials"
                   },
                   "httpMethod": {
                     "type": "string",

--- a/locales/en/administration.json
+++ b/locales/en/administration.json
@@ -382,7 +382,7 @@
     },
     "errors": {
       "urlRequired": "URL is required.",
-      "urlInvalid": "Enter a valid http(s) URL.",
+      "urlInvalid": "Enter a valid HTTPS URL without embedded credentials.",
       "headerNameRequired": "Header name is required for API key authentication.",
       "headerKeyRequired": "Header key is required."
     },

--- a/locales/it/administration.json
+++ b/locales/it/administration.json
@@ -382,7 +382,7 @@
     },
     "errors": {
       "urlRequired": "L'URL è obbligatorio.",
-      "urlInvalid": "Inserisci un URL http(s) valido.",
+      "urlInvalid": "Inserisci un URL HTTPS valido senza credenziali incorporate.",
       "headerNameRequired": "Il nome header è obbligatorio per l'autenticazione con chiave API.",
       "headerKeyRequired": "La chiave dell'header è obbligatoria."
     },

--- a/server/routes/webhooks.ts
+++ b/server/routes/webhooks.ts
@@ -72,7 +72,11 @@ const webhookResponseSchema = {
 const webhookBodyProperties = {
   name: { type: 'string', maxLength: MAX_NAME_LEN },
   description: { type: 'string' },
-  url: { type: 'string', maxLength: MAX_URL_LEN },
+  url: {
+    type: 'string',
+    maxLength: MAX_URL_LEN,
+    description: 'HTTPS target URL without embedded credentials',
+  },
   httpMethod: { type: 'string', enum: [...WEBHOOK_HTTP_METHODS] },
   authType: { type: 'string', enum: [...WEBHOOK_AUTH_TYPES] },
   authUsername: { type: 'string', maxLength: MAX_AUTH_FIELD_LEN },
@@ -109,7 +113,7 @@ const idParamsSchema = {
 const isValidWebhookUrl = (value: string): boolean => {
   try {
     const url = new URL(value);
-    return url.protocol === 'http:' || url.protocol === 'https:';
+    return url.protocol === 'https:' && !url.username && !url.password;
   } catch {
     return false;
   }
@@ -165,7 +169,7 @@ const validateWebhookBody = (
       return null;
     }
     if (!isValidWebhookUrl(url.value)) {
-      badRequest(reply, 'url must be a valid http(s) URL');
+      badRequest(reply, 'url must be a valid HTTPS URL without embedded credentials');
       return null;
     }
     input.url = url.value;

--- a/server/services/sso.ts
+++ b/server/services/sso.ts
@@ -1,10 +1,3 @@
-import type { LookupAddress } from 'node:dns';
-import dns from 'node:dns/promises';
-import type { IncomingMessage } from 'node:http';
-import https, { type RequestOptions as HttpsRequestOptions } from 'node:https';
-import { isIP } from 'node:net';
-import { addAbortSignal, Readable } from 'node:stream';
-import { createBrotliDecompress, createGunzip, createInflate } from 'node:zlib';
 import {
   type CacheItem,
   type CacheProvider,
@@ -27,7 +20,14 @@ import { NotFoundError } from '../utils/http-errors.ts';
 import { createChildLogger } from '../utils/logger.ts';
 import { generatePrefixedId } from '../utils/order-ids.ts';
 import { getRolePermissions } from '../utils/permissions.ts';
+import {
+  fetchPinnedRemoteUrl,
+  isPrivateIp,
+  resolveSafeRemoteAddresses,
+} from '../utils/safe-remote-fetch.ts';
 import { ExternalAuthError, resolveExternalIdentity } from './external-auth.ts';
+
+export { isPrivateIp };
 
 const logger = createChildLogger({ module: 'sso' });
 
@@ -479,160 +479,6 @@ const parseSamlMetadata = (xml: string): SamlMetadataConfig => {
     candidates.find((candidate) => hasConfigValue(candidate.idpIssuer)) ??
     candidates[0] ?? { idpIssuer: '', entryPoint: '', idpCert: '' }
   );
-};
-
-/**
- * Returns true when `ip` is in an IPv4 / IPv6 private, loopback, or link-local range that a
- * server-side fetch should NEVER target. Blocks the standard SSRF egress targets:
- *   - 127.0.0.0/8 (loopback)
- *   - 10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16 (RFC1918 private)
- *   - 169.254.0.0/16 (link-local incl. cloud metadata 169.254.169.254)
- *   - 100.64.0.0/10 (carrier-grade NAT — non-routable on the public internet)
- *   - 0.0.0.0/8
- *   - ::1 (IPv6 loopback)
- *   - fc00::/7 (IPv6 unique-local)
- *   - fe80::/10 (IPv6 link-local)
- */
-const ipv4FromMappedIpv6 = (ip: string): string | null => {
-  const dotted = ip.match(/^(?:::ffff:|0:0:0:0:0:ffff:)(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
-  if (dotted) return dotted[1];
-
-  const hex = ip.match(/^(?:::ffff:|0:0:0:0:0:ffff:)([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
-  if (!hex) return null;
-  const high = Number.parseInt(hex[1], 16);
-  const low = Number.parseInt(hex[2], 16);
-  return `${(high >> 8) & 0xff}.${high & 0xff}.${(low >> 8) & 0xff}.${low & 0xff}`;
-};
-
-export const isPrivateIp = (ip: string): boolean => {
-  const v4 = ip.match(/^(\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})$/);
-  if (v4) {
-    const [a, b] = [Number(v4[1]), Number(v4[2])];
-    if (a === 10) return true;
-    if (a === 127) return true;
-    if (a === 0) return true;
-    if (a === 172 && b >= 16 && b <= 31) return true;
-    if (a === 192 && b === 168) return true;
-    if (a === 169 && b === 254) return true;
-    if (a === 100 && b >= 64 && b <= 127) return true;
-    return false;
-  }
-  // IPv6 — normalise to lower-case, strip zone id.
-  const v6 = ip.toLowerCase().split('%')[0];
-  if (v6 === '::1') return true;
-  if (v6 === '::') return true;
-  if (v6.startsWith('fc') || v6.startsWith('fd')) return true; // fc00::/7
-  if (v6.startsWith('fe8') || v6.startsWith('fe9') || v6.startsWith('fea') || v6.startsWith('feb'))
-    return true; // fe80::/10
-  // IPv4-mapped IPv6 — recursively check the embedded v4.
-  const mapped = ipv4FromMappedIpv6(v6);
-  if (mapped) return isPrivateIp(mapped);
-  return false;
-};
-
-const remoteUrlHostname = (url: URL): string => url.hostname.replace(/^\[|\]$/g, '');
-
-type AutoSelectingHttpsRequestOptions = HttpsRequestOptions & { autoSelectFamily: true };
-
-/**
- * Resolves `url` once and returns the public addresses that the caller may connect to. Returning
- * the vetted addresses (instead of merely validating them) prevents DNS rebinding between the
- * check and the TCP connection.
- */
-const resolveSafeRemoteAddresses = async (url: URL): Promise<LookupAddress[]> => {
-  if (url.protocol !== 'https:') {
-    throw new Error(`Refusing to fetch non-HTTPS URL: ${url.protocol}//...`);
-  }
-  const hostname = remoteUrlHostname(url);
-  const addresses = await dns.lookup(hostname, { all: true });
-  if (addresses.length === 0) {
-    throw new Error(`Could not resolve host ${url.hostname}`);
-  }
-  if (addresses.some((a) => isPrivateIp(a.address))) {
-    throw new Error(`Refusing to fetch URL with private/loopback host: ${url.hostname}`);
-  }
-  return addresses;
-};
-
-const responseFromIncoming = (incoming: IncomingMessage, request: Request): Response => {
-  const responseHeaders = new Headers();
-  for (let index = 0; index < incoming.rawHeaders.length; index += 2) {
-    responseHeaders.append(incoming.rawHeaders[index], incoming.rawHeaders[index + 1]);
-  }
-  const status = incoming.statusCode ?? 500;
-  const hasBody = request.method !== 'HEAD' && ![204, 205, 304].includes(status);
-  const contentEncoding = responseHeaders.get('content-encoding')?.trim().toLowerCase();
-  let responseBody: Readable = incoming;
-  if (contentEncoding === 'gzip' || contentEncoding === 'x-gzip') {
-    responseBody = incoming.pipe(createGunzip());
-  } else if (contentEncoding === 'deflate') {
-    responseBody = incoming.pipe(createInflate());
-  } else if (contentEncoding === 'br') {
-    responseBody = incoming.pipe(createBrotliDecompress());
-  }
-  if (responseBody !== incoming) {
-    responseHeaders.delete('content-encoding');
-    responseHeaders.delete('content-length');
-    responseBody.once('close', () => incoming.destroy());
-  }
-  addAbortSignal(request.signal, responseBody);
-  return new Response(
-    hasBody ? (Readable.toWeb(responseBody) as ReadableStream<Uint8Array>) : null,
-    {
-      headers: responseHeaders,
-      status,
-      statusText: incoming.statusMessage,
-    },
-  );
-};
-
-/**
- * Performs one HTTPS request using only already-vetted IPs while retaining the original hostname
- * for the Host header, SNI, and certificate verification. The custom lookup enables connection
- * family selection without another DNS query.
- */
-const fetchPinnedRemoteUrl = async (
-  url: URL,
-  addresses: LookupAddress[],
-  options: RequestInit = {},
-): Promise<Response> => {
-  const request = new Request(url.href, options);
-  const body = request.body ? Buffer.from(await request.arrayBuffer()) : undefined;
-  const headers = new Headers(request.headers);
-  headers.set('host', url.host);
-  headers.set('accept-encoding', 'gzip, deflate, br');
-  const originalHostname = remoteUrlHostname(url);
-
-  return new Promise<Response>((resolve, reject) => {
-    const requestOptions: AutoSelectingHttpsRequestOptions = {
-      agent: false,
-      autoSelectFamily: true,
-      headers: Object.fromEntries(headers.entries()),
-      hostname: originalHostname,
-      lookup: (_hostname, lookupOptions, callback) => {
-        if (lookupOptions.all) {
-          callback(null, addresses);
-          return;
-        }
-        callback(null, addresses[0].address, addresses[0].family);
-      },
-      method: request.method,
-      path: `${url.pathname}${url.search}`,
-      port: url.port ? Number(url.port) : 443,
-      servername: isIP(originalHostname) === 0 ? originalHostname : undefined,
-      signal: request.signal,
-    };
-    const outbound = https.request(requestOptions, (incoming) => {
-      try {
-        resolve(responseFromIncoming(incoming, request));
-      } catch (error) {
-        incoming.destroy();
-        reject(error);
-      }
-    });
-    outbound.once('error', reject);
-    outbound.end(body);
-  });
 };
 
 const safeOidcFetch: oidc.CustomFetch = async (url, options) => {

--- a/server/services/sso.ts
+++ b/server/services/sso.ts
@@ -483,7 +483,7 @@ const parseSamlMetadata = (xml: string): SamlMetadataConfig => {
 
 const safeOidcFetch: oidc.CustomFetch = async (url, options) => {
   const parsed = new URL(url);
-  const addresses = await resolveSafeRemoteAddresses(parsed);
+  const addresses = await resolveSafeRemoteAddresses(parsed, options.signal);
   const response = await fetchPinnedRemoteUrl(parsed, addresses, options);
   return responseWithBoundedBody(response, options.method);
 };
@@ -598,7 +598,7 @@ const safeFetchRemoteUrl = async (url: string): Promise<Response> => {
   try {
     for (let hops = 0; hops <= REMOTE_FETCH_REDIRECT_LIMIT; hops++) {
       const parsed = new URL(current);
-      const addresses = await resolveSafeRemoteAddresses(parsed);
+      const addresses = await resolveSafeRemoteAddresses(parsed, controller.signal);
       const response = await fetchPinnedRemoteUrl(parsed, addresses, {
         signal: controller.signal,
         redirect: 'manual',

--- a/server/services/webhooks.ts
+++ b/server/services/webhooks.ts
@@ -212,7 +212,7 @@ export const dispatchWebhook = async (
 
   try {
     const url = new URL(webhook.url);
-    const addresses = await resolveSafeRemoteAddresses(url);
+    const addresses = await resolveSafeRemoteAddresses(url, controller.signal);
     const authSecret = webhook.authSecret ? decrypt(webhook.authSecret) : '';
     const response = await fetchPinnedRemoteUrl(url, addresses, {
       method: webhook.httpMethod,

--- a/server/services/webhooks.ts
+++ b/server/services/webhooks.ts
@@ -6,6 +6,7 @@ import type {
 import * as webhooksRepo from '../repositories/webhooksRepo.ts';
 import { decrypt, encrypt } from '../utils/crypto.ts';
 import { generatePrefixedId } from '../utils/order-ids.ts';
+import { fetchPinnedRemoteUrl, resolveSafeRemoteAddresses } from '../utils/safe-remote-fetch.ts';
 
 // Plaintext input from the route. `authSecret` carries the raw credential the admin typed, or
 // `undefined` (the field omitted) to mean "keep the stored value". The UI signals "unchanged" by
@@ -151,7 +152,6 @@ export type WebhookDispatchResult = {
 };
 
 export type WebhookDispatchOptions = {
-  fetchFn?: typeof fetch;
   timeoutMs?: number;
 };
 
@@ -204,7 +204,6 @@ export const dispatchWebhook = async (
   options: WebhookDispatchOptions = {},
 ): Promise<WebhookDispatchResult> => {
   const hasJsonBody = jsonBodyAllowed(webhook.httpMethod);
-  const authSecret = webhook.authSecret ? decrypt(webhook.authSecret) : '';
   const controller = new AbortController();
   const timer = setTimeout(
     () => controller.abort(),
@@ -212,12 +211,17 @@ export const dispatchWebhook = async (
   );
 
   try {
-    const response = await (options.fetchFn ?? fetch)(webhook.url, {
+    const url = new URL(webhook.url);
+    const addresses = await resolveSafeRemoteAddresses(url);
+    const authSecret = webhook.authSecret ? decrypt(webhook.authSecret) : '';
+    const response = await fetchPinnedRemoteUrl(url, addresses, {
       method: webhook.httpMethod,
       headers: buildDispatchHeaders(webhook, authSecret, hasJsonBody),
       ...(hasJsonBody ? { body: JSON.stringify(payload) } : {}),
+      redirect: 'manual',
       signal: controller.signal,
     });
+    await response.body?.cancel().catch(() => undefined);
     if (!response.ok) {
       throw new Error(`Webhook ${webhook.id} dispatch failed: HTTP ${response.status}`);
     }

--- a/server/test/routes/webhooks.test.ts
+++ b/server/test/routes/webhooks.test.ts
@@ -222,7 +222,7 @@ describe('POST /api/webhooks', () => {
     expect(JSON.parse(res.body).authSecret).toBe(MASKED_SECRET);
   });
 
-  test('400 when the URL is not http(s)', async () => {
+  test('400 when the URL scheme is unsupported', async () => {
     const res = await testApp.inject({
       method: 'POST',
       url: '/api/webhooks',
@@ -241,6 +241,30 @@ describe('POST /api/webhooks', () => {
       payload: { url: 'https://example.com/hook' },
     });
     expect(res.statusCode).toBe(400);
+  });
+
+  test('400 when the target does not use HTTPS', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/webhooks',
+      headers: authHeader(),
+      payload: { name: 'Internal', url: 'http://example.com/hook' },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/HTTPS/);
+    expect(createWebhookMock).not.toHaveBeenCalled();
+  });
+
+  test('400 when the target URL contains embedded credentials', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/webhooks',
+      headers: authHeader(),
+      payload: { name: 'Embedded', url: 'https://user:secret@example.com/hook' },
+    });
+    expect(res.statusCode).toBe(400);
+    expect(res.json().error).toMatch(/embedded credentials/);
+    expect(createWebhookMock).not.toHaveBeenCalled();
   });
 
   test('400 when authType is api_key without a header name', async () => {

--- a/server/test/services/sso.test.ts
+++ b/server/test/services/sso.test.ts
@@ -99,6 +99,7 @@ class StubSaml {
 }
 
 let sso: typeof import('../../services/sso.ts');
+let safeRemoteFetch: typeof import('../../utils/safe-remote-fetch.ts');
 
 beforeAll(async () => {
   mock.module('node:dns/promises', () => ({
@@ -153,6 +154,7 @@ beforeAll(async () => {
   }));
 
   sso = await import('../../services/sso.ts');
+  safeRemoteFetch = await import('../../utils/safe-remote-fetch.ts');
 });
 
 afterAll(() => {
@@ -194,6 +196,36 @@ beforeEach(() => {
   ])
     m.mockReset();
   lastSamlOptions = null;
+});
+
+describe('resolveSafeRemoteAddresses', () => {
+  test('does not start DNS resolution when its signal is already aborted', async () => {
+    const controller = new AbortController();
+    const abortReason = new Error('DNS resolution already timed out');
+    controller.abort(abortReason);
+
+    await expect(
+      safeRemoteFetch.resolveSafeRemoteAddresses(
+        new URL('https://idp.example.com'),
+        controller.signal,
+      ),
+    ).rejects.toBe(abortReason);
+    expect(dnsLookupMock).not.toHaveBeenCalled();
+  });
+
+  test('rejects a stalled DNS lookup when its signal is aborted', async () => {
+    dnsLookupMock.mockReturnValue(new Promise<LookupAddress[]>(() => undefined));
+    const controller = new AbortController();
+    const abortReason = new Error('DNS resolution timed out');
+
+    const resolution = safeRemoteFetch.resolveSafeRemoteAddresses(
+      new URL('https://idp.example.com'),
+      controller.signal,
+    );
+    controller.abort(abortReason);
+
+    await expect(resolution).rejects.toBe(abortReason);
+  });
 });
 
 describe('isPrivateIp', () => {

--- a/server/test/services/sso.test.ts
+++ b/server/test/services/sso.test.ts
@@ -249,6 +249,22 @@ describe('isPrivateIp', () => {
     expect(sso.isPrivateIp('100.63.255.255')).toBe(false);
     expect(sso.isPrivateIp('100.128.0.1')).toBe(false);
   });
+
+  test('detects reserved IPv4 ranges', () => {
+    expect(sso.isPrivateIp('192.0.2.1')).toBe(true);
+    expect(sso.isPrivateIp('198.18.0.1')).toBe(true);
+    expect(sso.isPrivateIp('198.51.100.1')).toBe(true);
+    expect(sso.isPrivateIp('203.0.113.1')).toBe(true);
+    expect(sso.isPrivateIp('224.0.0.1')).toBe(true);
+    expect(sso.isPrivateIp('255.255.255.255')).toBe(true);
+  });
+
+  test('detects reserved and transition IPv6 ranges', () => {
+    expect(sso.isPrivateIp('2001:db8::1')).toBe(true);
+    expect(sso.isPrivateIp('2002::1')).toBe(true);
+    expect(sso.isPrivateIp('3fff::1')).toBe(true);
+    expect(sso.isPrivateIp('ff02::1')).toBe(true);
+  });
 });
 
 describe('resolvePublicBaseUrl', () => {
@@ -426,6 +442,20 @@ describe('startSamlLogin SSRF protections', () => {
     dnsLookupMock.mockResolvedValue([{ address: '169.254.169.254', family: 4 }]);
     await expect(sso.startSamlLogin('okta')).rejects.toThrow(/private\/loopback/);
   });
+
+  test('rejects the entire DNS result when any resolved address is private', async () => {
+    findBySlugMock.mockResolvedValue({
+      ...SAML_PROVIDER,
+      metadataUrl: 'https://mixed.example.com/metadata',
+    });
+    dnsLookupMock.mockResolvedValue([
+      { address: '8.8.8.8', family: 4 },
+      { address: '10.0.0.5', family: 4 },
+    ]);
+
+    await expect(sso.startSamlLogin('okta')).rejects.toThrow(/private\/loopback/);
+    expect(httpsRequestMock).not.toHaveBeenCalled();
+  });
 });
 
 describe('safeFetchRemoteUrl behavior (exercised via SAML metadata fetch)', () => {
@@ -438,7 +468,7 @@ describe('safeFetchRemoteUrl behavior (exercised via SAML metadata fetch)', () =
       metadataUrl: 'https://idp.example.com/metadata',
     });
     // Default: every DNS lookup resolves to a benign public IP.
-    dnsLookupMock.mockResolvedValue([{ address: '203.0.113.10', family: 4 }]);
+    dnsLookupMock.mockResolvedValue([{ address: '8.8.8.8', family: 4 }]);
   });
 
   afterAll(() => {
@@ -484,7 +514,7 @@ describe('safeFetchRemoteUrl behavior (exercised via SAML metadata fetch)', () =
   test('offers every vetted DNS address to connection family selection', async () => {
     const addresses: LookupAddress[] = [
       { address: '2606:4700:4700::1111', family: 6 },
-      { address: '203.0.113.10', family: 4 },
+      { address: '8.8.8.8', family: 4 },
     ];
     dnsLookupMock.mockResolvedValue(addresses);
     pinnedFetchResponseMock.mockResolvedValueOnce(
@@ -550,7 +580,7 @@ describe('safeFetchRemoteUrl behavior (exercised via SAML metadata fetch)', () =
       }),
     );
     dnsLookupMock
-      .mockResolvedValueOnce([{ address: '203.0.113.10', family: 4 }])
+      .mockResolvedValueOnce([{ address: '8.8.8.8', family: 4 }])
       .mockResolvedValueOnce([{ address: '10.0.0.1', family: 4 }]);
     await expect(sso.startSamlLogin('okta')).rejects.toThrow(/private\/loopback/);
   });
@@ -767,7 +797,7 @@ describe('OIDC remote endpoint hardening', () => {
     const options = oidcDiscoveryMock.mock.calls[0][4];
 
     dnsLookupMock.mockReset();
-    dnsLookupMock.mockResolvedValue([{ address: '203.0.113.25', family: 4 }]);
+    dnsLookupMock.mockResolvedValue([{ address: '8.8.4.4', family: 4 }]);
     httpsRequestMock.mockClear();
     pinnedFetchResponseMock.mockResolvedValueOnce(new Response('{}', { status: 200 }));
 
@@ -833,7 +863,7 @@ describe('OIDC remote endpoint hardening', () => {
     const options = oidcDiscoveryMock.mock.calls[0][4];
 
     dnsLookupMock.mockReset();
-    dnsLookupMock.mockResolvedValue([{ address: '203.0.113.10', family: 4 }]);
+    dnsLookupMock.mockResolvedValue([{ address: '8.8.8.8', family: 4 }]);
     pinnedFetchResponseMock.mockResolvedValueOnce(
       new Response(null, {
         status: 200,
@@ -858,7 +888,7 @@ describe('OIDC remote endpoint hardening', () => {
     const options = oidcDiscoveryMock.mock.calls[0][4];
 
     dnsLookupMock.mockReset();
-    dnsLookupMock.mockResolvedValue([{ address: '203.0.113.10', family: 4 }]);
+    dnsLookupMock.mockResolvedValue([{ address: '8.8.8.8', family: 4 }]);
     const oneMb = new Uint8Array(1024 * 1024).fill(65);
     const stream = new ReadableStream<Uint8Array>({
       start(controller) {
@@ -1443,7 +1473,7 @@ describe('endOidcSession', () => {
   beforeEach(() => {
     process.env.SSO_CALLBACK_BASE_URL = 'https://app.example.com';
     process.env.FRONTEND_URL = 'https://app.example.com';
-    dnsLookupMock.mockResolvedValue([{ address: '203.0.113.10', family: 4 }]);
+    dnsLookupMock.mockResolvedValue([{ address: '8.8.8.8', family: 4 }]);
   });
 
   afterAll(() => {
@@ -1568,7 +1598,7 @@ describe('SSO login persists id_token only when one is present', () => {
   beforeEach(() => {
     process.env.SSO_CALLBACK_BASE_URL = 'https://app.example.com';
     process.env.FRONTEND_URL = 'https://app.example.com';
-    dnsLookupMock.mockResolvedValue([{ address: '203.0.113.10', family: 4 }]);
+    dnsLookupMock.mockResolvedValue([{ address: '8.8.8.8', family: 4 }]);
     loginTicketsInsertMock.mockResolvedValue(undefined);
     resolveExternalIdentityMock.mockResolvedValue({ id: 'u1', role: 'user' });
   });

--- a/server/test/services/webhooks.test.ts
+++ b/server/test/services/webhooks.test.ts
@@ -1,16 +1,21 @@
 import { afterAll, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import type { LookupAddress } from 'node:dns';
 import * as realWebhooksRepo from '../../repositories/webhooksRepo.ts';
 import * as realCrypto from '../../utils/crypto.ts';
+import * as realSafeRemoteFetch from '../../utils/safe-remote-fetch.ts';
 
 // Snapshot real exports BEFORE registering mocks (mock.module inside beforeAll is not hoisted).
 const cryptoSnapshot = { ...realCrypto };
 const repoSnapshot = { ...realWebhooksRepo };
+const safeRemoteFetchSnapshot = { ...realSafeRemoteFetch };
 
 const encryptMock = mock((plaintext: string) => `enc(${plaintext})`);
 const decryptMock = mock((ciphertext: string) => `dec(${ciphertext})`);
 const insertMock = mock();
 const updateMock = mock();
 const findByIdMock = mock();
+const resolveSafeRemoteAddressesMock = mock();
+const fetchPinnedRemoteUrlMock = mock();
 
 let webhooksService: typeof import('../../services/webhooks.ts');
 
@@ -27,12 +32,18 @@ beforeAll(async () => {
     update: updateMock,
     findById: findByIdMock,
   }));
+  mock.module('../../utils/safe-remote-fetch.ts', () => ({
+    ...safeRemoteFetchSnapshot,
+    resolveSafeRemoteAddresses: resolveSafeRemoteAddressesMock,
+    fetchPinnedRemoteUrl: fetchPinnedRemoteUrlMock,
+  }));
   webhooksService = await import('../../services/webhooks.ts');
 });
 
 afterAll(() => {
   mock.module('../../utils/crypto.ts', () => cryptoSnapshot);
   mock.module('../../repositories/webhooksRepo.ts', () => repoSnapshot);
+  mock.module('../../utils/safe-remote-fetch.ts', () => safeRemoteFetchSnapshot);
 });
 
 const existingWebhook = (
@@ -52,7 +63,7 @@ const existingWebhook = (
   ...overrides,
 });
 
-const asFetch = (fn: unknown): typeof fetch => fn as typeof fetch;
+const PUBLIC_ADDRESSES: LookupAddress[] = [{ address: '8.8.8.8', family: 4 }];
 
 const insertedArg = () => insertMock.mock.calls[0]?.[0] as realWebhooksRepo.NewWebhook;
 const updatedPatch = () => updateMock.mock.calls[0]?.[1] as realWebhooksRepo.WebhookPatch;
@@ -63,8 +74,12 @@ beforeEach(() => {
   insertMock.mockReset();
   updateMock.mockReset();
   findByIdMock.mockReset();
+  resolveSafeRemoteAddressesMock.mockReset();
+  fetchPinnedRemoteUrlMock.mockReset();
   insertMock.mockImplementation(async (webhook) => webhook);
   updateMock.mockImplementation(async (_id, patch) => ({ ...existingWebhook(), ...patch }));
+  resolveSafeRemoteAddressesMock.mockResolvedValue(PUBLIC_ADDRESSES);
+  fetchPinnedRemoteUrlMock.mockImplementation(async () => new Response(null, { status: 204 }));
 });
 
 describe('createWebhook', () => {
@@ -274,29 +289,40 @@ describe('updateWebhook', () => {
 });
 
 describe('dispatchWebhook', () => {
-  test('sends a JSON body with custom headers and bearer auth', async () => {
-    const fetchMock = mock(
-      async (_input: Parameters<typeof fetch>[0], _init?: Parameters<typeof fetch>[1]) =>
-        new Response(null, { status: 204 }),
+  test('rejects loopback targets before issuing the webhook request', async () => {
+    resolveSafeRemoteAddressesMock.mockRejectedValue(
+      new Error('Refusing to fetch URL with private/loopback/reserved host'),
     );
+
+    await expect(
+      webhooksService.dispatchWebhook(
+        existingWebhook({ url: 'https://127.0.0.1/latest/meta-data' }),
+        {},
+      ),
+    ).rejects.toThrow(/private|loopback/i);
+    expect(fetchPinnedRemoteUrlMock).not.toHaveBeenCalled();
+    expect(decryptMock).not.toHaveBeenCalled();
+  });
+
+  test('sends a JSON body with custom headers and bearer auth', async () => {
     const webhook = existingWebhook({
       authType: 'bearer',
       authSecret: 'enc(tok)',
       customHeaders: [{ key: 'X-Custom', value: '1' }],
     });
 
-    const result = await webhooksService.dispatchWebhook(
-      webhook,
-      { eventType: 'project_rule_triggered' },
-      { fetchFn: asFetch(fetchMock) },
-    );
+    const result = await webhooksService.dispatchWebhook(webhook, {
+      eventType: 'project_rule_triggered',
+    });
 
     expect(result).toEqual({ delivered: true, skipped: false, status: 204 });
     expect(decryptMock).toHaveBeenCalledWith('enc(tok)');
-    expect(fetchMock).toHaveBeenCalledWith(
-      'https://example.com/hook',
+    expect(fetchPinnedRemoteUrlMock).toHaveBeenCalledWith(
+      expect.objectContaining({ href: 'https://example.com/hook' }),
+      PUBLIC_ADDRESSES,
       expect.objectContaining({
         method: 'POST',
+        redirect: 'manual',
         body: JSON.stringify({ eventType: 'project_rule_triggered' }),
         headers: expect.objectContaining({
           'Content-Type': 'application/json',
@@ -308,19 +334,15 @@ describe('dispatchWebhook', () => {
   });
 
   test('sends api key auth under the configured header', async () => {
-    const fetchMock = mock(
-      async (_input: Parameters<typeof fetch>[0], _init?: Parameters<typeof fetch>[1]) =>
-        new Response(null, { status: 200 }),
-    );
     const webhook = existingWebhook({
       authType: 'api_key',
       authHeaderName: 'X-API-Key',
       authSecret: 'enc(key)',
     });
 
-    await webhooksService.dispatchWebhook(webhook, { ok: true }, { fetchFn: asFetch(fetchMock) });
+    await webhooksService.dispatchWebhook(webhook, { ok: true });
 
-    expect(fetchMock.mock.calls[0][1]).toEqual(
+    expect(fetchPinnedRemoteUrlMock.mock.calls[0][2]).toEqual(
       expect.objectContaining({
         headers: expect.objectContaining({ 'X-API-Key': 'dec(enc(key))' }),
       }),
@@ -328,20 +350,12 @@ describe('dispatchWebhook', () => {
   });
 
   test('does not send a body for GET webhooks', async () => {
-    const fetchMock = mock(
-      async (_input: Parameters<typeof fetch>[0], _init?: Parameters<typeof fetch>[1]) =>
-        new Response(null, { status: 200 }),
-    );
     const webhook = existingWebhook({ httpMethod: 'GET', authType: 'none', authSecret: '' });
 
-    await webhooksService.dispatchWebhook(
-      webhook,
-      { ignored: true },
-      { fetchFn: asFetch(fetchMock) },
-    );
+    await webhooksService.dispatchWebhook(webhook, { ignored: true });
 
-    expect(fetchMock.mock.calls[0][1]).not.toHaveProperty('body');
-    expect(fetchMock.mock.calls[0][1]).not.toEqual(
+    expect(fetchPinnedRemoteUrlMock.mock.calls[0][2]).not.toHaveProperty('body');
+    expect(fetchPinnedRemoteUrlMock.mock.calls[0][2]).not.toEqual(
       expect.objectContaining({
         headers: expect.objectContaining({ 'Content-Type': 'application/json' }),
       }),
@@ -349,33 +363,37 @@ describe('dispatchWebhook', () => {
   });
 
   test('throws when the remote endpoint returns a non-2xx response', async () => {
-    const fetchMock = mock(
-      async (_input: Parameters<typeof fetch>[0], _init?: Parameters<typeof fetch>[1]) =>
-        new Response(null, { status: 500 }),
+    fetchPinnedRemoteUrlMock.mockResolvedValueOnce(new Response(null, { status: 500 }));
+
+    await expect(webhooksService.dispatchWebhook(existingWebhook(), {})).rejects.toThrow(
+      'HTTP 500',
+    );
+  });
+
+  test('does not follow redirects from a webhook target', async () => {
+    fetchPinnedRemoteUrlMock.mockResolvedValueOnce(
+      new Response(null, {
+        status: 302,
+        headers: { location: 'https://internal.example/latest/meta-data' },
+      }),
     );
 
-    await expect(
-      webhooksService.dispatchWebhook(existingWebhook(), {}, { fetchFn: asFetch(fetchMock) }),
-    ).rejects.toThrow('HTTP 500');
+    await expect(webhooksService.dispatchWebhook(existingWebhook(), {})).rejects.toThrow(
+      'HTTP 302',
+    );
+    expect(fetchPinnedRemoteUrlMock).toHaveBeenCalledTimes(1);
   });
 
   test('aborts the fetch when the timeout elapses', async () => {
-    const fetchMock = mock(
-      (_input: Parameters<typeof fetch>[0], init?: Parameters<typeof fetch>[1]) =>
+    fetchPinnedRemoteUrlMock.mockImplementation(
+      (_url: URL, _addresses: LookupAddress[], init?: RequestInit) =>
         new Promise<Response>((_resolve, reject) => {
           init?.signal?.addEventListener('abort', () => reject(new Error('aborted')));
         }),
     );
 
     await expect(
-      webhooksService.dispatchWebhook(
-        existingWebhook(),
-        {},
-        {
-          fetchFn: asFetch(fetchMock),
-          timeoutMs: 1,
-        },
-      ),
+      webhooksService.dispatchWebhook(existingWebhook(), {}, { timeoutMs: 1 }),
     ).rejects.toThrow('aborted');
   });
 });

--- a/server/test/services/webhooks.test.ts
+++ b/server/test/services/webhooks.test.ts
@@ -396,6 +396,23 @@ describe('dispatchWebhook', () => {
       webhooksService.dispatchWebhook(existingWebhook(), {}, { timeoutMs: 1 }),
     ).rejects.toThrow('aborted');
   });
+
+  test('aborts DNS resolution when the timeout elapses', async () => {
+    resolveSafeRemoteAddressesMock.mockImplementation((_url: URL, signal?: AbortSignal) => {
+      if (!signal) return Promise.reject(new Error('missing DNS abort signal'));
+      return new Promise<LookupAddress[]>((_resolve, reject) => {
+        signal.addEventListener('abort', () => reject(new Error('aborted DNS resolution')), {
+          once: true,
+        });
+      });
+    });
+
+    await expect(
+      webhooksService.dispatchWebhook(existingWebhook(), {}, { timeoutMs: 1 }),
+    ).rejects.toThrow('aborted DNS resolution');
+    expect(fetchPinnedRemoteUrlMock).not.toHaveBeenCalled();
+    expect(decryptMock).not.toHaveBeenCalled();
+  });
 });
 
 describe('dispatchWebhookById', () => {

--- a/server/utils/safe-remote-fetch.ts
+++ b/server/utils/safe-remote-fetch.ts
@@ -1,0 +1,192 @@
+import type { LookupAddress } from 'node:dns';
+import dns from 'node:dns/promises';
+import type { IncomingMessage } from 'node:http';
+import https, { type RequestOptions as HttpsRequestOptions } from 'node:https';
+import { isIP } from 'node:net';
+import { addAbortSignal, Readable } from 'node:stream';
+import { createBrotliDecompress, createGunzip, createInflate } from 'node:zlib';
+
+type AutoSelectingHttpsRequestOptions = HttpsRequestOptions & { autoSelectFamily: true };
+
+const remoteUrlHostname = (url: URL): string => url.hostname.replace(/^\[|\]$/g, '');
+
+const parseIpv4 = (ip: string): [number, number, number, number] | null => {
+  if (isIP(ip) !== 4) return null;
+  return ip.split('.').map(Number) as [number, number, number, number];
+};
+
+const parseIpv6 = (ip: string): bigint | null => {
+  const halves = ip.split('::');
+  if (halves.length > 2) return null;
+  const head = halves[0] ? halves[0].split(':') : [];
+  const tail = halves.length === 2 && halves[1] ? halves[1].split(':') : [];
+  if (halves.length === 1 && head.length !== 8) return null;
+  const missing = 8 - head.length - tail.length;
+  if (missing < (halves.length === 2 ? 1 : 0)) return null;
+  const parts = [...head, ...Array<string>(missing).fill('0'), ...tail];
+  if (parts.length !== 8 || parts.some((part) => !/^[0-9a-f]{1,4}$/i.test(part))) return null;
+  return parts.reduce((value, part) => (value << 16n) | BigInt(`0x${part}`), 0n);
+};
+
+const ipv4FromMappedIpv6 = (value: bigint): string | null => {
+  if (value >> 32n !== 0xffffn) return null;
+  const embedded = Number(value & 0xffff_ffffn);
+  return [embedded >>> 24, (embedded >>> 16) & 0xff, (embedded >>> 8) & 0xff, embedded & 0xff].join(
+    '.',
+  );
+};
+
+const inIpv6Cidr = (value: bigint, base: bigint, prefix: number): boolean => {
+  const shift = BigInt(128 - prefix);
+  return value >> shift === base >> shift;
+};
+
+const IPV6_GLOBAL_UNICAST = [0x20000000000000000000000000000000n, 3] as const;
+const BLOCKED_IPV6_GLOBAL_RANGES: ReadonlyArray<readonly [bigint, number]> = [
+  [0x20010000000000000000000000000000n, 32], // Teredo
+  [0x20010002000000000000000000000000n, 48], // Benchmarking
+  [0x20010010000000000000000000000000n, 28], // Deprecated ORCHID
+  [0x20010db8000000000000000000000000n, 32], // Documentation
+  [0x20020000000000000000000000000000n, 16], // 6to4
+  [0x3fff0000000000000000000000000000n, 20], // Documentation
+];
+
+/**
+ * Returns true for an IP that is not safe as a public server-side request destination. Besides
+ * loopback, private, link-local, and shared ranges, this blocks IANA-reserved documentation,
+ * benchmarking, multicast, transition, and future-use space. Invalid input fails closed.
+ */
+export const isPrivateIp = (ip: string): boolean => {
+  const normalized = ip.toLowerCase().split('%')[0];
+  const v4 = parseIpv4(normalized);
+  if (v4) {
+    const [a, b, c] = v4;
+    return (
+      a === 0 ||
+      a === 10 ||
+      a === 127 ||
+      (a === 100 && b >= 64 && b <= 127) ||
+      (a === 169 && b === 254) ||
+      (a === 172 && b >= 16 && b <= 31) ||
+      (a === 192 && b === 0 && c === 0) ||
+      (a === 192 && b === 0 && c === 2) ||
+      (a === 192 && b === 88 && c === 99) ||
+      (a === 192 && b === 168) ||
+      (a === 198 && (b === 18 || b === 19)) ||
+      (a === 198 && b === 51 && c === 100) ||
+      (a === 203 && b === 0 && c === 113) ||
+      a >= 224
+    );
+  }
+
+  if (isIP(normalized) !== 6) return true;
+  const v6 = parseIpv6(normalized);
+  if (v6 === null) return true;
+  const mapped = ipv4FromMappedIpv6(v6);
+  if (mapped) return isPrivateIp(mapped);
+  if (!inIpv6Cidr(v6, ...IPV6_GLOBAL_UNICAST)) return true;
+  return BLOCKED_IPV6_GLOBAL_RANGES.some(([base, prefix]) => inIpv6Cidr(v6, base, prefix));
+};
+
+/**
+ * Resolve the destination exactly once and return only addresses that the subsequent connection
+ * may use. Rejecting the whole result when any answer is unsafe prevents mixed-answer rebinding.
+ */
+export const resolveSafeRemoteAddresses = async (url: URL): Promise<LookupAddress[]> => {
+  if (url.protocol !== 'https:') {
+    throw new Error(`Refusing to fetch non-HTTPS URL: ${url.protocol}//...`);
+  }
+  if (url.username || url.password) {
+    throw new Error('Refusing to fetch URL with embedded credentials');
+  }
+  const hostname = remoteUrlHostname(url);
+  const addresses = await dns.lookup(hostname, { all: true });
+  if (addresses.length === 0) {
+    throw new Error(`Could not resolve host ${url.hostname}`);
+  }
+  if (addresses.some(({ address }) => isPrivateIp(address))) {
+    throw new Error(`Refusing to fetch URL with private/loopback/reserved host: ${url.hostname}`);
+  }
+  return addresses;
+};
+
+const responseFromIncoming = (incoming: IncomingMessage, request: Request): Response => {
+  const responseHeaders = new Headers();
+  for (let index = 0; index < incoming.rawHeaders.length; index += 2) {
+    responseHeaders.append(incoming.rawHeaders[index], incoming.rawHeaders[index + 1]);
+  }
+  const status = incoming.statusCode ?? 500;
+  const hasBody = request.method !== 'HEAD' && ![204, 205, 304].includes(status);
+  const contentEncoding = responseHeaders.get('content-encoding')?.trim().toLowerCase();
+  let responseBody: Readable = incoming;
+  if (contentEncoding === 'gzip' || contentEncoding === 'x-gzip') {
+    responseBody = incoming.pipe(createGunzip());
+  } else if (contentEncoding === 'deflate') {
+    responseBody = incoming.pipe(createInflate());
+  } else if (contentEncoding === 'br') {
+    responseBody = incoming.pipe(createBrotliDecompress());
+  }
+  if (responseBody !== incoming) {
+    responseHeaders.delete('content-encoding');
+    responseHeaders.delete('content-length');
+    responseBody.once('close', () => incoming.destroy());
+  }
+  addAbortSignal(request.signal, responseBody);
+  return new Response(
+    hasBody ? (Readable.toWeb(responseBody) as ReadableStream<Uint8Array>) : null,
+    {
+      headers: responseHeaders,
+      status,
+      statusText: incoming.statusMessage,
+    },
+  );
+};
+
+/**
+ * Perform one HTTPS request through the already-vetted addresses while retaining the original
+ * hostname for the Host header, SNI, and certificate verification. No redirect is followed here.
+ */
+export const fetchPinnedRemoteUrl = async (
+  url: URL,
+  addresses: LookupAddress[],
+  options: RequestInit = {},
+): Promise<Response> => {
+  if (addresses.length === 0) throw new Error('Cannot fetch a remote URL without a vetted address');
+  const request = new Request(url.href, options);
+  const body = request.body ? Buffer.from(await request.arrayBuffer()) : undefined;
+  const headers = new Headers(request.headers);
+  headers.set('host', url.host);
+  headers.set('accept-encoding', 'gzip, deflate, br');
+  const originalHostname = remoteUrlHostname(url);
+
+  return new Promise<Response>((resolve, reject) => {
+    const requestOptions: AutoSelectingHttpsRequestOptions = {
+      agent: false,
+      autoSelectFamily: true,
+      headers: Object.fromEntries(headers.entries()),
+      hostname: originalHostname,
+      lookup: (_hostname, lookupOptions, callback) => {
+        if (lookupOptions.all) {
+          callback(null, addresses);
+          return;
+        }
+        callback(null, addresses[0].address, addresses[0].family);
+      },
+      method: request.method,
+      path: `${url.pathname}${url.search}`,
+      port: url.port ? Number(url.port) : 443,
+      servername: isIP(originalHostname) === 0 ? originalHostname : undefined,
+      signal: request.signal,
+    };
+    const outbound = https.request(requestOptions, (incoming) => {
+      try {
+        resolve(responseFromIncoming(incoming, request));
+      } catch (error) {
+        incoming.destroy();
+        reject(error);
+      }
+    });
+    outbound.once('error', reject);
+    outbound.end(body);
+  });
+};

--- a/server/utils/safe-remote-fetch.ts
+++ b/server/utils/safe-remote-fetch.ts
@@ -10,6 +10,26 @@ type AutoSelectingHttpsRequestOptions = HttpsRequestOptions & { autoSelectFamily
 
 const remoteUrlHostname = (url: URL): string => url.hostname.replace(/^\[|\]$/g, '');
 
+const runWithAbortSignal = <T>(operation: () => Promise<T>, signal?: AbortSignal): Promise<T> => {
+  if (!signal) return operation();
+  if (signal.aborted) return Promise.reject(signal.reason);
+
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = () => reject(signal.reason);
+    signal.addEventListener('abort', onAbort, { once: true });
+    void operation().then(
+      (value) => {
+        signal.removeEventListener('abort', onAbort);
+        resolve(value);
+      },
+      (error) => {
+        signal.removeEventListener('abort', onAbort);
+        reject(error);
+      },
+    );
+  });
+};
+
 const parseIpv4 = (ip: string): [number, number, number, number] | null => {
   if (isIP(ip) !== 4) return null;
   return ip.split('.').map(Number) as [number, number, number, number];
@@ -92,7 +112,10 @@ export const isPrivateIp = (ip: string): boolean => {
  * Resolve the destination exactly once and return only addresses that the subsequent connection
  * may use. Rejecting the whole result when any answer is unsafe prevents mixed-answer rebinding.
  */
-export const resolveSafeRemoteAddresses = async (url: URL): Promise<LookupAddress[]> => {
+export const resolveSafeRemoteAddresses = async (
+  url: URL,
+  signal?: AbortSignal,
+): Promise<LookupAddress[]> => {
   if (url.protocol !== 'https:') {
     throw new Error(`Refusing to fetch non-HTTPS URL: ${url.protocol}//...`);
   }
@@ -100,7 +123,7 @@ export const resolveSafeRemoteAddresses = async (url: URL): Promise<LookupAddres
     throw new Error('Refusing to fetch URL with embedded credentials');
   }
   const hostname = remoteUrlHostname(url);
-  const addresses = await dns.lookup(hostname, { all: true });
+  const addresses = await runWithAbortSignal(() => dns.lookup(hostname, { all: true }), signal);
   if (addresses.length === 0) {
     throw new Error(`Could not resolve host ${url.hostname}`);
   }

--- a/test/components/administration/WebhooksView.test.tsx
+++ b/test/components/administration/WebhooksView.test.tsx
@@ -115,6 +115,27 @@ describe('<WebhooksView />', () => {
     });
   });
 
+  test('rejects non-HTTPS URLs and embedded credentials in the form', async () => {
+    render(<WebhooksView permissions={FULL_PERMS} />);
+    await screen.findByText('administration:webhooks.empty.title');
+    fireEvent.click(screen.getByText('administration:webhooks.createWebhook'));
+
+    fireEvent.change(
+      await screen.findByPlaceholderText('administration:webhooks.placeholders.name'),
+      { target: { value: 'Unsafe Hook' } },
+    );
+    const urlInput = screen.getByPlaceholderText('administration:webhooks.placeholders.url');
+    fireEvent.change(urlInput, { target: { value: 'http://example.com/hook' } });
+    fireEvent.click(screen.getByRole('button', { name: 'common:buttons.create' }));
+
+    expect(await screen.findByText('administration:webhooks.errors.urlInvalid')).toBeDefined();
+    expect(createMock).not.toHaveBeenCalled();
+
+    fireEvent.change(urlInput, { target: { value: 'https://user:secret@example.com/hook' } });
+    fireEvent.click(screen.getByRole('button', { name: 'common:buttons.create' }));
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
   test('hides create and row actions without the matching permissions', async () => {
     listMock.mockResolvedValue([SAMPLE]);
     render(<WebhooksView permissions={['administration.webhooks.view']} />);


### PR DESCRIPTION
## Summary
- Blocks webhook SSRF to loopback, private, link-local, shared, multicast, transition, documentation, and other reserved address space.
- Requires credential-free HTTPS webhook URLs and disables redirect following.
- Reuses one DNS-vetted, address-pinned HTTPS transport across webhooks and SSO.

## Changes
- Resolves every webhook hostname before dispatch, rejects the entire DNS answer set when any address is unsafe, and pins the HTTPS connection to the vetted addresses while preserving Host, SNI, and certificate verification.
- Removes the direct `fetch` path, prevents redirect hops, cancels unused response bodies, and validates the target before decrypting webhook credentials.
- Strengthens the shared IPv4/IPv6 range policy and preserves existing SSO redirect revalidation and response-size controls through the extracted transport.
- Aligns backend routes, the admin form, English/Italian translations, generated OpenAPI, and bilingual user docs with the HTTPS-only contract.
- Adds regressions for loopback dispatch, mixed public/private DNS answers, reserved ranges, redirect blocking, UI/API validation, and existing dispatch behavior.

## Security impact
Before this change, an administrator with webhook create/update permission could store an internal URL and cause project rules to send controlled methods, headers, credentials, and JSON bodies through the server's default redirect-following `fetch`. Dispatch now permits only public credential-free HTTPS targets, validates all resolved addresses, and connects only through those vetted addresses. Redirect responses fail without a second request.

## Testing
- Pre-fix proof: `cd server && bun test ./test/services/webhooks.test.ts` — 25 passed, 1 failed because the loopback dispatch resolved instead of rejecting; the transport mock was called.
- `cd server && bun test ./test/services/webhooks.test.ts ./test/routes/webhooks.test.ts ./test/services/sso.test.ts` — 137 passed, 0 failed.
- `bun test ./test/components/administration/WebhooksView.test.tsx` — 17 passed, 0 failed.
- `bun run test:server` — passed; Bun reported 4,337 tests across 220 files.
- `bun run test:frontend` — 2,416 passed, 4 unrelated CRLF-sensitive source-string tests failed in this Windows checkout (`App.tsx` MFA datasets, `App.tsx` module cancellation, `ProjectDetailView`, and `ProjectsView`).
- `bun run typecheck` — passed after the final rebase.
- `bun run build` — passed, including 22 bilingual documentation pages and the production login smoke test; only the existing large-chunk warning remains.
- `bun run docs:api` — passed and regenerated `docs/api/openapi.json`.
- `bun run i18n:check` — passed.
- `bun x biome check` on all changed code, tests, translations, and generated OpenAPI — passed.
- `git diff --check origin/main...HEAD` — passed.
- `bun run test:react-doctor` — 80/100 before and after, with the same unrelated `DashboardGrid.tsx:165` error and 32 warnings.

## Review discipline
Completed three consecutive clean review/simplify cycles after the final implementation edit, covering code reuse, efficiency, and quality/bugs. One earlier validated finding removed resolver/request override seams from production dispatch options; no further actionable issues were found.

## Risks / Rollout
- Intentional compatibility change: existing `http://` webhook rows remain stored and visible but no longer dispatch. Administrators must replace them with public HTTPS endpoints.
- Existing targets that resolve to any non-public/reserved address or return redirects now fail closed; use a directly reachable public HTTPS endpoint.
- The shared SSO transport now also rejects additional IANA-reserved ranges; normal public IdP endpoints are unchanged.
- No database migration, backfill, seed, dependency, configuration, or deployment-order change. Normal application deployment is sufficient.
- Roll forward by correcting affected endpoint URLs. A code revert restores prior compatibility but also restores the SSRF exposure.

## Issues
Issue: Not linked