### PR TITLE
db(security): require explicit production password

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,8 @@ jobs:
     name: Lint, Typecheck & DB Schema Checks
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      DB_PASSWORD: ci-schema-check-not-used
     steps:
       - uses: actions/checkout@v4
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -15,6 +15,8 @@ DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=tempo
 DB_USER=tempo
+# Required unless NODE_ENV is explicitly development or test. Production and
+# unspecified runtimes fail closed instead of using a published password.
 DB_PASSWORD=tempo
 
 # JWT Secret. Generate a unique high-entropy value before first startup.

--- a/server/db/config.ts
+++ b/server/db/config.ts
@@ -16,6 +16,19 @@ const envInt = (
 };
 
 const DEFAULT_DB_PORT = 5432;
+const LOCAL_DB_PASSWORD = 'praetor';
+
+const getDbPassword = (): string => {
+  const configured = process.env.DB_PASSWORD;
+  if (configured) return configured;
+
+  const runtime = process.env.NODE_ENV?.trim().toLowerCase();
+  if (runtime === 'development' || runtime === 'test') return LOCAL_DB_PASSWORD;
+
+  throw new Error(
+    'DB_PASSWORD is required outside explicit development or test runtimes. Set NODE_ENV accordingly only for local use.',
+  );
+};
 
 export interface DbConnectionConfig {
   host: string;
@@ -30,7 +43,7 @@ export const getDbConnectionConfig = (): DbConnectionConfig => ({
   port: envInt('DB_PORT', DEFAULT_DB_PORT, { min: 1, max: 65_535 }),
   database: process.env.DB_NAME || 'praetor',
   user: process.env.DB_USER || 'praetor',
-  password: process.env.DB_PASSWORD || 'praetor',
+  password: getDbPassword(),
 });
 
 const invalidSslWarnings = new Set<string>();

--- a/server/test/db/config.test.ts
+++ b/server/test/db/config.test.ts
@@ -5,6 +5,7 @@ import { join } from 'node:path';
 import { createDbPoolConfig, getDbConnectionConfig, getDbSslConfig } from '../../db/config.ts';
 
 const DB_ENV_KEYS = [
+  'NODE_ENV',
   'DB_HOST',
   'DB_PORT',
   'DB_NAME',
@@ -26,6 +27,7 @@ beforeEach(() => {
     envSnapshot[key] = process.env[key];
     delete process.env[key];
   }
+  process.env.NODE_ENV = 'test';
 });
 
 afterEach(() => {
@@ -40,7 +42,7 @@ afterEach(() => {
 });
 
 describe('getDbConnectionConfig', () => {
-  test('defaults all credentials to "praetor" / localhost / 5432 when no env vars are set', () => {
+  test('uses local defaults in the explicit test runtime', () => {
     expect(getDbConnectionConfig()).toEqual({
       host: 'localhost',
       port: 5432,
@@ -48,6 +50,27 @@ describe('getDbConnectionConfig', () => {
       user: 'praetor',
       password: 'praetor',
     });
+  });
+
+  test('requires DB_PASSWORD in production', () => {
+    process.env.NODE_ENV = 'production';
+    expect(() => getDbConnectionConfig()).toThrow('DB_PASSWORD is required');
+  });
+
+  test('uses an explicit DB_PASSWORD in production', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.DB_PASSWORD = 'production-secret';
+    expect(getDbConnectionConfig().password).toBe('production-secret');
+  });
+
+  test('requires DB_PASSWORD when the runtime mode is unspecified', () => {
+    delete process.env.NODE_ENV;
+    expect(() => getDbConnectionConfig()).toThrow('DB_PASSWORD is required');
+  });
+
+  test('keeps the local fallback in the explicit development runtime', () => {
+    process.env.NODE_ENV = 'development';
+    expect(getDbConnectionConfig().password).toBe('praetor');
   });
 
   test('reads overrides from env vars', () => {


### PR DESCRIPTION
## Summary
- Removes the production-reachable hard-coded database password fallback reported as `praetor-secret-in-fallback-8a59d07fd5`.
- Keeps the published local password only for explicitly selected `development` and `test` runtimes.
- Makes production and unspecified runtimes fail closed when `DB_PASSWORD` is absent.

## Changes
- Centralizes database-password resolution in `server/db/config.ts` so runtime pools, migrations, and Drizzle tooling share the same policy.
- Adds regression coverage for production, unspecified, test, development, and explicitly configured production behavior.
- Documents the fail-closed requirement in `server/.env.example`.

## Testing
- `bun test ./test/db/config.test.ts ./test/db/drizzleConfig.test.ts` — 22 passed.
- `bun run test:server` — 4,583 passed, 28 skipped, 0 failed.
- `bun run typecheck` — passed.
- `bunx biome check server/db/config.ts server/test/db/config.test.ts` — passed.
- `git diff --check` — passed.
- `bun run test:react-doctor` — 75/100 before and after; same 2 pre-existing errors and 96 warnings.
- Three consecutive clean local review+simplify cycles completed.
- Full `bun run lint` reached Biome but is not usable in this Windows clone because checkout-wide CRLF conversion reports formatting errors across unchanged files; changed files pass Biome directly.

## Risks / Rollout
- Deployments that omitted `DB_PASSWORD` will now fail fast instead of trying a published credential. The developer and customer compose definitions already inject an explicit database password, so existing documented deployments remain compatible.
- No database schema or data migration is required.
- Rollback is application-only; restoring the prior image restores the old fallback behavior.

## Documentation
- Updated the backend environment example. User-facing Italian and English product documentation is unchanged because this only affects operator runtime configuration.

## Issues
Issue: Not linked