### PR TITLE
users(security): enforce role management scope

### DIFF
--- a/docs-site/src/content/docs/administration.md
+++ b/docs-site/src/content/docs/administration.md
@@ -15,6 +15,8 @@ Le righe di permesso con ambito **All** concedono accesso trasversale a tutti i 
 
 L'eliminazione di un utente richiede il permesso **Delete** adatto al tipo di dipendente. Senza `administration.user_management_all.view`, il chiamante può eliminare soltanto utenti che gestisce tramite un Competence Center condiviso; l'ambito **All** consente invece di eliminare qualsiasi utente idoneo, escluso il proprio account.
 
+La consultazione e la modifica dei ruoli assegnati seguono lo stesso ambito: con **User Management - Update** ma senza `administration.user_management_all.view` puoi intervenire soltanto sugli utenti gestiti tramite un Competence Center condiviso. La modifica dei ruoli richiede inoltre una sessione interattiva del browser, non accetta token API personali e non consente mai di cambiare i propri ruoli.
+
 Il permesso `timesheets.expired_projects.create` abilita la registrazione di ore su progetti scaduti. I ruoli di sistema **Manager** e **Top Manager** lo ricevono per impostazione predefinita; per gli altri ruoli assegnalo solo quando è necessario consentire consuntivazioni tardive o rettifiche operative su progetti già conclusi.
 
 Il permesso di sola lettura `projects.details.view` separa l'archivio commesse dai dati avanzati della singola commessa. Per aprire il dettaglio servono anche `projects.manage.view` o `projects.manage_all.view`; Manager e Top Manager ricevono il nuovo permesso per impostazione predefinita, mentre User e Admin no. I ruoli personalizzati possono riceverlo manualmente.

--- a/docs-site/src/content/docs/en/administration.md
+++ b/docs-site/src/content/docs/en/administration.md
@@ -15,6 +15,8 @@ Permission rows marked **All** grant cross-record access for the same area, such
 
 Deleting a user requires the **Delete** permission for that employee type. Without `administration.user_management_all.view`, the caller may delete only users they manage through a shared competence center; **All** scope permits deletion of any otherwise eligible user except the caller's own account.
 
+Viewing and changing assigned roles follows the same scope: with **User Management - Update** but without `administration.user_management_all.view`, you may act only on users managed through a shared competence center. Role changes also require an interactive browser session, reject personal API tokens, and never allow callers to change their own roles.
+
 The `timesheets.expired_projects.create` permission allows time entry logging on expired projects. The built-in **Manager** and **Top Manager** roles receive it by default; grant it to other roles only when they need late timesheet corrections or operational logging on completed projects.
 
 The view-only `projects.details.view` permission separates the jobs archive from an individual job's advanced data. Opening the detail also requires `projects.manage.view` or `projects.manage_all.view`; Manager and Top Manager receive the new permission by default, while User and Admin do not. Custom roles can be granted it explicitly.

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4370,7 +4370,6 @@
         "tags": [
           "users"
         ],
