### PR TITLE
sales(ui): extend linked record header action to supplier documents

### DIFF
--- a/components/accounting/SupplierOrdersView.tsx
+++ b/components/accounting/SupplierOrdersView.tsx
@@ -1,7 +1,7 @@
 import type React from 'react';
 import { useCallback, useMemo, useReducer } from 'react';
 import { useTranslation } from 'react-i18next';
-import { LinkedRecordBanner } from '@/components/shared/LinkedRecordBanner';
+import { LinkedRecordHeaderButton } from '@/components/shared/LinkedRecordHeaderButton';
 import { Button } from '@/components/ui/button';
 import { Field, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
@@ -849,7 +849,22 @@ const SupplierOrderModal: React.FC<{ controller: SupplierOrdersController }> = (
                 </ModalReadOnlyStatusBanner>
               ) : null}
             </ModalTitle>
-            <ModalCloseButton onClick={controller.closeEditModal} />
+            <div className="flex shrink-0 items-center gap-2">
+              {controller.formData.linkedQuoteId && controller.onViewQuote ? (
+                <LinkedRecordHeaderButton
+                  label={controller.t('accounting:supplierOrders.viewLinkedQuote', {
+                    defaultValue: 'View linked quote',
+                  })}
+                  onClick={() => {
+                    const linkedQuoteId = controller.formData.linkedQuoteId;
+                    if (linkedQuoteId && controller.onViewQuote) {
+                      controller.onViewQuote(linkedQuoteId);
+                    }
+                  }}
+                />
+              ) : null}
+              <ModalCloseButton onClick={controller.closeEditModal} />
+            </div>
           </div>
         </ModalHeader>
         <ModalBody className="flex-1 space-y-5">
@@ -866,7 +881,6 @@ const SupplierOrderModal: React.FC<{ controller: SupplierOrdersController }> = (
               />
             </div>
           ) : null}
-          <SupplierOrderModalAlerts controller={controller} />
           <SupplierOrderDetailsSection controller={controller} />
           <SupplierOrderItemsSection controller={controller} />
           <SupplierOrderNotesSummarySection controller={controller} />
