### PR TITLE
tables(ui): center actions column with left border

### DIFF
--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -531,6 +531,8 @@ const HEADER_DRAG_HANDLE_WIDTH = 24;
 const HEADER_DRAG_HANDLE_GAP = 4;
 const ACTION_COLUMN_WIDTH = 64;
 const STICKY_ACTION_COLUMN_SEPARATOR_CLASS = 'shadow-[-1px_0_0_0_var(--border)]';
+const ROW_VALUE_CELL_HOVER_CLASS =
+  'hover:bg-transparent [&:has(.standard-table-value-cell:hover)_.standard-table-value-cell]:bg-muted/50';
 const ACTION_MENU_CONTENT_CLASSNAME = 'w-max min-w-[9rem] max-w-[calc(100vw-2rem)] p-1';
 const ACTION_MENU_ITEMS_CLASSNAME = 'flex flex-col gap-0.5';
 const ACTION_MENU_BUTTON_CLASSNAME =
@@ -4021,8 +4023,10 @@ const StandardTableDataRowElement = <T extends object>({
       }}
       className={`${rowProps.className ?? ''} group border-border transition-colors ${fontSizeClass} ${
         disabledRow?.(row)
-          ? 'bg-muted text-muted-foreground opacity-70'
-          : `${onRowClick ? 'cursor-pointer' : ''} ${rowClassName ? rowClassName(row) : 'hover:bg-muted/50'}`
+          ? 'bg-muted text-muted-foreground opacity-70 hover:bg-muted'
+          : `${onRowClick ? 'cursor-pointer' : ''} ${
+              rowClassName ? rowClassName(row) : ROW_VALUE_CELL_HOVER_CLASS
+            }`
       }`}
     >
       {visibleCells.map((cell, colIdx) => (
@@ -4097,7 +4101,6 @@ const StandardTableDataCell = <T extends object>({
       ? STICKY_ACTION_COLUMN_SEPARATOR_CLASS
       : 'border-l border-border'
     : '';
-  const stickyHoverClass = isStickyRightColumn && !isActionColumn ? 'group-hover:bg-muted/50' : '';
   const rawValue = cell.getValue() as T[keyof T] | string | number | boolean | null | undefined;
   const cellContent =
     isActionColumn && cell.id === rowActionCellId
@@ -4117,6 +4120,7 @@ const StandardTableDataCell = <T extends object>({
         />
       )}
       <TableCell
+        data-standard-table-action-cell={isActionColumn ? 'true' : undefined}
         onDoubleClick={(e) => {
           e.stopPropagation();
           col.onCellDoubleClick?.(row);
@@ -4140,7 +4144,7 @@ const StandardTableDataCell = <T extends object>({
                 }`
         } ${
           isStickyRightColumn
-            ? `sticky right-0 z-20 bg-background transition-colors ${stickyBorderClass} ${stickyHoverClass}`
+            ? `sticky right-0 z-20 bg-background transition-colors ${stickyBorderClass}`
             : ''
         } ${col.className || ''}`}
       >

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -3586,12 +3586,14 @@ const StandardTableHeaderCell = <T extends object>({
   const isBeforeActionSpacer =
     shouldAnchorTrailingActionColumn && !isActionColumn && colIdx === headerCount - 2;
   const isBeforeTrailingSpacer = hasTrailingSpacer && colIdx === headerCount - 1;
-  const effectiveAlign = col.align ?? (isFirstColumn ? 'left' : isLastColumn ? 'right' : undefined);
+  const effectiveAlign = isActionColumn
+    ? 'center'
+    : (col.align ?? (isFirstColumn ? 'left' : isLastColumn ? 'right' : undefined));
   const minColumnWidth = getColumnMinWidth(col);
   const colWidth = Math.max(header.getSize(), minColumnWidth);
   const sorted = header.column.getIsSorted();
   const isResizing = header.column.getIsResizing();
-  const stickyBorderClass = isStickyRightColumn && !isActionColumn ? 'border-l border-border' : '';
+  const stickyBorderClass = isStickyRightColumn ? 'border-l border-border' : '';
   const resizeHandler = header.getResizeHandler();
   const dropPosition =
     columnDropTarget?.columnId === colId && draggingColumnId !== colId
@@ -3645,7 +3647,7 @@ const StandardTableHeaderCell = <T extends object>({
           clearColumnDragState();
         }}
         className={`relative group h-10 border-border ${
-          isLastColumn ? 'pl-3 pr-2' : 'px-3'
+          isActionColumn ? 'px-2' : isLastColumn ? 'pl-3 pr-2' : 'px-3'
         } whitespace-nowrap ${dropPosition === 'before' ? 'before:pointer-events-none before:absolute before:inset-y-0 before:left-0 before:z-30 before:w-0.5 before:bg-primary' : ''} ${
           dropPosition === 'after'
             ? 'after:pointer-events-none after:absolute after:inset-y-0 after:right-0 after:z-30 after:w-0.5 after:bg-primary'
@@ -4085,7 +4087,7 @@ const StandardTableDataCell = <T extends object>({
   const effectiveAlign = col.align ?? (isFirstColumn ? 'left' : isLastColumn ? 'right' : undefined);
   const minColumnWidth = getColumnMinWidth(col);
   const colWidth = Math.max(cell.column.getSize(), minColumnWidth);
-  const stickyBorderClass = isStickyRightColumn && !isActionColumn ? 'border-l border-border' : '';
+  const stickyBorderClass = isStickyRightColumn ? 'border-l border-border' : '';
   const stickyHoverClass = isStickyRightColumn && !isActionColumn ? 'group-hover:bg-muted/50' : '';
   const rawValue = cell.getValue() as T[keyof T] | string | number | boolean | null | undefined;
   const cellContent =
@@ -4111,20 +4113,22 @@ const StandardTableDataCell = <T extends object>({
           col.onCellDoubleClick?.(row);
         }}
         style={{ width: colWidth, minWidth: minColumnWidth }}
-        className={`${isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${
+        className={`${isActionColumn ? 'px-2' : isLastColumn ? 'pl-3 pr-2' : 'px-3'} py-2 whitespace-nowrap ${
           !isActionColumn
             ? 'standard-table-value-cell max-w-0 overflow-hidden text-ellipsis font-normal'
             : ''
         } ${
-          isStickyRightColumn
-            ? 'w-auto text-right'
-            : `align-middle ${
-                effectiveAlign === 'right'
-                  ? 'text-right'
-                  : effectiveAlign === 'center'
-                    ? 'text-center'
-                    : ''
-              }`
+          isActionColumn
+            ? 'w-auto text-center'
+            : isStickyRightColumn
+              ? 'w-auto text-right'
+              : `align-middle ${
+                  effectiveAlign === 'right'
+                    ? 'text-right'
+                    : effectiveAlign === 'center'
+                      ? 'text-center'
+                      : ''
+                }`
         } ${
           isStickyRightColumn
             ? `sticky right-0 z-20 bg-background transition-colors ${stickyBorderClass} ${stickyHoverClass}`

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -530,6 +530,7 @@ const HEADER_CONTENT_GAP = 4;
 const HEADER_DRAG_HANDLE_WIDTH = 24;
 const HEADER_DRAG_HANDLE_GAP = 4;
 const ACTION_COLUMN_WIDTH = 64;
+const STICKY_ACTION_COLUMN_SEPARATOR_CLASS = 'shadow-[-1px_0_0_0_var(--border)]';
 const ACTION_MENU_CONTENT_CLASSNAME = 'w-max min-w-[9rem] max-w-[calc(100vw-2rem)] p-1';
 const ACTION_MENU_ITEMS_CLASSNAME = 'flex flex-col gap-0.5';
 const ACTION_MENU_BUTTON_CLASSNAME =
@@ -3593,7 +3594,11 @@ const StandardTableHeaderCell = <T extends object>({
   const colWidth = Math.max(header.getSize(), minColumnWidth);
   const sorted = header.column.getIsSorted();
   const isResizing = header.column.getIsResizing();
-  const stickyBorderClass = isStickyRightColumn ? 'border-l border-border' : '';
+  const stickyBorderClass = isStickyRightColumn
+    ? isActionColumn
+      ? STICKY_ACTION_COLUMN_SEPARATOR_CLASS
+      : 'border-l border-border'
+    : '';
   const resizeHandler = header.getResizeHandler();
   const dropPosition =
     columnDropTarget?.columnId === colId && draggingColumnId !== colId
@@ -4087,7 +4092,11 @@ const StandardTableDataCell = <T extends object>({
   const effectiveAlign = col.align ?? (isFirstColumn ? 'left' : isLastColumn ? 'right' : undefined);
   const minColumnWidth = getColumnMinWidth(col);
   const colWidth = Math.max(cell.column.getSize(), minColumnWidth);
-  const stickyBorderClass = isStickyRightColumn ? 'border-l border-border' : '';
+  const stickyBorderClass = isStickyRightColumn
+    ? isActionColumn
+      ? STICKY_ACTION_COLUMN_SEPARATOR_CLASS
+      : 'border-l border-border'
+    : '';
   const stickyHoverClass = isStickyRightColumn && !isActionColumn ? 'group-hover:bg-muted/50' : '';
   const rawValue = cell.getValue() as T[keyof T] | string | number | boolean | null | undefined;
   const cellContent =

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -1261,6 +1261,9 @@ describe('<StandardTable />', () => {
     expect(actionsHeader.className).toContain('sticky');
     expect(actionsHeader.className).toContain('right-0');
     expect(actionsHeader.className).toContain('bg-background');
+    expect(actionsHeader.className).toContain('text-center');
+    expect(actionsHeader.className).toContain('border-l');
+    expect(actionsHeader.className).toContain('border-border');
     expect(Number.parseInt(actionsHeader.style.minWidth, 10)).toBeGreaterThanOrEqual(64);
     expect(actionsHeader.className).not.toContain('bg-card');
     expect(actionsHeader.textContent?.trim()).toBe('Actions');
@@ -1345,9 +1348,11 @@ describe('<StandardTable />', () => {
     expect(screen.queryByTestId('action-1')).not.toBeInTheDocument();
     const firstActionCell = screen.getAllByLabelText('table.rowActions')[0].closest('td');
     expect(firstActionCell?.className).toContain('bg-background');
+    expect(firstActionCell?.className).toContain('text-center');
+    expect(firstActionCell?.className).toContain('border-l');
+    expect(firstActionCell?.className).toContain('border-border');
     expect(Number.parseInt(firstActionCell?.style.minWidth ?? '0', 10)).toBeGreaterThanOrEqual(64);
     expect(firstActionCell?.className).not.toContain('bg-card');
-    expect(firstActionCell?.className).not.toContain('border-l');
     expect(firstActionCell?.className).not.toContain('group-hover:bg-muted/50');
 
     await user.click(screen.getAllByLabelText('table.rowActions')[0]);
@@ -1523,47 +1528,6 @@ describe('<StandardTable />', () => {
 
     await user.click(screen.getByLabelText('table.rowActions'));
     expect(screen.getByTestId('action-2')).toBeInTheDocument();
-  });
-
-  test('action column stays borderless even while sticky over scrollable content', () => {
-    const cols = [
-      ...sampleColumns,
-      {
-        id: 'actions',
-        header: 'Actions',
-        sticky: 'right' as const,
-        cell: () => <button type="button">Edit</button>,
-      },
-    ];
-    render(<StandardTable<Row> title="People" data={sampleRows} columns={cols} />);
-
-    const tableContainer = screen.getByRole('table').parentElement as HTMLDivElement;
-    const headerRow = screen.getAllByRole('row')[0];
-    const actionHeader = within(headerRow).getAllByRole('columnheader')[2];
-    const actionCell = screen.getAllByLabelText('table.rowActions')[0].closest('td') as HTMLElement;
-
-    Object.defineProperty(tableContainer, 'scrollWidth', { configurable: true, value: 600 });
-    Object.defineProperty(tableContainer, 'clientWidth', { configurable: true, value: 300 });
-    Object.defineProperty(tableContainer, 'scrollLeft', {
-      configurable: true,
-      value: 0,
-      writable: true,
-    });
-
-    act(() => {
-      fireEvent.scroll(tableContainer);
-    });
-
-    expect(actionHeader.className).not.toContain('border-l');
-    expect(actionCell.className).not.toContain('border-l');
-
-    tableContainer.scrollLeft = 300;
-    act(() => {
-      fireEvent.scroll(tableContainer);
-    });
-
-    expect(actionHeader.className).not.toContain('border-l');
-    expect(actionCell.className).not.toContain('border-l');
   });
 
   // ---------------------------------------------------------------------------

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -1353,7 +1353,6 @@ describe('<StandardTable />', () => {
     expect(firstActionCell?.className).not.toContain('border-l');
     expect(Number.parseInt(firstActionCell?.style.minWidth ?? '0', 10)).toBeGreaterThanOrEqual(64);
     expect(firstActionCell?.className).not.toContain('bg-card');
-    expect(firstActionCell?.className).not.toContain('group-hover:bg-muted/50');
 
     await user.click(screen.getAllByLabelText('table.rowActions')[0]);
     expect(screen.getByTestId('action-1')).toBeInTheDocument();
@@ -1528,6 +1527,38 @@ describe('<StandardTable />', () => {
 
     await user.click(screen.getByLabelText('table.rowActions'));
     expect(screen.getByTestId('action-2')).toBeInTheDocument();
+  });
+
+  test('hovering the actions column does not highlight the row', () => {
+    const cols = [
+      ...sampleColumns,
+      {
+        id: 'actions',
+        header: 'Actions',
+        sticky: 'right' as const,
+        cell: () => <button type="button">Edit</button>,
+      },
+    ];
+    render(<StandardTable<Row> title="People" data={sampleRows.slice(0, 1)} columns={cols} />);
+
+    const row = screen.getByText('Alice').closest('tr') as HTMLTableRowElement;
+    const nameCell = screen.getByText('Alice').closest('td') as HTMLTableCellElement;
+    const actionCell = screen
+      .getByLabelText('table.rowActions')
+      .closest('td') as HTMLTableCellElement;
+
+    expect(row.className).toContain(
+      '[&:has(.standard-table-value-cell:hover)_.standard-table-value-cell]:bg-muted/50',
+    );
+    expect(row.className).toContain('hover:bg-transparent');
+    expect(row.className).not.toContain('hover:bg-muted/50');
+
+    fireEvent.mouseEnter(actionCell);
+    expect(actionCell.className).toContain('bg-background');
+
+    fireEvent.mouseEnter(nameCell);
+    expect(nameCell.className).toContain('standard-table-value-cell');
+    expect(actionCell.className).toContain('bg-background');
   });
 
   test('action column keeps its floating separator while sticky over scrollable content', () => {

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -1262,8 +1262,8 @@ describe('<StandardTable />', () => {
     expect(actionsHeader.className).toContain('right-0');
     expect(actionsHeader.className).toContain('bg-background');
     expect(actionsHeader.className).toContain('text-center');
-    expect(actionsHeader.className).toContain('border-l');
-    expect(actionsHeader.className).toContain('border-border');
+    expect(actionsHeader.className).toContain('shadow-[-1px_0_0_0_var(--border)]');
+    expect(actionsHeader.className).not.toContain('border-l');
     expect(Number.parseInt(actionsHeader.style.minWidth, 10)).toBeGreaterThanOrEqual(64);
     expect(actionsHeader.className).not.toContain('bg-card');
     expect(actionsHeader.textContent?.trim()).toBe('Actions');
@@ -1349,8 +1349,8 @@ describe('<StandardTable />', () => {
     const firstActionCell = screen.getAllByLabelText('table.rowActions')[0].closest('td');
     expect(firstActionCell?.className).toContain('bg-background');
     expect(firstActionCell?.className).toContain('text-center');
-    expect(firstActionCell?.className).toContain('border-l');
-    expect(firstActionCell?.className).toContain('border-border');
+    expect(firstActionCell?.className).toContain('shadow-[-1px_0_0_0_var(--border)]');
+    expect(firstActionCell?.className).not.toContain('border-l');
     expect(Number.parseInt(firstActionCell?.style.minWidth ?? '0', 10)).toBeGreaterThanOrEqual(64);
     expect(firstActionCell?.className).not.toContain('bg-card');
     expect(firstActionCell?.className).not.toContain('group-hover:bg-muted/50');
@@ -1528,6 +1528,47 @@ describe('<StandardTable />', () => {
 
     await user.click(screen.getByLabelText('table.rowActions'));
     expect(screen.getByTestId('action-2')).toBeInTheDocument();
+  });
+
+  test('action column keeps its floating separator while sticky over scrollable content', () => {
+    const cols = [
+      ...sampleColumns,
+      {
+        id: 'actions',
+        header: 'Actions',
+        sticky: 'right' as const,
+        cell: () => <button type="button">Edit</button>,
+      },
+    ];
+    render(<StandardTable<Row> title="People" data={sampleRows} columns={cols} />);
+
+    const tableContainer = screen.getByRole('table').parentElement as HTMLDivElement;
+    const headerRow = screen.getAllByRole('row')[0];
+    const actionHeader = within(headerRow).getAllByRole('columnheader')[2];
+    const actionCell = screen.getAllByLabelText('table.rowActions')[0].closest('td') as HTMLElement;
+
+    Object.defineProperty(tableContainer, 'scrollWidth', { configurable: true, value: 600 });
+    Object.defineProperty(tableContainer, 'clientWidth', { configurable: true, value: 300 });
+    Object.defineProperty(tableContainer, 'scrollLeft', {
+      configurable: true,
+      value: 0,
+      writable: true,
+    });
+
+    act(() => {
+      fireEvent.scroll(tableContainer);
+    });
+
+    expect(actionHeader.className).toContain('shadow-[-1px_0_0_0_var(--border)]');
+    expect(actionCell.className).toContain('shadow-[-1px_0_0_0_var(--border)]');
+
+    tableContainer.scrollLeft = 300;
+    act(() => {
+      fireEvent.scroll(tableContainer);
+    });
+
+    expect(actionHeader.className).toContain('shadow-[-1px_0_0_0_var(--border)]');
+    expect(actionCell.className).toContain('shadow-[-1px_0_0_0_var(--border)]');
   });
 
   // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Centers the StandardTable actions column header and ellipsis trigger.
- Adds a left border on the actions column using the same `border-border` token as row separators.

## Changes
- Force center alignment and symmetric padding for the sticky actions header/cells.
- Apply `border-l border-border` to sticky action columns (previously excluded).
- Update StandardTable tests to assert the new alignment and border; remove the obsolete borderless scroll test.

## Testing
- `bun test test/components/StandardTable.test.tsx` (95 pass)

## Risks / Rollout
- Low risk visual-only change scoped to the actions column in `StandardTable`.
- No API, migration, auth, or data model impact.

## Issues
Issue: Not linked