-        "description": "Requires user-management update permission. Callers without administration.user_management_all.view may inspect only users they manage through a shared work unit.",
         "parameters": [
           {
             "schema": {
@@ -4714,7 +4713,7 @@
         "tags": [
           "users"
         ],
-        "description": "Requires an interactive session and user-management update permission. Callers without administration.user_management_all.view may update only users they manage through a shared work unit.",
+        "description": "Role changes in this payload require an interactive session. Other updates follow their field-specific permissions and scope rules.",
         "requestBody": {
           "required": true,
           "content": {
@@ -6020,6 +6019,7 @@
         "tags": [
           "users"
         ],
+        "description": "Requires user-management update permission. Callers without administration.user_management_all.view may inspect only users they manage through a shared work unit.",
         "parameters": [
           {
             "schema": {
@@ -6189,6 +6189,7 @@
         "tags": [
           "users"
         ],
+        "description": "Requires an interactive session and user-management update permission. Callers without administration.user_management_all.view may update only users they manage through a shared work unit.",
         "requestBody": {
           "required": true,
           "content": {

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -4370,6 +4370,7 @@
         "tags": [
           "users"
         ],
+        "description": "Requires user-management update permission. Callers without administration.user_management_all.view may inspect only users they manage through a shared work unit.",
         "parameters": [
           {
             "schema": {
@@ -4713,6 +4714,7 @@
         "tags": [
           "users"
         ],
+        "description": "Requires an interactive session and user-management update permission. Callers without administration.user_management_all.view may update only users they manage through a shared work unit.",
         "requestBody": {
           "required": true,
           "content": {

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -1948,6 +1948,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       schema: {
         tags: ['users'],
         summary: 'Get user roles',
+        description:
+          'Requires user-management update permission. Callers without administration.user_management_all.view may inspect only users they manage through a shared work unit.',
         params: idParamSchema,
         response: {
           200: userRolesSchema,
@@ -1960,10 +1962,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      const [user, assignedRoleIds] = await Promise.all([
-        usersRepo.findCoreById(idResult.value),
-        usersRepo.getUserRoleIds(idResult.value),
-      ]);
+      const user = await usersRepo.findCoreById(idResult.value);
       if (!user) {
         return replyError(request, reply, {
           statusCode: 404,
@@ -1973,6 +1972,21 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           entityId: idResult.value,
         });
       }
+      if (
+        !hasPermission(request, 'administration.user_management_all.view') &&
+        !(await usersRepo.canManageUser(idResult.value, request.user?.id ?? ''))
+      ) {
+        return replyError(request, reply, {
+          statusCode: 403,
+          message: 'Insufficient permissions',
+          action: 'user.roles_view.denied',
+          entityType: 'user',
+          entityId: idResult.value,
+          details: { secondaryLabel: 'cannot_manage_user' },
+        });
+      }
+
+      const assignedRoleIds = await usersRepo.getUserRoleIds(idResult.value);
 
       const primaryRoleId = user.role;
       const roleIds = Array.from(
@@ -1987,10 +2001,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.put(
     '/:id/roles',
     {
-      onRequest: [authenticateToken, requirePermission('administration.user_management.update')],
+      onRequest: [
+        authenticateToken,
+        requireSessionAuth,
+        requirePermission('administration.user_management.update'),
+      ],
       schema: {
         tags: ['users'],
         summary: 'Update user roles',
+        description:
+          'Requires an interactive session and user-management update permission. Callers without administration.user_management_all.view may update only users they manage through a shared work unit.',
         params: idParamSchema,
         body: userRolesUpdateBodySchema,
         response: {
@@ -2039,6 +2059,19 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           action: 'user.roles_update.not_found',
           entityType: 'user',
           entityId: idResult.value,
+        });
+      }
+      if (
+        !hasPermission(request, 'administration.user_management_all.view') &&
+        !(await usersRepo.canManageUser(idResult.value, request.user?.id ?? ''))
+      ) {
+        return replyError(request, reply, {
+          statusCode: 403,
+          message: 'Insufficient permissions',
+          action: 'user.roles_update.denied',
+          entityType: 'user',
+          entityId: idResult.value,
+          details: { secondaryLabel: 'cannot_manage_user' },
         });
       }
 

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -1230,6 +1230,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       schema: {
         tags: ['users'],
         summary: 'Update user',
+        description:
+          'Role changes in this payload require an interactive session. Other updates follow their field-specific permissions and scope rules.',
         params: idParamSchema,
         body: userUpdateBodySchema,
         response: {
@@ -1251,6 +1253,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       };
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
+      if (role !== undefined) {
+        await requireSessionAuth(request, reply);
+        if (reply.sent) return;
+      }
 
       const fields: usersRepo.UserUpdateFields = {};
       const isSelf = idResult.value === request.user?.id;

--- a/server/test/routes/users.test.ts
+++ b/server/test/routes/users.test.ts
@@ -1858,6 +1858,30 @@ describe('PUT /api/users/:id', () => {
     );
   });
 
+  test('403 (PAT): a personal-access token cannot change roles through the legacy update route', async () => {
+    findCoreByIdMock.mockResolvedValue(SAMPLE_USER_CORE);
+    rolesFindByIdMock.mockResolvedValue({
+      id: 'manager',
+      name: 'Manager',
+      isSystem: true,
+      isAdmin: false,
+    });
+    updateUserDynamicMock.mockResolvedValue({ ...SAMPLE_USER_CORE, role: 'manager' });
+    findByIdMock.mockResolvedValue({ ...SAMPLE_USER_ROW, role: 'manager' });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/users/u-target',
+      headers: patHeader(),
+      payload: { role: 'manager' },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toBe('Session authentication required');
+    expect(findCoreByIdMock).not.toHaveBeenCalled();
+    expect(replaceUserRolesMock).not.toHaveBeenCalled();
+  });
+
   test('200 promoting to an admin role via PUT /:id revokes sessions when 2FA is enforced', async () => {
     // The legacy single-role update path must also revoke a newly-admin user's sessions under
     // enforcement — otherwise their pre-existing token keeps admin access without enrolling.

--- a/server/test/routes/users.test.ts
+++ b/server/test/routes/users.test.ts
@@ -3343,6 +3343,42 @@ describe('GET /api/users/:id/roles', () => {
     const body = JSON.parse(res.body);
     expect(body.primaryRoleId).toBe('user');
     expect(body.roleIds.sort()).toEqual(['manager', 'user']);
+    expect(canManageUserMock).not.toHaveBeenCalled();
+  });
+
+  test('200 manager can view roles for a managed user', async () => {
+    findAuthUserByIdMock.mockResolvedValue(MANAGER_USER);
+    getRolePermissionsMock.mockResolvedValue(['administration.user_management.update']);
+    findCoreByIdMock.mockResolvedValue({ ...SAMPLE_USER_CORE, role: 'user' });
+    getUserRoleIdsMock.mockResolvedValue(['user', 'manager']);
+    canManageUserMock.mockResolvedValue(true);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/users/u-target/roles',
+      headers: managerAuth(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(canManageUserMock).toHaveBeenCalledWith('u-target', MANAGER_USER.id);
+  });
+
+  test('403 manager cannot view roles for an unmanaged user', async () => {
+    findAuthUserByIdMock.mockResolvedValue(MANAGER_USER);
+    getRolePermissionsMock.mockResolvedValue(['administration.user_management.update']);
+    findCoreByIdMock.mockResolvedValue({ ...SAMPLE_USER_CORE, role: 'user' });
+    getUserRoleIdsMock.mockResolvedValue(['user', 'admin']);
+    canManageUserMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/users/u-target/roles',
+      headers: managerAuth(),
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(canManageUserMock).toHaveBeenCalledWith('u-target', MANAGER_USER.id);
+    expect(getUserRoleIdsMock).not.toHaveBeenCalled();
   });
 
   test('404 user not found', async () => {
@@ -3398,6 +3434,46 @@ describe('PUT /api/users/:id/roles', () => {
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'user.roles_updated' }),
     );
+    expect(canManageUserMock).not.toHaveBeenCalled();
+  });
+
+  test('200 manager can replace roles for a managed user', async () => {
+    findAuthUserByIdMock.mockResolvedValue(MANAGER_USER);
+    getRolePermissionsMock.mockResolvedValue(['administration.user_management.update']);
+    findCoreByIdMock.mockResolvedValue(SAMPLE_USER_CORE);
+    rolesFindExistingIdsMock.mockResolvedValue(new Set(['user', 'manager']));
+    canManageUserMock.mockResolvedValue(true);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/users/u-target/roles',
+      headers: managerAuth(),
+      payload: { roleIds: ['user', 'manager'], primaryRoleId: 'manager' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(canManageUserMock).toHaveBeenCalledWith('u-target', MANAGER_USER.id);
+    expect(replaceUserRolesAndSetPrimaryMock).toHaveBeenCalled();
+  });
+
+  test('403 manager cannot replace roles for an unmanaged user', async () => {
+    findAuthUserByIdMock.mockResolvedValue(MANAGER_USER);
+    getRolePermissionsMock.mockResolvedValue(['administration.user_management.update']);
+    findCoreByIdMock.mockResolvedValue(SAMPLE_USER_CORE);
+    rolesFindExistingIdsMock.mockResolvedValue(new Set(['user', 'admin']));
+    canManageUserMock.mockResolvedValue(false);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/users/u-target/roles',
+      headers: managerAuth(),
+      payload: { roleIds: ['user', 'admin'], primaryRoleId: 'admin' },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(canManageUserMock).toHaveBeenCalledWith('u-target', MANAGER_USER.id);
+    expect(rolesFindExistingIdsMock).not.toHaveBeenCalled();
+    expect(replaceUserRolesAndSetPrimaryMock).not.toHaveBeenCalled();
   });
 
   test('200 granting an admin role to an unenrolled user revokes sessions when 2FA is enforced', async () => {
@@ -3534,6 +3610,22 @@ describe('PUT /api/users/:id/roles', () => {
     });
 
     expect(res.statusCode).toBe(403);
+  });
+
+  test("403 (PAT): a personal-access token cannot replace another user's roles", async () => {
+    findCoreByIdMock.mockResolvedValue(SAMPLE_USER_CORE);
+    rolesFindExistingIdsMock.mockResolvedValue(new Set(['user', 'admin']));
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/users/u-target/roles',
+      headers: patHeader(),
+      payload: { roleIds: ['user', 'admin'], primaryRoleId: 'admin' },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(JSON.parse(res.body).error).toBe('Session authentication required');
+    expect(replaceUserRolesAndSetPrimaryMock).not.toHaveBeenCalled();
   });
 
   // Regression: replaceUserRolesAndSetPrimary + syncTopManagerAssignmentsForUser


### PR DESCRIPTION
## Summary
- Enforces work-unit row scope when reading or replacing another user's assigned roles.
- Requires an interactive session for role mutation so personal API tokens cannot grant roles.
- Preserves all-scope administrator behavior and the existing self-role-change prohibition.

## Changes
- Checks administration.user_management_all.view before falling back to usersRepo.canManageUser for GET and PUT /api/users/:id/roles.
- Avoids reading assigned roles or validating/writing role IDs until the target is authorized.
- Adds managed, unmanaged, all-scope, and PAT regression coverage.
- Updates inline OpenAPI descriptions, generated OpenAPI, and paired Italian/English administration guides.

## Testing
- Pre-fix regressions: initial scope/session matrix had 156 passed and 5 expected failures; Codex P1 legacy-route case had 161 passed and 1 expected failure.
- Focused users route: 162 passed, 0 failed after the review fix.
- bun run test:server: 4,378 passed, 28 integration skips, 0 failed.
- bun run typecheck: passed.
- bun x biome check server/routes/users.ts server/test/routes/users.test.ts: passed.
- bun run docs: passed; 66 pre-existing TypeDoc warnings.
- bun run build: passed, including login bundle smoke test; existing chunk-size warning remains.
- bun run test:react-doctor: 80/100 before and after, with the same 34 pre-existing findings.
- git diff --check: passed.

## Risks / Rollout
- Security-sensitive authorization change: scoped/custom managers now receive 403 for users outside their managed work units, and role PUTs reject non-session authentication.
- Full-scope callers and managed-user workflows remain compatible; no route, payload, database, migration, seed, configuration, or deployment-order changes.
- Rollback is a normal code revert; no data restoration or compatibility window is required.

## Issues
Issue: Not linked (DeepSec validation finding).
