### PR TITLE
numbers(fix): group four-digit thousands consistently

### DIFF
--- a/components/administration/SiemLogsTab.tsx
+++ b/components/administration/SiemLogsTab.tsx
@@ -18,6 +18,7 @@ import {
   type SiemConfigUpdate,
   type SiemStatus,
 } from '../../services/api/logs';
+import { formatNumber } from '../../utils/numbers';
 import SecretField from '../shared/SecretField';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
@@ -884,9 +885,7 @@ const SiemLogsTab: React.FC<Props> = ({ canUpdate }) => {
               </div>
               <div>
                 <div className="text-xs text-muted-foreground">{t('logs.siem.status.pending')}</div>
-                <div className="mt-1 font-medium">
-                  {(status?.pendingCount ?? 0).toLocaleString(i18n.language)}
-                </div>
+                <div className="mt-1 font-medium">{formatNumber(status?.pendingCount ?? 0)}</div>
               </div>
               <div>
                 <div className="text-xs text-muted-foreground">
@@ -899,9 +898,7 @@ const SiemLogsTab: React.FC<Props> = ({ canUpdate }) => {
               <div>
                 <div className="text-xs text-muted-foreground">{t('logs.siem.status.dropped')}</div>
                 <div className="mt-1 font-medium">
-                  {(
-                    (status?.droppedCapacity ?? 0) + (status?.droppedRetention ?? 0)
-                  ).toLocaleString(i18n.language)}
+                  {formatNumber((status?.droppedCapacity ?? 0) + (status?.droppedRetention ?? 0))}
                 </div>
               </div>
             </div>

--- a/components/reports/AiReportingView.tsx
+++ b/components/reports/AiReportingView.tsx
@@ -63,6 +63,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import { cn } from '@/lib/utils';
 import api from '../../services/api';
 import type { ReportChatMessage, ReportChatSessionSummary } from '../../types';
+import { formatNumber } from '../../utils/numbers';
 import { buildPermission, hasPermission } from '../../utils/permissions';
 import {
   AiReportingVisualization,
@@ -109,8 +110,6 @@ const toOptionLabel = (session: ReportChatSessionSummary) => {
   const title = session.title?.trim() ? session.title.trim() : '';
   return title;
 };
-
-const AI_REPORTING_NUMBER_FORMATTER = new Intl.NumberFormat();
 
 const safeHref = (href: string | undefined) => {
   if (!href) return null;
@@ -2436,9 +2435,8 @@ const AiReportingHeader: React.FC<AiReportingHeaderProps> = ({
                   className="gap-1.5 font-normal tabular-nums"
                 >
                   {t('aiReporting.contextWindow', { defaultValue: 'Context' })}{' '}
-                  {AI_REPORTING_NUMBER_FORMATTER.format(technicalInfo.contextTokensUsed)} /{' '}
-                  {AI_REPORTING_NUMBER_FORMATTER.format(technicalInfo.contextWindowTokens)} (
-                  {contextPercentage}%)
+                  {formatNumber(technicalInfo.contextTokensUsed)} /{' '}
+                  {formatNumber(technicalInfo.contextWindowTokens)} ({contextPercentage}%)
                   {isContextWarning && (
                     <Tooltip>
                       <TooltipTrigger asChild>
@@ -3155,7 +3153,7 @@ const AiMarkdownMessage: React.FC<{
   isStreaming,
   shouldRevealVisualizationsProgressively,
 }) => {
-  const { t, language, resolveTableMarkdown, tableRefs, completeProgressiveVisualizationReveal } =
+  const { t, resolveTableMarkdown, tableRefs, completeProgressiveVisualizationReveal } =
     interactions;
   let tableRenderIndex = 0;
 
@@ -3208,7 +3206,6 @@ const AiMarkdownMessage: React.FC<{
             <AiReportingVisualization
               key={`${message.id}-visualization-${block.visualizationIndex}`}
               visualization={block.visualization}
-              language={language}
             />
           );
         }

--- a/components/reports/AiReportingVisualization.tsx
+++ b/components/reports/AiReportingVisualization.tsx
@@ -50,6 +50,7 @@ import {
   TableRow,
 } from '@/components/ui/table';
 import { CopyElementAsPngError, copyElementAsPng } from '@/utils/copyElementAsPng';
+import { formatNumber } from '@/utils/numbers';
 import {
   CHART_COLORS,
   getBarPointColor,
@@ -71,17 +72,12 @@ const DEFAULT_TYPE_LABELS = {
 
 interface AiReportingVisualizationProps {
   visualization: AiReportingVisualizationDefinition;
-  language: string;
 }
 
 const getFractionDigits = (series: AiReportingVisualizationSeries) =>
   series.decimals ?? (series.format === 'currency' ? 2 : series.format === 'percent' ? 1 : 2);
 
-const formatVisualizationValue = (
-  value: number,
-  series: AiReportingVisualizationSeries,
-  language: string,
-) => {
+const formatVisualizationValue = (value: number, series: AiReportingVisualizationSeries) => {
   const options: Intl.NumberFormatOptions = {
     minimumFractionDigits: series.decimals,
     maximumFractionDigits: getFractionDigits(series),
@@ -92,7 +88,7 @@ const formatVisualizationValue = (
     options.currency = series.currency;
   }
 
-  const formatted = new Intl.NumberFormat(language, options).format(value);
+  const formatted = formatNumber(value, options);
   const formattedValue = series.format === 'percent' ? `${formatted}%` : formatted;
   return series.unit ? `${formattedValue} ${series.unit}` : formattedValue;
 };
@@ -110,15 +106,10 @@ const buildChartConfig = (visualization: AiReportingVisualizationDefinition): Ch
 
 interface VisualizationTooltipProps {
   visualization: AiReportingVisualizationDefinition;
-  language: string;
   circular?: boolean;
 }
 
-const VisualizationTooltip = ({
-  visualization,
-  language,
-  circular = false,
-}: VisualizationTooltipProps) => (
+const VisualizationTooltip = ({ visualization, circular = false }: VisualizationTooltipProps) => (
   <ChartTooltip
     cursor={false}
     content={
@@ -140,7 +131,7 @@ const VisualizationTooltip = ({
             <div className="flex min-w-40 items-center justify-between gap-4">
               <span className="text-muted-foreground">{label}</span>
               <span className="font-mono font-medium tabular-nums text-foreground">
-                {formatVisualizationValue(value, series, language)}
+                {formatVisualizationValue(value, series)}
               </span>
             </div>
           );
@@ -167,15 +158,15 @@ const DistinctBarShape = ({ height, index, width, x, y }: BarShapeProps) => {
   );
 };
 
-const CartesianVisualization = ({ visualization, language }: VisualizationTooltipProps) => {
+const CartesianVisualization = ({ visualization }: VisualizationTooltipProps) => {
   const isHorizontalBar =
     visualization.type === 'bar' && visualization.orientation === 'horizontal';
   const firstSeries = visualization.series[0];
   const axisFormatter = (value: number) =>
-    new Intl.NumberFormat(language, {
+    formatNumber(value, {
       notation: 'compact',
       maximumFractionDigits: Math.min(getFractionDigits(firstSeries), 2),
-    }).format(value);
+    });
   const commonChildren = (
     <>
       <CartesianGrid vertical={isHorizontalBar} horizontal={!isHorizontalBar} />
@@ -202,7 +193,7 @@ const CartesianVisualization = ({ visualization, language }: VisualizationToolti
           <YAxis tickFormatter={axisFormatter} tickLine={false} axisLine={false} width={56} />
         </>
       )}
-      <VisualizationTooltip visualization={visualization} language={language} />
+      <VisualizationTooltip visualization={visualization} />
       {visualization.series.length > 1 ? (
         <ChartLegend content={<ChartLegendContent className="flex-wrap gap-x-4 gap-y-2" />} />
       ) : null}
@@ -278,7 +269,7 @@ interface CircularVisualizationProps extends VisualizationTooltipProps {
   config: ChartConfig;
 }
 
-const CircularVisualization = ({ visualization, language, config }: CircularVisualizationProps) => {
+const CircularVisualization = ({ visualization, config }: CircularVisualizationProps) => {
   const series = visualization.series[0];
   const pieData: Array<Record<string, number | string>> = visualization.data.map(
     (datum, index) => ({
@@ -295,7 +286,7 @@ const CircularVisualization = ({ visualization, language, config }: CircularVisu
         aria-label={visualization.title}
       >
         <PieChart accessibilityLayer>
-          <VisualizationTooltip visualization={visualization} language={language} circular />
+          <VisualizationTooltip visualization={visualization} circular />
           <Pie
             data={pieData}
             dataKey={series.key}
@@ -322,7 +313,7 @@ const CircularVisualization = ({ visualization, language, config }: CircularVisu
               <span className="truncate">{String(datum[visualization.xKey])}</span>
             </span>
             <span className="font-mono font-medium tabular-nums text-foreground">
-              {formatVisualizationValue(Number(datum[series.key]), series, language)}
+              {formatVisualizationValue(Number(datum[series.key]), series)}
             </span>
           </div>
         ))}
@@ -335,11 +326,7 @@ interface VisualizationDataTableProps extends AiReportingVisualizationProps {
   label: string;
 }
 
-const VisualizationDataTable = ({
-  visualization,
-  language,
-  label,
-}: VisualizationDataTableProps) => (
+const VisualizationDataTable = ({ visualization, label }: VisualizationDataTableProps) => (
   <div className="max-h-72 overflow-auto border-t">
     <Table aria-label={label}>
       <TableHeader className="sticky top-0 z-10 bg-card">
@@ -358,7 +345,7 @@ const VisualizationDataTable = ({
             <TableCell className="font-medium">{String(datum[visualization.xKey])}</TableCell>
             {visualization.series.map((series) => (
               <TableCell key={series.key} className="text-right font-mono tabular-nums">
-                {formatVisualizationValue(Number(datum[series.key]), series, language)}
+                {formatVisualizationValue(Number(datum[series.key]), series)}
               </TableCell>
             ))}
           </TableRow>
@@ -368,10 +355,7 @@ const VisualizationDataTable = ({
   </div>
 );
 
-const AiReportingVisualizationContent = ({
-  visualization,
-  language,
-}: AiReportingVisualizationProps) => {
+const AiReportingVisualizationContent = ({ visualization }: AiReportingVisualizationProps) => {
   const { t } = useTranslation('reports');
   const titleId = useId();
   const chartExportRef = useRef<HTMLDivElement>(null);
@@ -456,18 +440,14 @@ const AiReportingVisualizationContent = ({
         </CardHeader>
         <CardContent className="px-3 py-4 sm:px-5">
           {isCircular ? (
-            <CircularVisualization
-              visualization={visualization}
-              language={language}
-              config={config}
-            />
+            <CircularVisualization visualization={visualization} config={config} />
           ) : (
             <ChartContainer
               config={config}
               className="h-80 w-full aspect-auto"
               aria-label={visualization.title}
             >
-              <CartesianVisualization visualization={visualization} language={language} />
+              <CartesianVisualization visualization={visualization} />
             </ChartContainer>
           )}
         </CardContent>
@@ -487,7 +467,6 @@ const AiReportingVisualizationContent = ({
         <CollapsibleContent>
           <VisualizationDataTable
             visualization={visualization}
-            language={language}
             label={t('aiReporting.visualizationDataTable', {
               defaultValue: 'Data used for {{title}}',
               title: visualization.title,

--- a/components/reports/TimeReportView.tsx
+++ b/components/reports/TimeReportView.tsx
@@ -33,6 +33,7 @@ import type {
 } from '../../types';
 import { getLocalDateString } from '../../utils/date';
 import { downloadBlob } from '../../utils/download';
+import { formatDecimal } from '../../utils/numbers';
 import { hasPermission } from '../../utils/permissions';
 import {
   finalizeTimeReportFavorite,
@@ -135,11 +136,7 @@ const formatDuration = (hours: number) => {
   return `${Math.floor(totalMinutes / 60)}:${String(Math.abs(totalMinutes % 60)).padStart(2, '0')}`;
 };
 
-const formatCost = (value: number, currency: string, language: string) =>
-  `${new Intl.NumberFormat(language, {
-    minimumFractionDigits: 2,
-    maximumFractionDigits: 2,
-  }).format(value)} ${currency}`;
+const formatCost = (value: number, currency: string) => `${formatDecimal(value)} ${currency}`;
 
 export interface TimeReportViewProps {
   permissions: string[];
@@ -529,7 +526,7 @@ const TimeReportView = ({
             <span
               className={row.kind === 'subtotal' ? 'font-semibold tabular-nums' : 'tabular-nums'}
             >
-              {formatCost(row.cost, currency, i18n.language)}
+              {formatCost(row.cost, currency)}
             </span>
           ),
         align: 'right',
@@ -568,7 +565,7 @@ const TimeReportView = ({
       });
     }
     return columns;
-  }, [currency, generatedDefinition, i18n.language, openEntryEditor, options?.editableUserIds, t]);
+  }, [currency, generatedDefinition, openEntryEditor, options?.editableUserIds, t]);
 
   const saveEditedEntry = async (
     id: string,
@@ -882,8 +879,7 @@ const TimeReportView = ({
                 </span>
                 {result.totals.cost !== null && (
                   <span>
-                    {t('timeReport.results.totalCost')}:{' '}
-                    {formatCost(result.totals.cost, currency, i18n.language)}
+                    {t('timeReport.results.totalCost')}: {formatCost(result.totals.cost, currency)}
                   </span>
                 )}
               </div>

--- a/test/components/administration/LogsView.test.tsx
+++ b/test/components/administration/LogsView.test.tsx
@@ -204,6 +204,21 @@ describe('<LogsView />', () => {
     expect(await screen.findByDisplayValue('siem.example.test')).toBeInTheDocument();
   });
 
+  test('uses the shared Italian thousands separator for SIEM status counters', async () => {
+    logsApiMock.getSiemStatus.mockResolvedValueOnce({
+      ...siemStatus,
+      pendingCount: 7000,
+      droppedRetention: 3000,
+      droppedCapacity: 4000,
+    });
+    const user = userEvent.setup();
+    render(<LogsView canUpdateSiem />);
+
+    await user.click(screen.getByRole('tab', { name: 'logs.tabs.siem' }));
+
+    expect(await screen.findAllByText('7.000')).toHaveLength(2);
+  });
+
   test('keeps the SIEM layout width stable while configuration loads', async () => {
     const user = userEvent.setup();
     const configRequest = createDeferred<SiemConfig>();

--- a/test/components/reports/AiReportingInteractions.test.tsx
+++ b/test/components/reports/AiReportingInteractions.test.tsx
@@ -363,8 +363,8 @@ describe('<AiReportingView /> interactions', () => {
 
     expect(screen.getByText('gemini · gemini-2.5-pro')).toBeInTheDocument();
     const warning = screen.getByLabelText('Context window warning');
-    expect(warning.closest('[data-slot="badge"]')?.textContent).toMatch(
-      /850[.,]000 \/ 1[.,]000[.,]000 \(85%\)/,
+    expect(warning.closest('[data-slot="badge"]')?.textContent).toContain(
+      '850.000 / 1.000.000 (85%)',
     );
   });
 
@@ -978,7 +978,7 @@ describe('<AiReportingView /> interactions', () => {
     fireEvent.click(screen.getByRole('button', { name: 'Show data' }));
     const table = await screen.findByRole('table', { name: 'Data used for Monthly revenue' });
     expect(within(table).getByText('January')).toBeInTheDocument();
-    expect(within(table).getByText('€1,200.00')).toBeInTheDocument();
+    expect(within(table).getByText('1.200,00 €')).toBeInTheDocument();
     expect(within(table).getByText('12% pts')).toBeInTheDocument();
   });
 

--- a/test/utils/numbers.test.ts
+++ b/test/utils/numbers.test.ts
@@ -94,9 +94,31 @@ describe('localized number formatting', () => {
     expect(normalizeLocalizedNumber('1.234,56')).toBe('1234.56');
   });
 
+  test('groups four-digit thousands even on runtimes that default to min2 grouping', () => {
+    const NativeNumberFormat = Intl.NumberFormat;
+    const Min2NumberFormat = function (
+      locales?: Intl.LocalesArgument,
+      options: Intl.NumberFormatOptions = {},
+    ) {
+      return new NativeNumberFormat(locales, {
+        ...options,
+        useGrouping: options.useGrouping ?? 'min2',
+      });
+    } as typeof Intl.NumberFormat;
+    Min2NumberFormat.supportedLocalesOf = NativeNumberFormat.supportedLocalesOf;
+    Intl.NumberFormat = Min2NumberFormat;
+
+    try {
+      expect(formatNumber(7000, { numberingSystem: 'latn' })).toBe('7.000');
+    } finally {
+      Intl.NumberFormat = NativeNumberFormat;
+    }
+  });
+
   test('uses commas for decimals and dots only for thousands', () => {
     expect(formatDecimal(1234.5)).toBe('1.234,50');
     expect(formatNumber(1234567.89, { maximumFractionDigits: 2 })).toBe('1.234.567,89');
+    expect(formatNumber(7000, { useGrouping: false })).toBe('7000');
   });
 
   test('never exposes NaN or Infinity in the UI', () => {

--- a/utils/numbers.ts
+++ b/utils/numbers.ts
@@ -78,10 +78,16 @@ export const formatNumber = (
 ): string => {
   const finiteValue = Number.isFinite(value) ? (value as number) : 0;
   const displayValue = Object.is(finiteValue, -0) ? 0 : finiteValue;
+  // Some ICU/CLDR versions default Italian formatting to `min2`, which leaves four-digit
+  // values ungrouped (7000) while grouping five-digit values (10.000). Default to grouping
+  // from the first thousands group while allowing editable inputs to opt out explicitly.
   const cacheKey = JSON.stringify(options);
   let formatter = numberFormatters.get(cacheKey);
   if (!formatter) {
-    formatter = new Intl.NumberFormat(NUMBER_LOCALE, options);
+    formatter = new Intl.NumberFormat(NUMBER_LOCALE, {
+      ...options,
+      useGrouping: options.useGrouping ?? 'always',
+    });
     numberFormatters.set(cacheKey, formatter);
   }
   return formatter.format(displayValue);

--- a/utils/rilExport.ts
+++ b/utils/rilExport.ts
@@ -1,5 +1,6 @@
 import type { Cell, Workbook } from 'exceljs';
 import { downloadBlob } from './download';
+import { formatDecimal } from './numbers';
 import type { RilRow } from './ril';
 import {
   calculateRilTotals,
@@ -80,10 +81,6 @@ const setFill = (cell: Cell, argb: string) => {
 };
 
 const MONTH_NAME_FORMAT = new Intl.DateTimeFormat('it-IT', { month: 'long' });
-const PICAP_FORMAT = new Intl.NumberFormat('it-IT', {
-  minimumFractionDigits: 2,
-  maximumFractionDigits: 2,
-});
 
 // Renders minutes as H:MM with an unpadded hour, to read like the reference form (e.g. 160:00).
 const formatMinutesClock = (minutes: number): string => {
@@ -98,7 +95,7 @@ const formatMonthLabel = (year: number, month: number) => {
   return `${monthName}-${String(year).slice(-2)}`;
 };
 
-const formatPicap = (value: number) => PICAP_FORMAT.format(value);
+const formatPicap = (value: number) => formatDecimal(value);
 
 const normalizeRows = (rows: RilRow[]): RilRow[] => {
   const byDay = new Map(rows.map((row) => [row.day, row]));


### PR DESCRIPTION
## Summary
- Ensures four-digit values use the Italian thousands separator (`7000` → `7.000`) across supported runtimes.
- Applies the shared number formatter consistently to SIEM counters, time reports, AI reporting, and RIL exports.

## Changes
- Defaults `formatNumber` to `useGrouping: "always"` while preserving the explicit no-grouping behavior used by editable inputs.
- Replaces direct locale-dependent formatters with the cached Italian formatter and removes now-unused language props and memo dependencies.
- Adds regression coverage for runtimes that default to `min2` grouping, the input opt-out, SIEM counters, AI context statistics, and AI currency values.

## Testing
- `bun test test/utils/numbers.test.ts test/utils/rilExport.test.ts test/components/administration/LogsView.test.tsx test/components/reports/TimeReportView.test.tsx test/components/reports/AiReportingInteractions.test.tsx` — 154 passed.
- `bun run typecheck` — passed.
- `bunx biome check <changed files>` — passed.
- `bun run build` — passed, including the production login smoke test; existing bundle-size warnings remain.
- `bun run test:react-doctor` — improved from 80 to 81; exits non-zero because of the existing `DashboardGrid.tsx:165` finding.
- `bun run test:frontend` — 2,433 passed and 4 unrelated source-string tests failed because their expectations are sensitive to CRLF line endings in unmodified files.

## Risks / Rollout
- Low risk and display-only: no database, API, permission, configuration, or dependency changes.
- Editable numeric inputs retain `useGrouping: false`, so entry behavior is unchanged.

## Issues
Issue: Not linked
