### PR TITLE
sales(fix): restore current history badge and auto-select

### DIFF
--- a/components/shared/VersionHistoryPanel.tsx
+++ b/components/shared/VersionHistoryPanel.tsx
@@ -27,7 +27,7 @@ interface VersionHistoryPanelLabels {
   searchPlaceholder: string;
   searchAriaLabel: string;
   noResults: string;
-  currentBadge?: string;
+  currentBadge: string;
   previewBadge: string;
   infoTooltip?: string;
 }
@@ -123,11 +123,14 @@ export function VersionHistoryPanel<Row extends VersionHistoryPanelRow>({
     closeSearch();
   };
 
-  // Live document is shown when `selectedVersionId` is null — history rows are all
-  // restorable snapshots (newest-first). Do not treat rows[0] as an unselectable "live" stand-in.
-  const radioValue = selectedVersionId ?? '';
+  const currentRowId = rows[0]?.id ?? null;
+  const radioValue = selectedVersionId ?? currentRowId ?? '';
 
   const handleRadioChange = (value: string) => {
+    if (currentRowId && value === currentRowId) {
+      if (selectedVersionId) onClearPreview();
+      return;
+    }
     const row = filteredRows.find((candidate) => candidate.id === value);
     if (row) onSelect(row);
   };
@@ -269,6 +272,7 @@ export function VersionHistoryPanel<Row extends VersionHistoryPanelRow>({
           >
             {filteredRows.map((row) => {
               const selected = row.id === selectedVersionId;
+              const isCurrent = currentRowId === row.id;
               const reasonLabel =
                 row.reason === 'restore' ? labels.reasonRestore : labels.reasonUpdate;
               const timestamp = formatInsertDateTime(row.createdAt, locale);
@@ -296,7 +300,11 @@ export function VersionHistoryPanel<Row extends VersionHistoryPanelRow>({
                       {reasonLabel || optionLabel}
                       {row.createdByUserName ? ` · ${row.createdByUserName}` : ''}
                     </span>
-                    {selected ? (
+                    {isCurrent ? (
+                      <span className="rounded-full bg-emerald-500/15 px-1.5 py-0.5 text-[9px] font-bold tracking-wider text-emerald-700 uppercase dark:text-emerald-400">
+                        {labels.currentBadge}
+                      </span>
+                    ) : selected ? (
                       <span className="rounded-full bg-amber-500/15 px-1.5 py-0.5 text-[9px] font-bold tracking-wider text-amber-700 uppercase dark:text-amber-400">
                         {labels.previewBadge}
                       </span>

--- a/test/components/OfferVersionsPanel.test.tsx
+++ b/test/components/OfferVersionsPanel.test.tsx
@@ -178,8 +178,10 @@ describe('<OfferVersionsPanel />', () => {
     );
   });
 
-  test('clicking a row fetches the full version and calls onPreview', async () => {
-    listVersionsMock.mockImplementation(() => Promise.resolve([VERSION_ROW_UPDATE]));
+  test('clicking a historical row fetches the full version and calls onPreview', async () => {
+    listVersionsMock.mockImplementation(() =>
+      Promise.resolve([VERSION_ROW_RESTORE, VERSION_ROW_UPDATE]),
+    );
     getVersionMock.mockImplementation(() => Promise.resolve(FULL_VERSION));
     const onPreview = mock(() => {});
     render(<OfferVersionsPanel {...baseProps} onPreview={onPreview} />);

--- a/test/components/OrderVersionsPanel.test.tsx
+++ b/test/components/OrderVersionsPanel.test.tsx
@@ -175,8 +175,10 @@ describe('<OrderVersionsPanel />', () => {
     );
   });
 
-  test('clicking a row fetches the full version and calls onPreview', async () => {
-    listVersionsMock.mockImplementation(() => Promise.resolve([VERSION_ROW_UPDATE]));
+  test('clicking a historical row fetches the full version and calls onPreview', async () => {
+    listVersionsMock.mockImplementation(() =>
+      Promise.resolve([VERSION_ROW_RESTORE, VERSION_ROW_UPDATE]),
+    );
     getVersionMock.mockImplementation(() => Promise.resolve(FULL_VERSION));
     const onPreview = mock(() => {});
     render(<OrderVersionsPanel {...baseProps} onPreview={onPreview} />);

--- a/test/components/QuoteVersionsPanel.test.tsx
+++ b/test/components/QuoteVersionsPanel.test.tsx
@@ -195,8 +195,10 @@ describe('<QuoteVersionsPanel />', () => {
     );
   });
 
-  test('clicking a row fetches the full version and calls onPreview', async () => {
-    listVersionsMock.mockImplementation(() => Promise.resolve([VERSION_ROW_UPDATE]));
+  test('clicking a historical row fetches the full version and calls onPreview', async () => {
+    listVersionsMock.mockImplementation(() =>
+      Promise.resolve([VERSION_ROW_RESTORE, VERSION_ROW_UPDATE]),
+    );
     getVersionMock.mockImplementation(() => Promise.resolve(FULL_VERSION));
     const onPreview = mock(() => {});
     render(<QuoteVersionsPanel {...baseProps} onPreview={onPreview} />);

--- a/test/components/SupplierOrderVersionsPanel.test.tsx
+++ b/test/components/SupplierOrderVersionsPanel.test.tsx
@@ -177,8 +177,10 @@ describe('<SupplierOrderVersionsPanel />', () => {
     );
   });
 
-  test('clicking a row fetches the full version and calls onPreview', async () => {
-    listVersionsMock.mockImplementation(() => Promise.resolve([VERSION_ROW_UPDATE]));
+  test('clicking a historical row fetches the full version and calls onPreview', async () => {
+    listVersionsMock.mockImplementation(() =>
+      Promise.resolve([VERSION_ROW_RESTORE, VERSION_ROW_UPDATE]),
+    );
     getVersionMock.mockImplementation(() => Promise.resolve(FULL_VERSION));
     const onPreview = mock(() => {});
     render(<SupplierOrderVersionsPanel {...baseProps} onPreview={onPreview} />);

--- a/test/components/VersionHistoryPanel.test.tsx
+++ b/test/components/VersionHistoryPanel.test.tsx
@@ -77,7 +77,7 @@ describe('<VersionHistoryPanel />', () => {
     expect(screen.getByRole('region', { name: labels.title })).toBeInTheDocument();
     expect(screen.getByRole('heading', { level: 4, name: labels.title })).toBeInTheDocument();
     expect(screen.getByRole('button', { name: labels.searchAriaLabel })).toBeInTheDocument();
-    expect(screen.queryByText(labels.currentBadge)).not.toBeInTheDocument();
+    expect(screen.getByText(labels.currentBadge)).toBeInTheDocument();
     expect(screen.getByText(labels.previewBadge)).toBeInTheDocument();
     expect(screen.getByRole('radio', { name: 'REV 3' })).toBeInTheDocument();
     expect(screen.getByRole('radio', { name: 'REV 2' })).toBeChecked();
@@ -103,7 +103,7 @@ describe('<VersionHistoryPanel />', () => {
     expect(screen.getAllByTestId('version-history-empty-slot')).toHaveLength(2);
   });
 
-  test('does not preselect a history row when viewing the live document', async () => {
+  test('preselects the newest history row when viewing the live document', async () => {
     const onSelect = mock(() => {});
     const onClearPreview = mock(() => {});
     render(
@@ -116,15 +116,17 @@ describe('<VersionHistoryPanel />', () => {
       />,
     );
 
-    expect(screen.getByRole('radio', { name: 'REV 3' })).not.toBeChecked();
+    expect(screen.getByRole('radio', { name: 'REV 3' })).toBeChecked();
+    expect(screen.getByText(labels.currentBadge)).toBeInTheDocument();
+    expect(screen.queryByText(labels.previewBadge)).not.toBeInTheDocument();
     expect(screen.queryByRole('button', { name: labels.backToCurrent })).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('radio', { name: 'REV 3' }));
-    expect(onSelect).toHaveBeenCalledWith(versionRows[0]);
+    expect(onSelect).not.toHaveBeenCalled();
     expect(onClearPreview).not.toHaveBeenCalled();
   });
 
-  test('selecting the newest history row previews it instead of clearing', () => {
+  test('selecting the newest history row clears preview instead of re-selecting', () => {
     const onSelect = mock(() => {});
     const onClearPreview = mock(() => {});
     render(
@@ -138,11 +140,11 @@ describe('<VersionHistoryPanel />', () => {
     );
 
     fireEvent.click(screen.getByRole('radio', { name: 'REV 3' }));
-    expect(onSelect).toHaveBeenCalledWith(versionRows[0]);
-    expect(onClearPreview).not.toHaveBeenCalled();
+    expect(onClearPreview).toHaveBeenCalled();
+    expect(onSelect).not.toHaveBeenCalled();
   });
 
-  test('shows a preview badge on the selected historical row', () => {
+  test('shows a preview badge on the selected historical row and current on newest', () => {
     render(
       <VersionHistoryPanel
         {...baseProps}
@@ -152,20 +154,14 @@ describe('<VersionHistoryPanel />', () => {
     );
 
     expect(screen.getByText(labels.previewBadge)).toBeInTheDocument();
-    expect(screen.queryByText(labels.currentBadge)).not.toBeInTheDocument();
+    expect(screen.getByText(labels.currentBadge)).toBeInTheDocument();
   });
 
-  test('shows a preview badge when the newest snapshot is selected', () => {
-    render(
-      <VersionHistoryPanel
-        {...baseProps}
-        rows={versionRows}
-        selectedVersionId={versionRows[0].id}
-      />,
-    );
+  test('shows a current badge when the newest snapshot represents the live document', () => {
+    render(<VersionHistoryPanel {...baseProps} rows={versionRows} selectedVersionId={null} />);
 
-    expect(screen.getByText(labels.previewBadge)).toBeInTheDocument();
-    expect(screen.queryByText(labels.currentBadge)).not.toBeInTheDocument();
+    expect(screen.getByText(labels.currentBadge)).toBeInTheDocument();
+    expect(screen.queryByText(labels.previewBadge)).not.toBeInTheDocument();
   });
 
   test('expands search on the header row and filters the local list', async () => {


### PR DESCRIPTION
## Summary
- Restores auto-selection of the newest revision/version row when viewing the live document.
- Brings back the green CORRENTE/Current badge on that row so revision history again shows which entry is current.

## Changes
- Updates shared `VersionHistoryPanel` so `selectedVersionId === null` selects `rows[0]`, shows the current badge, and clicking the newest row clears preview instead of opening Anteprima.
- Aligns unit tests for the panel and related quote/offer/order version panels.

## Testing
- `bun test test/components/VersionHistoryPanel.test.tsx test/components/VersionHistoryDialog.test.tsx test/components/OfferRevisionsPanel.test.tsx test/components/QuoteVersionsPanel.test.tsx test/components/OfferVersionsPanel.test.tsx test/components/OrderVersionsPanel.test.tsx test/components/SupplierOrderVersionsPanel.test.tsx` (59 pass)

## Risks / Rollout
- Low risk UI-only change in the shared history panel. Newest snapshot is again treated as the live stand-in and is not independently previewable via radio click.

## Issues
Issue: Not linked