### PR TITLE
sales(ui): add variant section header

### DIFF
--- a/components/sales/ClientQuotesView.tsx
+++ b/components/sales/ClientQuotesView.tsx
@@ -110,7 +110,7 @@ import CostSummaryPanel from '../shared/CostSummaryPanel';
 import DateField from '../shared/DateField';
 import DeleteConfirmModal from '../shared/DeleteConfirmModal';
 import DurationUnitSelector from '../shared/DurationUnitSelector';
-import FieldTooltip from '../shared/FieldTooltip';
+import FieldTooltip, { type FieldTooltipProps } from '../shared/FieldTooltip';
 import HeaderAddButton from '../shared/HeaderAddButton';
 import {
   LINE_ITEM_NOTE_CELL_CLASSNAME,
@@ -2339,6 +2339,8 @@ const ClientQuoteCandidatesBar: React.FC<{ controller: ClientQuotesController }>
     editingQuote,
     isReadOnly,
     errors,
+    readOnlyStatus,
+    statusLabel,
   } = controller;
   const [renamingCandidateId, setRenamingCandidateId] = useState<string | null>(null);
   const [renameDraft, setRenameDraft] = useState('');
@@ -2362,7 +2364,17 @@ const ClientQuoteCandidatesBar: React.FC<{ controller: ClientQuotesController }>
   };
 
   return (
-    <div className="space-y-1">
+    <div className="space-y-2">
+      <ClientQuoteSectionHeading
+        label={t('sales:clientQuotes.candidates.column', { defaultValue: 'Varianti' })}
+        description={t('sales:fieldInfo.variants', {
+          defaultValue:
+            'Configure alternatives for the same quote: each variant keeps its own items, prices, discounts, and terms.',
+        })}
+        status={readOnlyStatus}
+        statusLabel={statusLabel}
+        tooltipIcon="info"
+      />
       <div
         data-testid="quote-candidate-tabs-scroll"
         className="overflow-x-auto overflow-y-hidden border-b border-border pt-1"
@@ -2781,12 +2793,18 @@ const ClientQuoteSectionHeading: React.FC<{
   description?: string;
   status?: string;
   statusLabel?: string;
-}> = ({ label, description, status, statusLabel }) => (
+  tooltipIcon?: FieldTooltipProps['icon'];
+}> = ({ label, description, status, statusLabel, tooltipIcon }) => (
   <h4 className="flex items-center gap-2 text-xs font-semibold uppercase tracking-widest text-primary">
     <span className="size-1.5 rounded-full bg-primary"></span>
     {label}
     {description && status && statusLabel && (
-      <FieldTooltip description={description} status={status} statusLabel={statusLabel} />
+      <FieldTooltip
+        description={description}
+        status={status}
+        statusLabel={statusLabel}
+        icon={tooltipIcon}
+      />
     )}
   </h4>
 );

--- a/locales/en/sales.json
+++ b/locales/en/sales.json
@@ -10,6 +10,7 @@
     "mol": "Margin overhead loading percentage",
     "notes": "Additional notes for the entire document",
     "clientInformation": "Client and document details",
+    "variants": "Configure alternatives for the same quote: each variant keeps its own items, prices, discounts, and terms.",
     "productsServices": "Products and services for this quote",
     "items": "Line items for this offer",
     "supplierInformation": "Supplier and document details",

--- a/locales/it/sales.json
+++ b/locales/it/sales.json
@@ -10,6 +10,7 @@
     "mol": "Percentuale margine e oneri",
     "notes": "Note aggiuntive per l'intero documento",
     "clientInformation": "Dettagli cliente e documento",
+    "variants": "Configura alternative dello stesso preventivo: ogni variante mantiene voci, prezzi, sconti e condizioni proprie.",
     "productsServices": "Prodotti e servizi per questo preventivo",
     "items": "Voci per questa offerta",
     "supplierInformation": "Dettagli fornitore e documento",

--- a/test/components/sales/ClientQuotesView.test.tsx
+++ b/test/components/sales/ClientQuotesView.test.tsx
@@ -1617,8 +1617,10 @@ describe('<ClientQuotesView /> line-item delete confirmation', () => {
     });
     expect(rowDeleteButtons(dialog)).toHaveLength(rowDeletes.length);
   });
+});
 
