### PR TITLE
orders(ui): place details beside version history

### DIFF
--- a/components/accounting/ClientsOrdersView.tsx
+++ b/components/accounting/ClientsOrdersView.tsx
@@ -1085,9 +1085,12 @@ const ClientsOrderModal: React.FC<{ controller: ClientsOrdersController }> = ({ 
         </ModalHeader>
         <ModalBody className="flex-1 space-y-5">
           {controller.editingOrder?.id ? (
-            <div className="flex justify-end">
+            <div className="grid items-start gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(28rem,40rem)]">
+              <div className="min-w-0 space-y-5">
+                <OrderDetailsSection controller={controller} />
+              </div>
               <OrderVersionsPanel
-                className="w-full max-w-2xl"
+                className="min-w-0 lg:justify-self-stretch"
                 orderId={controller.editingOrder.id}
                 selectedVersionId={controller.previewVersion?.id ?? null}
                 onPreview={controller.handleVersionPreview}
@@ -1096,8 +1099,9 @@ const ClientsOrderModal: React.FC<{ controller: ClientsOrdersController }> = ({ 
                 disabled={controller.isVersionRestoreLocked}
               />
             </div>
-          ) : null}
-          <OrderDetailsSection controller={controller} />
+          ) : (
+            <OrderDetailsSection controller={controller} />
+          )}
           <OrderItemsSection controller={controller} />
           <OrderNotesSummarySection controller={controller} />
         </ModalBody>
@@ -1126,7 +1130,7 @@ const OrderSectionTitle: React.FC<{ children: React.ReactNode }> = ({ children }
 const OrderDetailsSection: React.FC<{ controller: ClientsOrdersController }> = ({ controller }) => (
   <div className="space-y-2">
     <OrderSectionTitle>{controller.t('accounting:clientsOrders.orderDetails')}</OrderSectionTitle>
-    <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+    <div className="grid grid-cols-2 gap-3">
       <Field data-invalid={Boolean(controller.errors.clientId)}>
         <SelectControl
           id="client-order-client"

--- a/components/accounting/SupplierOrdersView.tsx
+++ b/components/accounting/SupplierOrdersView.tsx
@@ -869,9 +869,12 @@ const SupplierOrderModal: React.FC<{ controller: SupplierOrdersController }> = (
         </ModalHeader>
         <ModalBody className="flex-1 space-y-5">
           {controller.editingOrder?.id ? (
-            <div className="flex justify-end">
+            <div className="grid items-start gap-4 lg:grid-cols-[minmax(0,1fr)_minmax(28rem,40rem)]">
+              <div className="min-w-0 space-y-5">
+                <SupplierOrderDetailsSection controller={controller} />
+              </div>
               <SupplierOrderVersionsPanel
-                className="w-full max-w-2xl"
+                className="min-w-0 lg:justify-self-stretch"
                 orderId={controller.editingOrder.id}
                 selectedVersionId={controller.previewVersion?.id ?? null}
                 onPreview={controller.handleVersionPreview}
@@ -880,8 +883,9 @@ const SupplierOrderModal: React.FC<{ controller: SupplierOrdersController }> = (
                 disabled={controller.baseReadOnly}
               />
             </div>
-          ) : null}
-          <SupplierOrderDetailsSection controller={controller} />
+          ) : (
+            <SupplierOrderDetailsSection controller={controller} />
+          )}
           <SupplierOrderItemsSection controller={controller} />
           <SupplierOrderNotesSummarySection controller={controller} />
         </ModalBody>
@@ -912,7 +916,7 @@ const SupplierOrderDetailsSection: React.FC<{ controller: SupplierOrdersControll
     <SupplierOrderSectionTitle>
       {controller.t('accounting:supplierOrders.orderDetails')}
     </SupplierOrderSectionTitle>
-    <div className="grid grid-cols-2 gap-3 lg:grid-cols-3">
+    <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
       <Field>
         <SelectControl
           id="supplier-order-supplier"

--- a/test/components/accounting/ClientsOrdersView.test.tsx
+++ b/test/components/accounting/ClientsOrdersView.test.tsx
@@ -1113,3 +1113,20 @@ describe('<ClientsOrdersView /> paginated item validation', () => {
     expect(screen.getByText('common:validation.positiveQuantityRequired')).toBeInTheDocument();
   });
 });
+
+describe('<ClientsOrdersView /> edit modal layout', () => {
+  test('places client info beside version history with 2+2 fields then description', async () => {
+    const source = await readComponentSource('accounting/ClientsOrdersView.tsx');
+    expectSourceContainsAll(source, [
+      'lg:grid-cols-[minmax(0,1fr)_minmax(28rem,40rem)]',
+      'grid grid-cols-2 gap-3',
+      'id="client-order-description"',
+    ]);
+    // Old single-row 4-col packing and top-right-only history placement are gone.
+    expectSourceOmitsAll(source, [
+      'className="flex justify-end"',
+      'w-full max-w-2xl',
+      'lg:grid-cols-4',
+    ]);
+  });
+});

--- a/test/components/accounting/SupplierOrdersView.test.tsx
+++ b/test/components/accounting/SupplierOrdersView.test.tsx
@@ -3,6 +3,11 @@ import { act, fireEvent, screen, within } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import type { Product, Supplier, SupplierSaleOrder } from '../../../types';
 import { render } from '../../helpers/render';
+import {
+  expectSourceContainsAll,
+  expectSourceOmitsAll,
+  readComponentSource,
+} from '../modalStylingTestUtils';
 
 // Stable `t`/`i18n` references: opening the edit modal mounts SupplierOrderVersionsPanel, whose
 // `reload` puts `t` in a useCallback dep array. A fresh `t` per render would make that effect
@@ -419,5 +424,22 @@ describe('<SupplierOrdersView /> item pricing columns', () => {
         legacyDiscountRounding: false,
       }),
     );
+  });
+});
+
+describe('<SupplierOrdersView /> edit modal layout', () => {
+  test('places supplier info beside version history with compact 3-col packing', async () => {
+    const source = await readComponentSource('accounting/SupplierOrdersView.tsx');
+    expectSourceContainsAll(source, [
+      'lg:grid-cols-[minmax(0,1fr)_minmax(28rem,40rem)]',
+      'grid grid-cols-1 gap-3 sm:grid-cols-3',
+      'id="supplier-order-supplier"',
+    ]);
+    // Old single-row packing and top-right-only history placement are gone.
+    expectSourceOmitsAll(source, [
+      'className="flex justify-end"',
+      'w-full max-w-2xl',
+      'lg:grid-cols-3',
+    ]);
   });
 });


### PR DESCRIPTION
﻿## Summary
- Places client/supplier order details beside version history in the edit modal, matching offers and quotes.
- Removes the empty space caused by the old top-right-only history panel.

## Changes
- `ClientsOrderModal` and `SupplierOrderModal` use the shared two-column layout with compact field packing.
- Adds source-layout regression tests that forbid the legacy `flex justify-end` / `max-w-2xl` placement.

## Testing
- `bun test test/components/accounting/ClientsOrdersView.test.tsx --test-name-pattern "edit modal layout"`
- `bun test test/components/accounting/SupplierOrdersView.test.tsx --test-name-pattern "edit modal layout"`

## Risks / Rollout
- Low risk. Frontend-only layout change in order edit modals; no API or data changes.

## Issues
Issue: Not linked
