### PR TITLE
tables(fix): reduce line item note minimum width

### DIFF
--- a/components/shared/lineItemNoteStyles.ts
+++ b/components/shared/lineItemNoteStyles.ts
@@ -1,2 +1,2 @@
-export const LINE_ITEM_NOTE_COLUMN_MIN_WIDTH = 684;
-export const LINE_ITEM_NOTE_CELL_CLASSNAME = 'min-w-[660px]';
+export const LINE_ITEM_NOTE_COLUMN_MIN_WIDTH = 244;
+export const LINE_ITEM_NOTE_CELL_CLASSNAME = 'min-w-[220px]';

--- a/test/components/shared/lineItemNoteStyles.test.ts
+++ b/test/components/shared/lineItemNoteStyles.test.ts
@@ -5,8 +5,8 @@ import {
 } from '../../../components/shared/lineItemNoteStyles';
 
 describe('line item note column styles', () => {
-  test('reserves a note column at least three times wider than the previous editor', () => {
-    expect(LINE_ITEM_NOTE_COLUMN_MIN_WIDTH).toBeGreaterThanOrEqual(660);
-    expect(LINE_ITEM_NOTE_CELL_CLASSNAME).toBe('min-w-[660px]');
+  test('starts the note editor at a compact width', () => {
+    expect(LINE_ITEM_NOTE_COLUMN_MIN_WIDTH).toBe(244);
+    expect(LINE_ITEM_NOTE_CELL_CLASSNAME).toBe('min-w-[220px]');
   });
 });


### PR DESCRIPTION
## Summary
- Makes per-line note editors start at a compact width so document item tables expose more useful columns by default.
- Applies consistently to customer and supplier quotes, customer offers, and supplier orders through the existing shared style.

## Changes
- Reduces the note cell minimum width from 660 px to 220 px.
- Reduces the corresponding table column minimum from 684 px to 244 px, including cell padding.
- Updates the focused regression test to pin the compact starting dimensions.

## Testing
- `bun test test/components/shared/lineItemNoteStyles.test.ts` — 1 passed.
- `bun test test/components/shared` — 73 passed.
- `bun run typecheck` — passed.
- `bun run build` — passed, including user docs and the production login smoke test.
- `bun x biome check components/shared/lineItemNoteStyles.ts test/components/shared/lineItemNoteStyles.test.ts` — passed.
- `git diff --check` — passed.
- `bun run test:react-doctor` — remained at the baseline 80/100; the command exits non-zero for a pre-existing `DashboardGrid.tsx` diagnostic outside this change.

## Risks / Rollout
- Low risk and presentation-only; there are no API, database, configuration, permission, or migration changes.
- Existing user-resized widths remain preserved and can be reduced to the new minimum.
- No documentation changes are required for this layout-only adjustment.
- Rollback is a direct revert of the commit.

## Issues
Issue: Not linked
