### PR TITLE
catalog(fix): make subcategory deletion atomic

### DIFF
--- a/server/repositories/productsRepo.ts
+++ b/server/repositories/productsRepo.ts
@@ -825,6 +825,20 @@ export const deleteInternalSubcategoryByCategoryAndName = async (
   return rows[0] ?? null;
 };
 
+export const deleteInternalSubcategoryAndClearProducts = (
+  categoryId: string,
+  name: string,
+  type: string,
+  category: string,
+  exec: DbExecutor = db,
+): Promise<{ id: string } | null> =>
+  runAtomically(exec, async (tx) => {
+    const deleted = await deleteInternalSubcategoryByCategoryAndName(categoryId, name, tx);
+    if (!deleted) return null;
+    await clearProductsSubcategoryByName(name, type, category, tx);
+    return deleted;
+  });
+
 export const countProductsForSubcategory = async (
   name: string,
   type: string,

--- a/server/routes/products.ts
+++ b/server/routes/products.ts
@@ -1197,15 +1197,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         });
       }
 
-      await productsRepo.clearProductsSubcategoryByName(
+      const subDeleted = await productsRepo.deleteInternalSubcategoryAndClearProducts(
+        categoryId,
         nameResult.value,
         typeResult.value,
         categoryResult.value,
-      );
-
-      const subDeleted = await productsRepo.deleteInternalSubcategoryByCategoryAndName(
-        categoryId,
-        nameResult.value,
       );
       if (!subDeleted) {
         return replyError(request, reply, {

--- a/server/test/repositories/productsRepo.test.ts
+++ b/server/test/repositories/productsRepo.test.ts
@@ -730,6 +730,60 @@ describe('propagateSubcategoryNameToProducts / clearProductsSubcategoryByName / 
   });
 });
 
+describe('deleteInternalSubcategoryAndClearProducts', () => {
+  test('does not clear products when the subcategory does not exist', async () => {
+    exec.enqueue({ rows: [], rowCount: 0 });
+
+    expect(
+      await productsRepo.deleteInternalSubcategoryAndClearProducts(
+        'ipc-1',
+        'sub-a',
+        'good',
+        'cat-a',
+        testDb,
+      ),
+    ).toBeNull();
+    expect(exec.calls).toHaveLength(1);
+    expect(exec.calls[0].sql.toLowerCase()).toContain('delete from');
+  });
+
+  test('deletes the registry row before clearing matching products', async () => {
+    exec.enqueue({ rows: [['ips-1']], rowCount: 1 });
+    exec.enqueue({ rows: [], rowCount: 2 });
+
+    expect(
+      await productsRepo.deleteInternalSubcategoryAndClearProducts(
+        'ipc-1',
+        'sub-a',
+        'good',
+        'cat-a',
+        testDb,
+      ),
+    ).toEqual({ id: 'ips-1' });
+    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls[0].sql.toLowerCase()).toContain('delete from');
+    expect(exec.calls[1].sql.toLowerCase()).toContain('update');
+  });
+
+  test('propagates a clear failure so the transaction can roll back the delete', async () => {
+    exec.enqueue({ rows: [['ips-1']], rowCount: 1 });
+    exec.enqueue(() => {
+      throw new Error('simulated product clear failure');
+    });
+
+    await expect(
+      productsRepo.deleteInternalSubcategoryAndClearProducts(
+        'ipc-1',
+        'sub-a',
+        'good',
+        'cat-a',
+        testDb,
+      ),
+    ).rejects.toThrow(/update "products"/i);
+    expect(exec.calls).toHaveLength(2);
+  });
+});
+
 describe('countProductsForSubcategory', () => {
   test('parses count and filters by type/category/subcategory with supplier_id IS NULL', async () => {
     exec.enqueue({ rows: [['3']] });

--- a/server/test/routes/products.test.ts
+++ b/server/test/routes/products.test.ts
@@ -79,6 +79,7 @@ const updateInternalSubcategoryNameMock = mock();
 const propagateSubcategoryNameToProductsMock = mock();
 const clearProductsSubcategoryByNameMock = mock();
 const deleteInternalSubcategoryByCategoryAndNameMock = mock();
+const deleteInternalSubcategoryAndClearProductsMock = mock();
 const countProductsForSubcategoryMock = mock();
 const checkProductsLinkedToTransactionsMock = mock();
 
@@ -142,6 +143,7 @@ beforeAll(async () => {
     propagateSubcategoryNameToProducts: propagateSubcategoryNameToProductsMock,
     clearProductsSubcategoryByName: clearProductsSubcategoryByNameMock,
     deleteInternalSubcategoryByCategoryAndName: deleteInternalSubcategoryByCategoryAndNameMock,
+    deleteInternalSubcategoryAndClearProducts: deleteInternalSubcategoryAndClearProductsMock,
     countProductsForSubcategory: countProductsForSubcategoryMock,
     checkProductsLinkedToTransactions: checkProductsLinkedToTransactionsMock,
   }));
@@ -270,6 +272,7 @@ const allMocks = [
   propagateSubcategoryNameToProductsMock,
   clearProductsSubcategoryByNameMock,
   deleteInternalSubcategoryByCategoryAndNameMock,
+  deleteInternalSubcategoryAndClearProductsMock,
   countProductsForSubcategoryMock,
   checkProductsLinkedToTransactionsMock,
   findSupplierNameByIdMock,
@@ -1023,8 +1026,7 @@ describe('PUT /api/products/internal-subcategories/:name', () => {
 describe('DELETE /api/products/internal-subcategories/:name', () => {
   test('204 deletes subcategory', async () => {
     findCategoryIdByNameAndTypeMock.mockResolvedValue('ipc-1');
-    clearProductsSubcategoryByNameMock.mockResolvedValue(undefined);
-    deleteInternalSubcategoryByCategoryAndNameMock.mockResolvedValue({ id: 'ips-1' });
+    deleteInternalSubcategoryAndClearProductsMock.mockResolvedValue({ id: 'ips-1' });
 
     const res = await testApp.inject({
       method: 'DELETE',
@@ -1033,6 +1035,12 @@ describe('DELETE /api/products/internal-subcategories/:name', () => {
     });
 
     expect(res.statusCode).toBe(204);
+    expect(deleteInternalSubcategoryAndClearProductsMock).toHaveBeenCalledWith(
+      'ipc-1',
+      'Sub',
+      'goods',
+      'Electronics',
+    );
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'internal_subcategory.deleted' }),
     );
@@ -1052,8 +1060,7 @@ describe('DELETE /api/products/internal-subcategories/:name', () => {
 
   test('404 subcategory missing', async () => {
     findCategoryIdByNameAndTypeMock.mockResolvedValue('ipc-1');
-    clearProductsSubcategoryByNameMock.mockResolvedValue(undefined);
-    deleteInternalSubcategoryByCategoryAndNameMock.mockResolvedValue(null);
+    deleteInternalSubcategoryAndClearProductsMock.mockResolvedValue(null);
 
     const res = await testApp.inject({
       method: 'DELETE',
@@ -1062,6 +1069,7 @@ describe('DELETE /api/products/internal-subcategories/:name', () => {
     });
 
     expect(res.statusCode).toBe(404);
+    expect(clearProductsSubcategoryByNameMock).not.toHaveBeenCalled();
   });
 
   test('409 linked', async () => {


### PR DESCRIPTION
## Summary

- make internal product subcategory deletion and product cleanup atomic
- delete the registry row before clearing matching product references
- leave products untouched when the subcategory is already missing or concurrently deleted

## Changes

- add a repository helper that reuses the existing transaction and deletion/cleanup primitives
- route the DELETE endpoint through the atomic helper
- cover missing-row, ordering, failure propagation, and route argument regressions

## Testing

- Regression observed before the fix: the missing-subcategory route test failed because product cleanup was called once instead of zero times
- `bun test server/test/routes/products.test.ts server/test/repositories/productsRepo.test.ts` — 137 passed, 0 failed
- focused DELETE route tests — 4 passed, 0 failed
- focused repository helper tests — 3 passed, 0 failed
- `bun run lint` — passed (8 pre-existing warnings, 0 errors)
- `bun run typecheck` — passed
- `bun run build` — passed, including docs generation and login boot smoke test
- React Doctor — 75/100 before and 75/100 after, with the same 98 pre-existing findings
- three consecutive review/simplify passes completed cleanly

## Local test environment limitation

Bun 1.3.14 on Windows reproducibly panics from memory pressure in the unrelated `ClientsOrdersView.test.tsx`, including when that file runs alone. The per-file matrix passed more than 200 frontend files before reaching that known panic. No further global Windows reruns were performed; the complete Linux CI suite is the authoritative merge gate.

## Risk and rollout

Low-risk transactional bug fix. No schema, migration, API contract, configuration, or user-facing documentation changes are required. If cleanup fails, the propagated error rolls back the registry deletion.

## Issues

Internal DeepSec batch 7 finding; no public issue link.