### PR TITLE
sales(fix): hide supplier items used by other quotes

### DIFF
--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -1461,10 +1461,28 @@ const useClientQuotesController = ({
     return ids;
   }, [formData.items]);
 
+  const supplierQuoteItemIdsUsedByOtherQuotes = useMemo(() => {
+    const ids = new Set<string>();
+    for (const quote of quotes) {
+      if (quote.id === editingQuote?.id) continue;
+
+      for (const item of quote.items) {
+        if (item.supplierQuoteItemId) ids.add(item.supplierQuoteItemId);
+      }
+      for (const candidate of quote.candidates ?? []) {
+        for (const item of candidate.items) {
+          if (item.supplierQuoteItemId) ids.add(item.supplierQuoteItemId);
+        }
+      }
+    }
+    return ids;
+  }, [editingQuote?.id, quotes]);
+
   const supplierQuoteItemOptions = useMemo(() => {
     const options: Option[] = [];
     for (const quote of sourceableSupplierQuotes) {
       for (const item of quote.items) {
+        if (supplierQuoteItemIdsUsedByOtherQuotes.has(item.id)) continue;
         options.push({
           id: item.id,
           name: supplierQuoteItemLabel(quote, item),
@@ -1473,7 +1491,7 @@ const useClientQuotesController = ({
       }
     }
     return options;
-  }, [sourceableSupplierQuotes, usedSupplierQuoteItemIds]);
+  }, [sourceableSupplierQuotes, supplierQuoteItemIdsUsedByOtherQuotes, usedSupplierQuoteItemIds]);
 
   // item-id → its CURRENT supplier quote + item, across ALL supplier quotes (not just the
   // selectable ones), for the bidirectional-sync affordances (#779): lock detection

--- a/docs-site/src/content/docs/en/sales-accounting.md
+++ b/docs-site/src/content/docs/en/sales-accounting.md
@@ -43,7 +43,7 @@ From **Sent**, use **Choose the candidate to promote** to compare total, margin,
 
 A client quote is associated with supplier quotes purely through its **product lines** — each line can be sourced from a supplier quote item (there is no separate header field). While any supplier quote a line sources is **Expired**, the client quote shows an indicator and cannot progress to **Sent**, **Offer**, or **Accepted** until you extend that supplier quote's validity.
 
-While creating or editing a draft, supplier items already used by a line in the same quote appear greyed out in the picker and cannot be selected again; unlinking or removing the line makes the item immediately available.
+When creating or editing a quote, supplier items already used by another customer quote, including its saved variants, do not appear in the picker. Other items from the same supplier quote remain available. An item used in one variant remains available to the other variants of the same quote. In the open variant, items already selected by another line instead appear greyed out and cannot be selected again; unlinking or removing the line makes the item immediately available.
 
 Each picker option starts with the supplier quote code in square brackets, for example `[SQ-001]`.
 

--- a/docs-site/src/content/docs/sales-accounting.md
+++ b/docs-site/src/content/docs/sales-accounting.md
@@ -43,7 +43,7 @@ Da **Inviato**, usa **Scegli il candidato da promuovere** per confrontare totale
 
 Un preventivo cliente è associato ai preventivi fornitore solo tramite le sue **righe prodotto** — ogni riga può essere agganciata a una voce di un preventivo fornitore (non esiste più un campo header dedicato). Se un preventivo fornitore agganciato da una riga è **Scaduto**, il preventivo cliente mostra un indicatore e non può avanzare a **Inviato**, **Offerta** o **Accettato** finché non estendi la validità di quel preventivo fornitore.
 
-Durante la creazione o la modifica di una bozza, le voci fornitore già usate in una riga dello stesso preventivo appaiono in grigio nella selezione e non possono essere scelte di nuovo; scollegando o rimuovendo la riga, la voce torna immediatamente disponibile.
+Durante la creazione o la modifica di un preventivo, le voci fornitore già usate da un altro preventivo cliente, comprese le sue varianti salvate, non compaiono nella selezione. Le altre voci dello stesso preventivo fornitore restano disponibili. Una voce usata in una variante resta disponibile nelle altre varianti dello stesso preventivo. Nella variante aperta, le voci già scelte in un'altra riga appaiono invece in grigio e non possono essere selezionate di nuovo; scollegando o rimuovendo la riga, la voce torna immediatamente disponibile.
 
 Ogni opzione della selezione mostra all'inizio il codice del preventivo fornitore tra parentesi quadrate, per esempio `[PF-001]`.
 

--- a/test/components/ClientQuotesView.test.tsx
+++ b/test/components/ClientQuotesView.test.tsx
@@ -771,6 +771,102 @@ describe('<ClientQuotesView /> supplier-quote item availability', () => {
     expect(getOpenSupplierItem(firstSupplierItemLabel)).toHaveAttribute('data-disabled', 'false');
   });
 
+  test('hides items used by a saved candidate while creating a new quote', () => {
+    const candidateId = 'candidate-discarded';
+    const existingQuote = buildQuote({
+      id: 'Q-USED-SUPPLIER-ITEM',
+      candidates: [
+        {
+          id: candidateId,
+          quoteId: 'Q-USED-SUPPLIER-ITEM',
+          name: 'Variante archiviata',
+          position: 0,
+          state: 'discarded',
+          items: [
+            {
+              id: 'qi-used-supplier-item',
+              quoteId: 'Q-USED-SUPPLIER-ITEM',
+              candidateId,
+              productId: 'prod-1',
+              productName: 'Solar Panel',
+              quantity: 1,
+              unitPrice: 80,
+              supplierQuoteId: 'SQ-1',
+              supplierQuoteItemId: 'sqi-1',
+              supplierQuoteSupplierName: 'Acme Supplies',
+              supplierQuoteUnitPrice: 60,
+            },
+          ],
+          paymentTerms: 'immediate',
+          discount: 0,
+          discountType: 'percentage',
+          expirationDate: '2099-12-31',
+          createdAt: 1_700_000_000_000,
+          updatedAt: 1_700_000_000_000,
+        },
+      ],
+    });
+
+    render(
+      <ClientQuotesView
+        {...baseProps}
+        quotes={[existingQuote]}
+        supplierQuotes={[sourceableSupplierQuote]}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole('button', { name: 'sales:clientQuotes.createNewQuote' }));
+    fireEvent.click(screen.getByText('sales:clientQuotes.addProduct'));
+    fireEvent.click(screen.getByRole('button', { name: emptySupplierLabel }));
+
+    const openOptions = Array.from(
+      document.querySelectorAll<HTMLElement>('[data-slot="command-item"]'),
+    );
+    expect(openOptions.some((option) => option.textContent?.includes(firstSupplierItemLabel))).toBe(
+      false,
+    );
+    expect(getOpenSupplierItem(secondSupplierItemLabel)).toHaveAttribute('data-disabled', 'false');
+  });
+
+  test('keeps an item available when adding a new candidate to the saved quote that uses it', async () => {
+    const user = userEvent.setup();
+    const draftQuote = buildQuote({
+      id: 'Q-SAME-SUPPLIER-ITEM',
+      items: [
+        {
+          id: 'qi-same-supplier-item',
+          quoteId: 'Q-SAME-SUPPLIER-ITEM',
+          productId: 'prod-1',
+          productName: 'Solar Panel',
+          quantity: 1,
+          unitPrice: 80,
+          supplierQuoteId: 'SQ-1',
+          supplierQuoteItemId: 'sqi-1',
+          supplierQuoteSupplierName: 'Acme Supplies',
+          supplierQuoteUnitPrice: 60,
+        },
+      ],
+    });
+    render(
+      <ClientQuotesView
+        {...baseProps}
+        quotes={[draftQuote]}
+        supplierQuotes={[sourceableSupplierQuote]}
+      />,
+    );
+
+    await user.click(screen.getByText('Q-SAME-SUPPLIER-ITEM'));
+    await screen.findByRole('dialog');
+    await user.click(screen.getByRole('button', { name: 'sales:clientQuotes.candidates.addMenu' }));
+    await user.click(
+      await screen.findByRole('menuitem', { name: 'sales:clientQuotes.candidates.add' }),
+    );
+    await user.click(screen.getByText('sales:clientQuotes.addProduct'));
+    await user.click(screen.getByRole('button', { name: emptySupplierLabel }));
+
+    expect(getOpenSupplierItem(firstSupplierItemLabel)).toHaveAttribute('data-disabled', 'false');
+  });
+
   test('marks items already used by a draft as disabled while editing', async () => {
     const draftQuote = buildQuote({
       id: 'Q-SUPPLIER-AVAILABILITY',


### PR DESCRIPTION
## Summary

- Prevent supplier quote items already linked to another customer quote from appearing in the customer quote item picker.
- Keep the same supplier item reusable across saved variants of the same customer quote.

## Changes

- Collect supplier item IDs from every loaded customer quote and all of its saved variants, excluding the quote currently being edited.
- Omit items reserved by other customer quotes while preserving the existing same-variant duplicate guard.
- Add regression coverage for saved variants, unused sibling items, current-quote editing, and in-form duplicate handling.
- Document the selector behavior in the Italian and English user guides.

## Testing

- `bun test test/components/ClientQuotesView.test.tsx test/components/sales/ClientQuotesView.test.tsx` — 55 passed, 0 failed.
- `bun run typecheck` — passed.
- `bun run build` — passed; existing large-chunk warning remains.
- `bun x biome check components/sales/ClientQuotesView.tsx test/components/ClientQuotesView.test.tsx` — passed.
- `bun run test:react-doctor` — 80/100 before and after; exits with code 1 for the pre-existing `components/projects/DashboardGrid.tsx:165` finding.
- `bun run lint` — the i18n and typecheck stages pass, but the command remains non-clean because of existing repository-wide CRLF formatting diagnostics.

## Risks / rollout

- Low-risk frontend-only filtering; no API, database, migration, or public contract changes.
- Availability is derived from the customer quotes currently loaded by the view; server-side uniqueness is intentionally unchanged.

## Issue

Not linked.
