### PR TITLE
supplier-invoices(fix): derive supplier from linked order

### DIFF
--- a/server/routes/supplier-invoices.ts
+++ b/server/routes/supplier-invoices.ts
@@ -443,6 +443,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             };
         const txResult = await withDbTransaction(async (tx): Promise<CreateOutcome> => {
           let lockedSourceOrder: { id: string; linkedQuoteId: string | null } | null = null;
+          let invoiceSupplierId = supplierIdResult.value;
+          let invoiceSupplierName = supplierNameResult.value;
           let versionedItems = normalizedItems;
           // Lock the linked supplier order so a concurrent supplier-order restore
           // (which gates on "no linked invoice exists") serializes against this insert.
@@ -473,6 +475,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
               };
             }
             lockedSourceOrder = lockedOrder;
+            invoiceSupplierId = lockedOrder.supplierId;
+            invoiceSupplierName = lockedOrder.supplierName;
             const sourceOrderItems = await supplierOrdersRepo.findItemsForOrder(
               linkedSaleIdResult.value,
               tx,
@@ -506,8 +510,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             {
               id: invoiceId,
               linkedSaleId: linkedSaleIdResult.value || null,
-              supplierId: supplierIdResult.value,
-              supplierName: supplierNameResult.value,
+              supplierId: invoiceSupplierId,
+              supplierName: invoiceSupplierName,
               issueDate: issueDateResult.value,
               dueDate: dueDateResult.value,
               status: statusValue,

--- a/server/test/routes/supplier-invoices.test.ts
+++ b/server/test/routes/supplier-invoices.test.ts
@@ -373,7 +373,12 @@ describe('POST /api/supplier-invoices', () => {
       supplierName: 'Acme Supply',
       status: 'sent',
     });
-    lockOrderExistingByIdMock.mockResolvedValue({ id: 'SORD_26_0045_manual', status: 'sent' });
+    lockOrderExistingByIdMock.mockResolvedValue({
+      id: 'SORD_26_0045_manual',
+      supplierId: 's1',
+      supplierName: 'Acme Supply',
+      status: 'sent',
+    });
     findInvoiceForLinkedSaleMock.mockResolvedValue(null);
     createMock.mockResolvedValue({ ...SAMPLE_INVOICE, linkedSaleId: 'SORD_26_0045_manual' });
     insertItemsMock.mockResolvedValue([SAMPLE_ITEM]);
@@ -396,6 +401,42 @@ describe('POST /api/supplier-invoices', () => {
     );
   });
 
+  test('201 derives supplier identity from the locked source order', async () => {
+    const sourceOrder = {
+      id: 'SORD_26_0045_supplier',
+      linkedQuoteId: null,
+      supplierId: 's1',
+      supplierName: 'Acme Supply',
+      status: 'sent',
+    };
+    findOrderByIdMock.mockResolvedValue(sourceOrder);
+    lockOrderExistingByIdMock.mockResolvedValue(sourceOrder);
+    findInvoiceForLinkedSaleMock.mockResolvedValue(null);
+    createMock.mockResolvedValue({ ...SAMPLE_INVOICE, linkedSaleId: sourceOrder.id });
+    insertItemsMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/supplier-invoices',
+      headers: authHeader(),
+      payload: {
+        ...validBody,
+        linkedSaleId: sourceOrder.id,
+        supplierId: 's2',
+        supplierName: 'Different Supplier',
+      },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(createMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        supplierId: sourceOrder.supplierId,
+        supplierName: sourceOrder.supplierName,
+      }),
+      expect.anything(),
+    );
+  });
+
   test('201 preserves each source order pricing marker in a mixed supplier invoice', async () => {
     findOrderItemsMock.mockResolvedValue([
       { id: 'supplier-order-item-legacy', pricingSemanticsVersion: 1 },
@@ -407,7 +448,12 @@ describe('POST /api/supplier-invoices', () => {
       supplierName: 'Acme Supply',
       status: 'sent',
     });
-    lockOrderExistingByIdMock.mockResolvedValue({ id: 'SORD_26_0045_mixed', status: 'sent' });
+    lockOrderExistingByIdMock.mockResolvedValue({
+      id: 'SORD_26_0045_mixed',
+      supplierId: 's1',
+      supplierName: 'Acme Supply',
+      status: 'sent',
+    });
     findInvoiceForLinkedSaleMock.mockResolvedValue(null);
     createMock.mockResolvedValue({ ...SAMPLE_INVOICE, linkedSaleId: 'SORD_26_0045_mixed' });
     insertItemsMock.mockResolvedValue([SAMPLE_ITEM]);


### PR DESCRIPTION
## Summary
- Ensures supplier invoices linked to supplier orders persist the supplier identity from the transaction-locked source order.
- Adds regression coverage proving caller-supplied supplier fields cannot corrupt the order-to-invoice relationship.

## Changes
- Derive `supplierId` and `supplierName` from `lockExistingById` for linked invoice creation.
- Keep unlinked invoice creation behavior unchanged.
- Bring linked-order test doubles in line with the repository contract.

## Testing
- `bun test server/test/routes/supplier-invoices.test.ts` (49 pass)
- `bun run test:server` (4,608 pass, 28 skip, 0 fail)
- `bun run typecheck`
- `bun run i18n:check`
- `bunx biome check server/routes/supplier-invoices.ts server/test/routes/supplier-invoices.test.ts`
- `bun run build` (including production login smoke test)
- `bun run test:react-doctor` (75/100 before and after; unchanged pre-existing findings)
- `bun run test:frontend` was attempted twice on Bun 1.3.14 for Windows; all reported tests passed until Bun hit an internal assertion panic at approximately 9.7 GB peak memory. CI Linux is the authoritative full-frontend gate.

## Risks / Rollout
- Low risk. The change is scoped to linked supplier-invoice creation and reuses the existing transaction lock.
- No migration, configuration, API schema, status-code, or documentation changes.

## Issues
Issue: Not linked