-  test('chooses the first unused default variant name after renames', async () => {
+describe('<ClientQuotesView /> candidate variants', () => {
+  const openCreateQuote = async () => {
     const user = userEvent.setup();
     render(
       <ClientQuotesView
@@ -1635,6 +1637,12 @@ describe('<ClientQuotesView /> line-item delete confirmation', () => {
     );
 
     await user.click(screen.getByRole('button', { name: 'sales:clientQuotes.createNewQuote' }));
+    return user;
+  };
+
+  test('chooses the first unused default variant name after renames', async () => {
+    const user = await openCreateQuote();
+
     await user.click(screen.getByRole('button', { name: 'sales:clientQuotes.candidates.addMenu' }));
     await user.click(
       await screen.findByRole('menuitem', { name: 'sales:clientQuotes.candidates.add' }),
@@ -1654,23 +1662,22 @@ describe('<ClientQuotesView /> line-item delete confirmation', () => {
     expect(screen.getByRole('tab', { name: /Variante C/ })).toBeInTheDocument();
   });
 
-  test('keeps validation errors visible when renaming the active candidate', async () => {
-    const user = userEvent.setup();
-    render(
-      <ClientQuotesView
-        quotes={[]}
-        clients={clients}
-        products={[]}
-        supplierQuotes={[]}
-        communicationChannels={communicationChannels}
-        currency="EUR"
-        onAddQuote={mock(() => Promise.resolve())}
-        onUpdateQuote={mock(() => Promise.resolve())}
-        onDeleteQuote={mock(() => Promise.resolve())}
-      />,
-    );
+  test('shows the variants section heading and information tooltip above the tabs', async () => {
+    await openCreateQuote();
 
-    await user.click(screen.getByRole('button', { name: 'sales:clientQuotes.createNewQuote' }));
+    const heading = screen.getByRole('heading', {
+      name: /sales:clientQuotes.candidates.column/,
+    });
+    const tabs = screen.getByTestId('quote-candidate-tabs-scroll');
+    const tooltip = screen.getByRole('button', { name: 'sales:fieldInfo.variants' });
+
+    expect(heading.nextElementSibling).toBe(tabs);
+    expect(tooltip.querySelector('.fa-circle-info')).toBeInTheDocument();
+  });
+
+  test('keeps validation errors visible when renaming the active candidate', async () => {
+    const user = await openCreateQuote();
+
     await user.click(screen.getByRole('button', { name: 'sales:clientQuotes.createQuote' }));
     expect(screen.getByText('sales:clientQuotes.errors.clientRequired')).toBeInTheDocument();
 
@@ -1681,22 +1688,8 @@ describe('<ClientQuotesView /> line-item delete confirmation', () => {
   });
 
   test('manages browser-style candidate tabs from inline and contextual actions', async () => {
-    const user = userEvent.setup();
-    render(
-      <ClientQuotesView
-        quotes={[]}
-        clients={clients}
-        products={[]}
-        supplierQuotes={[]}
-        communicationChannels={communicationChannels}
-        currency="EUR"
-        onAddQuote={mock(() => Promise.resolve())}
-        onUpdateQuote={mock(() => Promise.resolve())}
-        onDeleteQuote={mock(() => Promise.resolve())}
-      />,
-    );
+    const user = await openCreateQuote();
 
-    await user.click(screen.getByRole('button', { name: 'sales:clientQuotes.createNewQuote' }));
     expect(screen.getByText('Variante A')).toBeInTheDocument();
     expect(screen.getByTestId('quote-candidate-tabs-scroll')).toHaveClass(
       'overflow-x-auto',


### PR DESCRIPTION
## Summary
- Adds a `Varianti` section header above the client quote variant tabs in create, edit, and read-only flows.
- Matches the existing client information section styling and adds a localized info tooltip describing variant behavior.

## Changes
- Reuses the client quote section heading and shared `FieldTooltip` with the info icon.
- Adds Italian and English tooltip copy.
- Adds focused regression coverage for the heading position and icon, and consolidates repeated candidate-test setup.

## Testing
- `bun test test/components/sales/ClientQuotesView.test.tsx` (40 passed)
- `bun run typecheck`
- `bun run build`
- `bun run i18n:check`
- `bunx --bun biome check --formatter-enabled=false components/sales/ClientQuotesView.tsx test/components/sales/ClientQuotesView.test.tsx locales/it/sales.json locales/en/sales.json`

## Risks / Rollout
- Low-risk, presentation-only frontend change with no API, database, permission, configuration, or deployment-order impact.
- React Doctor remains at the pre-existing 80/100 score; its existing `DashboardGrid.tsx:165` diagnostic is unrelated to this change.

## Issues
Issue: Not linked