@@ -889,39 +903,6 @@ const SupplierOrderSectionTitle: React.FC<{ children: React.ReactNode }> = ({ ch
     <span className="size-1.5 rounded-full bg-primary"></span>
     {children}
   </h4>
-);
-
-const SupplierOrderModalAlerts: React.FC<{ controller: SupplierOrdersController }> = ({
-  controller,
-}) => (
-  <>
-    {controller.formData.linkedQuoteId && (
-      <LinkedRecordBanner
-        label={controller.t('accounting:supplierOrders.linkedQuote')}
-        value={controller.t('accounting:supplierOrders.linkedQuoteInfo', {
-          number: formatDocumentCode(
-            controller.formData.linkedQuoteId,
-            controller.formData.linkedQuoteRevisionCode ??
-              controller.quotes.find((quote) => quote.id === controller.formData.linkedQuoteId)
-                ?.revisionCode,
-          ),
-        })}
-        note={controller.t('accounting:supplierOrders.quoteDetailsReadOnly')}
-        action={
-          controller.onViewQuote
-            ? {
-                label: controller.t('accounting:supplierOrders.viewQuote'),
-                onClick: () => {
-                  const linkedQuoteId = controller.formData.linkedQuoteId;
-                  if (!linkedQuoteId) return;
-                  controller.onViewQuote?.(linkedQuoteId);
-                },
-              }
-            : undefined
-        }
-      />
-    )}
-  </>
 );
 
 const SupplierOrderDetailsSection: React.FC<{ controller: SupplierOrdersController }> = ({

--- a/components/sales/SupplierQuotesView.tsx
+++ b/components/sales/SupplierQuotesView.tsx
@@ -1,7 +1,7 @@
 import type React from 'react';
 import { useCallback, useMemo, useReducer, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { LinkedRecordBanner } from '@/components/shared/LinkedRecordBanner';
+import { LinkedRecordHeaderButton } from '@/components/shared/LinkedRecordHeaderButton';
 import { Button } from '@/components/ui/button';
 import { Field, FieldDescription, FieldError, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
@@ -1379,7 +1379,6 @@ const SupplierQuoteModal: React.FC<{ controller: SupplierQuotesController }> = (
             ) : (
               <SupplierQuoteDetailsSection controller={controller} />
             )}
-            <SupplierQuoteModalAlerts controller={controller} />
             <SupplierQuoteItemsSection controller={controller} />
             <SupplierQuoteAttachmentsArea controller={controller} />
             <SupplierQuoteNotesSummarySection controller={controller} />
@@ -1440,45 +1439,25 @@ const SupplierQuoteModalHeader: React.FC<{ controller: SupplierQuotesController 
           <ModalReadOnlyStatusBanner>{controller.readOnlyReason}</ModalReadOnlyStatusBanner>
         ) : null}
       </ModalTitle>
-      <ModalCloseButton onClick={controller.closeModal} />
+      <div className="flex shrink-0 items-center gap-2">
+        {controller.editingQuote?.linkedOrderId && controller.onViewOrders ? (
+          <LinkedRecordHeaderButton
+            label={controller.t('sales:supplierQuotes.viewLinkedOrder', {
+              defaultValue: 'View linked order',
+            })}
+            onClick={() => {
+              const quoteId = controller.editingQuote?.id;
+              if (quoteId && controller.onViewOrders) {
+                controller.onViewOrders(quoteId);
+              }
+            }}
+          />
+        ) : null}
+        <ModalCloseButton onClick={controller.closeModal} />
+      </div>
     </div>
   </ModalHeader>
 );
-
-const SupplierQuoteModalAlerts: React.FC<{ controller: SupplierQuotesController }> = ({
-  controller,
-}) => {
-  const editingQuote = controller.editingQuote;
-
-  return (
-    <>
-      {editingQuote?.linkedOrderId && (
-        <LinkedRecordBanner
-          label={controller.t('sales:supplierQuotes.linkedOrderTitle', {
-            defaultValue: 'Linked Order',
-          })}
-          value={controller.t('sales:supplierQuotes.linkedOrderInfo', {
-            number: editingQuote.linkedOrderId,
-            defaultValue: 'Order #{{number}}',
-          })}
-          note={controller.t('sales:supplierQuotes.orderDetailsReadOnly', {
-            defaultValue: '(Quote details are read-only)',
-          })}
-          action={
-            controller.onViewOrders
-              ? {
-                  label: controller.t('sales:supplierQuotes.viewOrder', {
-                    defaultValue: 'View Order',
-                  }),
-                  onClick: () => controller.onViewOrders?.(editingQuote.id),
-                }
-              : undefined
-          }
-        />
-      )}
-    </>
-  );
-};
 
 const SupplierQuoteSectionTitle: React.FC<{
   children: React.ReactNode;

--- a/locales/en/accounting.json
+++ b/locales/en/accounting.json
@@ -172,6 +172,7 @@
     "linkedQuoteInfo": "This order was created from quote #{{number}}",
     "quoteDetailsReadOnly": "(Quote details are read-only)",
     "viewQuote": "View Quote",
+    "viewLinkedQuote": "View linked quote",
     "noItemsAdded": "No items added yet",
     "orderDetails": "Order Details",
     "items": "Items",

--- a/locales/en/sales.json
+++ b/locales/en/sales.json
@@ -417,6 +417,7 @@
     "linkedOrderInfo": "Order #{{number}}",
     "orderDetailsReadOnly": "(Quote details are read-only)",
     "viewOrder": "View Order",
+    "viewLinkedOrder": "View linked order",
     "supplierInformation": "Supplier Information",
     "supplier": "Supplier",
     "selectSupplier": "Select supplier",

--- a/locales/it/accounting.json
+++ b/locales/it/accounting.json
@@ -172,6 +172,7 @@
     "linkedQuoteInfo": "Questo ordine è stato creato dal preventivo #{{number}}",
     "quoteDetailsReadOnly": "(I dettagli del preventivo sono in sola lettura)",
     "viewQuote": "Visualizza Preventivo",
+    "viewLinkedQuote": "Vedi preventivo collegato",
     "noItemsAdded": "Nessun articolo aggiunto",
     "orderDetails": "Dettagli Ordine",
     "items": "Articoli",

--- a/locales/it/sales.json
+++ b/locales/it/sales.json
@@ -417,6 +417,7 @@
     "linkedOrderInfo": "Ordine #{{number}}",
     "orderDetailsReadOnly": "(I dettagli del preventivo sono in sola lettura)",
     "viewOrder": "Visualizza Ordine",
+    "viewLinkedOrder": "Vedi ordine collegato",
     "supplierInformation": "Informazioni Fornitore",
     "supplier": "Fornitore",
     "selectSupplier": "Seleziona fornitore",

--- a/test/components/SupplierQuotesView.test.tsx
+++ b/test/components/SupplierQuotesView.test.tsx
@@ -275,14 +275,20 @@ describe('<SupplierQuotesView /> read-only gating', () => {
     expect(screen.getByText('sales:supplierQuotes.readOnlyStatus')).toBeInTheDocument();
   });
 
-  test('clicking an accepted row with a linked order shows the linked-order banner', async () => {
-    render(<SupplierQuotesView {...baseProps} />);
+  test('clicking an accepted row with a linked order shows the linked-order header action', async () => {
+    const onViewOrders = mock(() => {});
+    render(<SupplierQuotesView {...baseProps} onViewOrders={onViewOrders} />);
     await openQuote('SQ-ACCEPTED-ORDER');
     expect(screen.getByText('sales:supplierQuotes.viewQuote')).toBeInTheDocument();
     expect(screen.queryByText('common:buttons.update')).not.toBeInTheDocument();
     // Linked-order copy wins over the generic non-draft copy.
     expect(screen.getByText('sales:supplierQuotes.readOnlyLinked')).toBeInTheDocument();
     expect(screen.queryByText('sales:supplierQuotes.readOnlyStatus')).not.toBeInTheDocument();
+    expect(screen.queryByText('sales:supplierQuotes.linkedOrderTitle')).not.toBeInTheDocument();
+    const viewButton = screen.getByRole('button', { name: 'sales:supplierQuotes.viewLinkedOrder' });
+    expect(viewButton.getAttribute('data-variant')).toBe('outline');
+    fireEvent.click(viewButton);
+    expect(onViewOrders).toHaveBeenCalledWith('SQ-ACCEPTED-ORDER');
   });
 });
 

--- a/test/components/accounting/SupplierOrdersView.test.tsx
+++ b/test/components/accounting/SupplierOrdersView.test.tsx
@@ -202,6 +202,39 @@ describe('<SupplierOrdersView /> supplier-quote column', () => {
   });
 });
 
+describe('<SupplierOrdersView /> linked quote header action', () => {
+  test('shows a header view-linked-quote action when the order has a linked supplier quote', async () => {
+    const onViewQuote = mock(() => {});
+    render(
+      <SupplierOrdersView
+        orders={[baseOrder]}
+        suppliers={suppliers}
+        products={[]}
+        orderIdsWithInvoices={new Set<string>()}
+        onUpdateOrder={mock(() => Promise.resolve())}
+        onDeleteOrder={mock(() => Promise.resolve())}
+        onViewQuote={onViewQuote}
+        currency="EUR"
+      />,
+    );
+
+    await act(async () => {
+      fireEvent.click(screen.getByText('dm_ss_01'));
+      await Promise.resolve();
+    });
+
+    const dialog = await screen.findByRole('dialog');
+    expect(within(dialog).queryByText('accounting:supplierOrders.linkedQuoteInfo')).toBeNull();
+    const viewButton = within(dialog).getByRole('button', {
+      name: 'accounting:supplierOrders.viewLinkedQuote',
+    });
+    expect(viewButton.getAttribute('data-variant')).toBe('outline');
+
+    fireEvent.click(viewButton);
+    expect(onViewQuote).toHaveBeenCalledWith('dm_sq_11');
+  });
+});
+
 describe('<SupplierOrdersView /> item pricing columns', () => {
   test('matches the supplier-quote pricing chain and keeps duration visible', async () => {
     renderView([


### PR DESCRIPTION
## Summary
- Completes the linked-record header navigation work merged in #1007 for the supplier side.
- Moves linked-order and linked-quote actions from body banners into modal headers for supplier quotes and supplier orders.

## Changes
- **Supplier quotes:** header button **Vedi ordine collegato** replaces the linked-order banner.
- **Supplier orders:** header button **Vedi preventivo collegato** replaces the linked-quote banner.
- Adds i18n keys `sales:supplierQuotes.viewLinkedOrder` and `accounting:supplierOrders.viewLinkedQuote`.
- Adds focused tests for both supplier modals.

## Testing
- `bun test test/components/SupplierQuotesView.test.tsx test/components/accounting/SupplierOrdersView.test.tsx`

## Risks / Rollout
- Low risk UI-only change on top of #1007. Navigation callbacks unchanged.

## Issues
Related to #1007

Made with [Cursor](https://cursor.com)