### PR TITLE
tasks(security): require assignment update permission

### DIFF
--- a/components/projects/TasksView.tsx
+++ b/components/projects/TasksView.tsx
@@ -121,6 +121,7 @@ export interface TasksViewProps {
 type TaskColumnsInput = {
   projects: Project[];
   clients: Client[];
+  canManageAssignments: boolean;
   canUpdateTasks: boolean;
   canDeleteTasks: boolean;
   currency: string;
@@ -137,6 +138,7 @@ type TaskColumnsInput = {
 const useTaskColumns = ({
   projects,
   clients,
+  canManageAssignments,
   canUpdateTasks,
   canDeleteTasks,
   currency,
@@ -415,7 +417,7 @@ const useTaskColumns = ({
         disableSorting: true,
         disableFiltering: true,
         cell: ({ row }) => {
-          if (!canUpdateTasks && !canDeleteTasks) return null;
+          if (!canManageAssignments && !canUpdateTasks && !canDeleteTasks) return null;
           const project = projects.find((p) => p.id === row.projectId);
           const client = clients.find((c) => c.id === project?.clientId);
           const isInheritedDisabled = project?.isDisabled || client?.isDisabled;
@@ -423,26 +425,28 @@ const useTaskColumns = ({
 
           return (
             <div className="flex items-center justify-end gap-2">
+              {canManageAssignments && (
+                <Tooltip>
+                  <TooltipTrigger asChild>
+                    <span className="inline-flex">
+                      <button
+                        type="button"
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onOpenAssignments(row.id);
+                        }}
+                        aria-label={t('tasks.manageMembers')}
+                        className="p-2 text-zinc-400 hover:text-praetor hover:bg-zinc-100 rounded-lg transition-all"
+                      >
+                        <i className="fa-solid fa-users"></i>
+                      </button>
+                    </span>
+                  </TooltipTrigger>
+                  <TooltipContent>{t('tasks.manageMembers')}</TooltipContent>
+                </Tooltip>
+              )}
               {canUpdateTasks && (
                 <>
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <span className="inline-flex">
-                        <button
-                          type="button"
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            onOpenAssignments(row.id);
-                          }}
-                          aria-label={t('tasks.manageMembers')}
-                          className="p-2 text-zinc-400 hover:text-praetor hover:bg-zinc-100 rounded-lg transition-all"
-                        >
-                          <i className="fa-solid fa-users"></i>
-                        </button>
-                      </span>
-                    </TooltipTrigger>
-                    <TooltipContent>{t('tasks.manageMembers')}</TooltipContent>
-                  </Tooltip>
                   <Tooltip>
                     <TooltipTrigger asChild>
                       <span className="inline-flex">
@@ -522,6 +526,7 @@ const useTaskColumns = ({
       t,
       projects,
       clients,
+      canManageAssignments,
       canUpdateTasks,
       canDeleteTasks,
       onUpdateTask,
@@ -556,6 +561,11 @@ const TasksView: React.FC<TasksViewProps> = ({
   const canCreateTasks = hasScopedActionPermission(permissions, 'projects.tasks', 'create');
   const canUpdateTasks = hasScopedActionPermission(permissions, 'projects.tasks', 'update');
   const canDeleteTasks = hasScopedActionPermission(permissions, 'projects.tasks', 'delete');
+  const canManageAssignments = hasScopedActionPermission(
+    permissions,
+    'projects.assignments',
+    'update',
+  );
   const [state, dispatch] = useReducer(tasksViewReducer, undefined, createTasksViewState);
   const {
     editingTask,
@@ -636,15 +646,16 @@ const TasksView: React.FC<TasksViewProps> = ({
 
   const openAssignments = useCallback(
     (taskId: string) => {
-      if (!canUpdateTasks) return;
+      if (!canManageAssignments) return;
       dispatch({ type: 'manageTask', taskId });
     },
-    [canUpdateTasks],
+    [canManageAssignments],
   );
 
   const columns = useTaskColumns({
     projects,
     clients,
+    canManageAssignments,
     canUpdateTasks,
     canDeleteTasks,
     currency,
@@ -722,7 +733,7 @@ const TasksView: React.FC<TasksViewProps> = ({
         saveAssignedUserIds={(ids) => tasksApi.updateUsers(managingTaskId as string, ids)}
         entityLabel={t('common:labels.task')}
         entityName={managingTask?.name || ''}
-        disabled={!canUpdateTasks}
+        disabled={!canManageAssignments}
       />
 
       <TaskFormModal

--- a/docs-site/src/content/docs/crm-projects.md
+++ b/docs-site/src/content/docs/crm-projects.md
@@ -95,7 +95,7 @@ La sezione **Regole della commessa** nella pagina di dettaglio permette di crear
 
 ### Assegnazione utenti
 
-Dal comando **Assegna Utenti** gestisci chi è assegnato a una commessa o a una sua attività. L'accesso a questa finestra è governato dal permesso **Assegnazioni Progetto**: l'azione **View** consente di aprire le assegnazioni di qualsiasi commessa o attività indipendentemente dalla propria appartenenza, mentre **Update** consente di modificarle. Manager e Top Manager dispongono di entrambe per impostazione predefinita, quindi possono gestire le assegnazioni anche quando non sono membri della commessa o dell'attività.
+Dal comando **Assegna Utenti** gestisci chi è assegnato a una commessa o a una sua attività. L'accesso a questa finestra è governato dal permesso **Assegnazioni Progetto**: l'azione **View** consente di aprire le assegnazioni di qualsiasi commessa o attività indipendentemente dalla propria appartenenza, mentre **Update** consente di modificarle. I permessi di modifica delle attività non autorizzano la gestione delle assegnazioni. Manager e Top Manager dispongono di entrambi i permessi di assegnazione per impostazione predefinita, quindi possono gestire le assegnazioni anche quando non sono membri della commessa o dell'attività.
 
 ## Competence Center
 

--- a/docs-site/src/content/docs/en/crm-projects.md
+++ b/docs-site/src/content/docs/en/crm-projects.md
@@ -95,7 +95,7 @@ The **Job rules** section on the detail page lets you create automatic controls 
 
 ### Assigning users
 
-The **Assign Users** command manages who is assigned to a job or one of its activities. Access to this dialog is governed by the **Project Assignments** permission: the **View** action lets a role open the assignments of any job or activity regardless of its own membership, while **Update** lets it edit them. Managers and Top Managers hold both by default, so they can manage assignments even when they are not members of the job or activity.
+The **Assign Users** command manages who is assigned to a job or one of its activities. Access to this dialog is governed by the **Project Assignments** permission: the **View** action lets a role open the assignments of any job or activity regardless of its own membership, while **Update** lets it edit them. Task-edit permissions do not grant assignment-management access. Managers and Top Managers hold both assignment permissions by default, so they can manage assignments even when they are not members of the job or activity.
 
 ## Competence centers
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -19750,6 +19750,7 @@
         "tags": [
           "tasks"
         ],
+        "description": "Requires projects.assignments.update. Task update permissions do not authorize assignment changes.",
         "requestBody": {
           "required": true,
           "content": {

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -3,6 +3,7 @@ import { withDbTransaction } from '../db/drizzle.ts';
 import {
   authenticateToken,
   requireAnyPermission,
+  requirePermission,
   requireScopedPermission,
 } from '../middleware/auth.ts';
 import * as projectsRepo from '../repositories/projectsRepo.ts';
@@ -760,17 +761,12 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/:id/users',
     {
-      onRequest: [
-        authenticateToken,
-        requireAnyPermission(
-          'projects.assignments.update',
-          'projects.tasks.update',
-          'projects.tasks_all.update',
-        ),
-      ],
+      onRequest: [authenticateToken, requirePermission('projects.assignments.update')],
       schema: {
         tags: ['tasks'],
         summary: 'Update task user assignments',
+        description:
+          'Requires projects.assignments.update. Task update permissions do not authorize assignment changes.',
         params: idParamSchema,
         body: userIdsSchema,
         response: {

--- a/server/test/routes/tasks.test.ts
+++ b/server/test/routes/tasks.test.ts
@@ -150,6 +150,7 @@ const TASKS_PERMS = [
   'projects.tasks.delete',
   'projects.tasks_all.view',
   'projects.manage.view',
+  'projects.assignments.update',
 ];
 
 const USER_PERMS = ['projects.tasks.view'];
@@ -1191,7 +1192,7 @@ describe('POST /api/tasks/:id/users', () => {
     expect(res.statusCode).toBe(401);
   });
 
-  test('403: missing tasks.update permission', async () => {
+  test('403: missing assignments.update permission', async () => {
     getRolePermissionsMock.mockResolvedValue(USER_PERMS);
 
     const res = await testApp.inject({
@@ -1202,6 +1203,25 @@ describe('POST /api/tasks/:id/users', () => {
     });
 
     expect(res.statusCode).toBe(403);
+  });
+
+  test.each([
+    'projects.tasks.update',
+    'projects.tasks_all.update',
+  ])('403: %s cannot mutate task assignments without assignments.update', async (permission) => {
+    getRolePermissionsMock.mockResolvedValue([permission]);
+    findNameAndProjectIdMock.mockResolvedValue({ name: 'Implement feature', projectId: 'p-1' });
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/tasks/t-1/users',
+      headers: authHeader(),
+      payload: { userIds: ['u2'] },
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(clearNonTopManagerAssignmentsMock).not.toHaveBeenCalled();
+    expect(addManualAssignmentsMock).not.toHaveBeenCalled();
   });
 
   // Issue #720: the assignments view+update grants (seeded to manager/top_manager) permit editing

--- a/test/components/projects/TasksView.test.ts
+++ b/test/components/projects/TasksView.test.ts
@@ -62,6 +62,21 @@ describe('TasksView', () => {
   });
 
   describe('assignment modal user list (issue #720)', () => {
+    test('uses the dedicated assignment update permission for task membership changes', async () => {
+      const source = await readTasksViewSource();
+
+      expect(source).toMatch(
+        /const canManageAssignments = hasScopedActionPermission\(\s*permissions,\s*'projects\.assignments',\s*'update',\s*\);/,
+      );
+      expect(source).toMatch(
+        /const openAssignments = useCallback\(\s*\(taskId: string\) => \{\s*if \(!canManageAssignments\) return;/,
+      );
+      expect(source).toMatch(
+        /\{canManageAssignments && \(\s*<Tooltip>[\s\S]*?onOpenAssignments\(row\.id\)/,
+      );
+      expect(source).toContain('disabled={!canManageAssignments}');
+    });
+
     test('filters top managers, admin-only, and disabled users out of the assignable list', async () => {
       const source = await readTasksViewSource();
 


### PR DESCRIPTION
## Summary
- Require the dedicated `projects.assignments.update` capability before task assignees can be rewritten.
- Keep existing task membership / global row-scope checks separate from capability admission.
- Align the task assignment UI, OpenAPI output, and Italian/English user documentation with the secured contract.

## Changes
- Replace the task-assignment POST route's task-edit fallback guard with `requirePermission('projects.assignments.update')`.
- Gate the Tasks view assignment action and modal on the assignment update permission.
- Add regressions proving `projects.tasks.update` and `projects.tasks_all.update` alone cannot mutate assignments.
- Document the permission requirement in route schema, generated OpenAPI, and bilingual project docs.

## Testing
- Regression before fix: `bun test server/test/routes/tasks.test.ts --test-name-pattern "cannot mutate task assignments"` — failed as expected (both callers received 200 instead of 403).
- Focused after fix: same command — 2 passed.
- Affected files: `bun test server/test/routes/tasks.test.ts test/components/projects/TasksView.test.ts` — 72 passed.
- Full server: `bun run test:server` — 4,375 passed, 28 skipped, 0 failed.
- Full frontend: `bun run test:frontend` — 2,421 passed, 4 failed in untouched Windows CRLF-sensitive source-string tests (`App.moduleLoadCancellation`, `App.mfaModuleDatasets`, `ProjectDetailView`, `ProjectsView`).
- `bun run typecheck` — passed.
- Scoped `biome check` for changed code — passed.
- `bun run i18n:check` — passed.
- `bun run docs` — passed; 66 pre-existing TypeDoc warnings.
- `bun run build` — passed, including production login smoke test; existing chunk-size warning remains.
- `bun run test:react-doctor` — 80/100 before and after (same pre-existing 1 error and 33 warnings).
- Three consecutive clean review/simplify cycles completed across Code Reuse, Efficiency, and Quality/Bugs after the final edit.

## Risks / Rollout
- Intentional authorization tightening: callers that only have task-update permissions now receive 403 when changing assignees.
- Manager and Top Manager defaults already include both assignment view/update permissions; no seed, schema, migration, configuration, or deployment-order change is required.
- Existing assignment managers retain the same membership/global row scope. Roll forward is immediate; rollback is a revert of this commit.

## Compatibility
- REST path and request/response shapes are unchanged.
- The only compatibility change is capability enforcement for an ACL mutation that previously accepted unrelated task-edit permissions.

## Issues
- Issue: Not linked. Validated DeepSec `acl-check` finding.