### PR TITLE
ci(security): pin release workflow actions

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           fetch-depth: 0
 
@@ -55,17 +55,17 @@ jobs:
             --generate-notes
 
       - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push frontend image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: .
           push: true
@@ -84,7 +84,7 @@ jobs:
           cache-to: type=gha,mode=max,scope=frontend
 
       - name: Build and push backend image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         with:
           context: ./server
           push: true


### PR DESCRIPTION
## Summary
- Pins every external Action in the release workflow to a verified full commit SHA.
- Preserves the existing dispatch-version validation and tag-verified release flow that defend against command injection.

## Changes
- Pins `actions/checkout` to `v4.4.0` (`11d5960a326750d5838078e36cf38b85af677262`).
- Pins Docker Buildx, registry login, and image build/push Actions to their current exact release commits with version comments.

## Testing
- `bun run test:react-doctor` (75/100 before and after; exits 1 for 2 pre-existing errors and 96 warnings)
- Parsed `.github/workflows/create-release.yml` with PyYAML
- Verified each exact upstream release tag resolves to the pinned SHA
- Verified all five external `uses:` entries use 40-character SHAs with exact version comments
- `git diff --check`
- Three consecutive clean iterative review+simplify passes

## Risks / Rollout
- Low risk. Release behavior and permissions are unchanged; only Action references move from mutable major tags to immutable commits.
- Roll forward by updating a pin to another verified release commit if an upstream Action update is required.

## Issues
- Addresses security finding `praetor-other-github-workflow-supply-chain-adddc0ad4e`.