### PR TITLE
server(security): preserve insecure admin password warnings

### DIFF
--- a/server/routes/settings.ts
+++ b/server/routes/settings.ts
@@ -25,6 +25,7 @@ import {
 } from '../utils/personal-access-token.ts';
 import { LOGIN_RATE_LIMIT, STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import { replyError } from '../utils/replyError.ts';
+import { INSECURE_DEFAULT_ADMIN_PASSWORDS, isInsecureEnvValue } from '../utils/runtimeConfig.ts';
 import {
   badRequest,
   forbidden,
@@ -35,7 +36,6 @@ import {
 } from '../utils/validation.ts';
 
 const ADMIN_USERNAME = 'admin';
-const DEFAULT_ADMIN_PASSWORD = 'password';
 
 const MAX_RIL_TRANSFER_VALUE_LENGTH = 64;
 
@@ -468,7 +468,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       });
 
       if (request.user.username === ADMIN_USERNAME) {
-        if (newPasswordResult.value === DEFAULT_ADMIN_PASSWORD) {
+        if (isInsecureEnvValue(newPasswordResult.value, INSECURE_DEFAULT_ADMIN_PASSWORDS)) {
           await notificationsRepo.upsertAdminPasswordWarning(request.user.id);
         } else {
           await notificationsRepo.deleteAdminPasswordWarning(request.user.id);

--- a/server/test/routes/settings.test.ts
+++ b/server/test/routes/settings.test.ts
@@ -698,7 +698,10 @@ describe('PUT /api/settings/password', () => {
     expect(upsertAdminPasswordWarningMock).not.toHaveBeenCalled();
   });
 
-  test('200 admin setting password back to default recreates warning', async () => {
+  test.each([
+    'password',
+    'change-me-strong-admin-password',
+  ])('200 admin setting insecure password %s recreates warning', async (newPassword) => {
     findAuthUserByIdMock.mockResolvedValue({ ...HAPPY_USER, username: 'admin' });
     getPasswordHashMock.mockResolvedValue('$2a$existing');
     bcryptCompareMock.mockResolvedValue(true);
@@ -709,7 +712,7 @@ describe('PUT /api/settings/password', () => {
       method: 'PUT',
       url: '/api/settings/password',
       headers: authHeader(),
-      payload: { currentPassword: 'new-secure-pw', newPassword: 'password' },
+      payload: { currentPassword: 'new-secure-pw', newPassword },
     });
 
     expect(res.statusCode).toBe(200);


### PR DESCRIPTION
## Summary

- Reuse the shared bootstrap-admin insecure-password denylist when an administrator changes their password through Settings.
- Keep the security warning active for both published defaults: `password` and `change-me-strong-admin-password`.
- Add a table-driven route regression covering both values.

The fresh-bootstrap fail-closed runtime/config/docs fix landed on current `main` in #991 while this PR was under review. This PR was rebased and narrowed to the remaining warning-consistency gap; all duplicate changes were dropped.

## Security validation

Before this route fix, the new placeholder regression failed because changing the admin password to `change-me-strong-admin-password` deleted the warning even though bootstrap classified the same value as insecure. The route now uses the exact shared denylist used by bootstrap.

## Compatibility and rollout

- No database migration, API shape, or deployment-order change.
- Existing initialized installations remain start-compatible.
- Password changes retain current compatibility: published defaults are accepted but keep/recreate the existing in-app warning.
- No additional user/API documentation change is needed beyond the guidance already merged in #991.

## Verification

- `bun test server/test/routes/settings.test.ts server/test/utils/runtimeConfig.test.ts server/test/db/bootstrapAdmin.test.ts` — 57 passed, 0 failed
- `bunx biome check server/routes/settings.ts server/test/routes/settings.test.ts` — passed
- `bun run typecheck` — passed
- `bun run test:react-doctor` — 80/100, unchanged from baseline (same pre-existing 1 error and 33 warnings)
- Three consecutive clean Reuse, Efficiency, and Quality/Bugs review+simplify cycles after the final edit