### PR TITLE
catalog(fix): render custom product types safely

### DIFF
--- a/components/catalog/InternalListingView.tsx
+++ b/components/catalog/InternalListingView.tsx
@@ -2013,7 +2013,11 @@ const getInternalListingProductColumns = (controller: InternalListingController)
     header: controller.t('crm:internalListing.type'),
     accessorKey: 'type' as const,
     cell: ({ row: product }: { row: Product }) => (
-      <Badge variant="secondary" className="text-[10px] font-black uppercase tracking-wider">
+      <Badge
+        data-standard-table-preserve-style
+        variant="secondary"
+        className="text-[10px] font-black uppercase tracking-wider"
+      >
         {getDisplayTypeName(product.type)}
       </Badge>
     ),

--- a/components/catalog/InternalListingView.tsx
+++ b/components/catalog/InternalListingView.tsx
@@ -1,6 +1,7 @@
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useReducer } from 'react';
 import { useTranslation } from 'react-i18next';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { FieldLabel, RequiredMark } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
@@ -35,7 +36,7 @@ import {
 } from '../shared/ModalLayout';
 import SelectControl, { type Option } from '../shared/SelectControl';
 import StandardTable from '../shared/StandardTable';
-import StatusBadge, { type StatusType } from '../shared/StatusBadge';
+import StatusBadge from '../shared/StatusBadge';
 import ValidatedNumberInput from '../shared/ValidatedNumberInput';
 
 export interface InternalListingViewProps {
@@ -2012,7 +2013,9 @@ const getInternalListingProductColumns = (controller: InternalListingController)
     header: controller.t('crm:internalListing.type'),
     accessorKey: 'type' as const,
     cell: ({ row: product }: { row: Product }) => (
-      <StatusBadge type={product.type as StatusType} label={getDisplayTypeName(product.type)} />
+      <Badge variant="secondary" className="text-[10px] font-black uppercase tracking-wider">
+        {getDisplayTypeName(product.type)}
+      </Badge>
     ),
     accessorFn: (row: Product) => getDisplayTypeName(row.type),
   },

--- a/src/index.css
+++ b/src/index.css
@@ -482,7 +482,15 @@ tr[data-standard-table-font-size] [data-slot="button"][data-size="icon-sm"] {
   animation: sidebar-entry-up 100ms ease-in;
 }
 
-.standard-table-value-cell :where(:not([data-status-badge], [data-status-badge] *)) {
+.standard-table-value-cell
+  :where(
+    :not(
+      [data-status-badge],
+      [data-status-badge] *,
+      [data-standard-table-preserve-style],
+      [data-standard-table-preserve-style] *
+    )
+  ) {
   background-color: transparent !important;
   border-color: transparent !important;
   border-radius: 0 !important;

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -2448,6 +2448,7 @@ describe('<StandardTable />', () => {
     expect(css).toContain('tr[data-standard-table-font-size] > td');
     expect(css).toContain('[data-slot="input"]');
     expect(css).toContain('--standard-table-control-height');
+    expect(css).toContain('[data-standard-table-preserve-style]');
     expect(css).toMatch(
       /\.standard-table-value-cell \[data-status-badge\]\s*{[^}]*font-size: 0\.714em/s,
     );

--- a/test/components/catalog/InternalListingView.test.tsx
+++ b/test/components/catalog/InternalListingView.test.tsx
@@ -213,8 +213,12 @@ describe('<InternalListingView /> product type badges', () => {
       await Promise.resolve();
     });
 
-    expect(screen.getByText('Hardware').closest('[data-slot="badge"]')).not.toBeNull();
-    expect(container.querySelector('[data-status-badge]')).not.toBeNull();
+    const productTypeBadge = screen
+      .getByText('Hardware')
+      .closest('[data-standard-table-preserve-style]');
+    expect(productTypeBadge).toHaveAttribute('data-slot', 'badge');
+    expect(productTypeBadge).not.toHaveAttribute('data-status-badge');
+    expect(container.querySelectorAll('[data-status-badge]')).toHaveLength(1);
   });
 });
 

--- a/test/components/catalog/InternalListingView.test.tsx
+++ b/test/components/catalog/InternalListingView.test.tsx
@@ -191,6 +191,33 @@ describe('<InternalListingView /> productFilterId', () => {
   });
 });
 
+describe('<InternalListingView /> product type badges', () => {
+  test('renders user-managed product types with a generic badge', async () => {
+    productTypes = [
+      {
+        id: 'type-hardware',
+        name: 'hardware',
+        costUnit: 'unit',
+        productCount: 1,
+        categoryCount: 0,
+      },
+    ];
+
+    const { container } = render(
+      <InternalListingView
+        {...baseProps}
+        products={[buildProduct({ name: 'Server Rack', type: 'hardware' })]}
+      />,
+    );
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(screen.getByText('Hardware').closest('[data-slot="badge"]')).not.toBeNull();
+    expect(container.querySelector('[data-status-badge]')).not.toBeNull();
+  });
+});
+
 describe('<InternalListingView /> managed catalog values', () => {
   const setupManagedCatalogValues = async (
     overrides: Partial<Parameters<typeof InternalListingView>[0]> = {},


### PR DESCRIPTION
## Summary
- Prevents the internal catalog listing from crashing on legitimate user-managed product types such as `hardware`.
- Keeps controlled active/disabled values on the dedicated `StatusBadge` rendering path.

## Changes
- Renders arbitrary product-type labels with the existing shadcn generic secondary badge instead of casting them to `StatusType`.
- Adds catalog-level regression coverage for a custom `hardware` product type and verifies the controlled status badge still renders.

## Testing
- `bun test ./test/components/catalog/InternalListingView.test.tsx` (9 passed)
- `bun run typecheck` (passed after installing locked root and server dependencies)
- `bunx --bun biome check components/catalog/InternalListingView.tsx test/components/catalog/InternalListingView.test.tsx` (passed)
- `bun run test:react-doctor` (75/100, matches baseline; existing unrelated findings only)
- `bun run test:frontend` (Windows Bun 1.3.14 internal assertion after many passing suites at `ClientsOrdersView.test.tsx`; not rerun; Linux CI is authoritative)

## Risks / Rollout
- Low risk. The change is limited to presentation of user-managed product type labels and has no API, database, configuration, or migration impact.
- Documentation reviewed; no update needed because the intended catalog workflow and behavior are unchanged.

## Issues
- DeepSec finding: `praetor-other-logic-bug-7c81ecc00b`
- GitHub issue: Not linked