### PR TITLE
sales(fix): serialize client quote mutations

### DIFF
--- a/server/routes/client-quotes.ts
+++ b/server/routes/client-quotes.ts
@@ -2015,6 +2015,17 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             // Serialize family edits with promotion/restore, which lock the same parent first.
             const lockedCurrent = await clientQuotesRepo.lockCurrentById(idResult.value, tx);
             if (!lockedCurrent) return { kind: 'not_found' as const };
+            const lockedLinkedOfferId = await clientQuotesRepo.findLinkedOfferId(
+              idResult.value,
+              tx,
+            );
+            if (lockedLinkedOfferId) {
+              return {
+                kind: 'conflict' as const,
+                message: 'Candidate families are read-only after promotion or finalization',
+                secondaryLabel: 'candidate_family_read_only',
+              };
+            }
             const isSending =
               normalizeQuoteStatus(lockedCurrent.status) === 'draft' &&
               normalizeQuoteStatus(requestedStatus) === 'sent';
@@ -2605,15 +2616,14 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         items: clientQuotesRepo.ClientQuoteItem[];
         syncAudits: SupplierItemSyncAudit[];
         revisionConflict?: boolean;
+        concurrentConflict?: boolean;
       };
       try {
         result = await withDbTransaction(async (tx) => {
           const sendingIntent =
             normalizeQuoteStatus(current.status) === 'draft' &&
             normalizeQuoteStatus(targetStatus ?? current.status) === 'sent';
-          const lockedQuote = sendingIntent
-            ? await clientQuotesRepo.lockCurrentById(idResult.value, tx)
-            : current;
+          const lockedQuote = await clientQuotesRepo.lockCurrentById(idResult.value, tx);
           if (!lockedQuote) return { quote: null, items: [], syncAudits: [] };
           if (sendingIntent && normalizeQuoteStatus(lockedQuote.status) !== 'draft') {
             return {
@@ -2621,6 +2631,19 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
               items: [],
               syncAudits: [],
               revisionConflict: true,
+            };
+          }
+          const lockedLinkedOfferId = await clientQuotesRepo.findLinkedOfferId(idResult.value, tx);
+          if (
+            normalizeQuoteStatus(lockedQuote.status) !== normalizeQuoteStatus(current.status) ||
+            lockedQuote.expirationDate !== current.expirationDate ||
+            lockedLinkedOfferId !== linkedOfferId
+          ) {
+            return {
+              quote: null,
+              items: [],
+              syncAudits: [],
+              concurrentConflict: true,
             };
           }
           const isSending =
@@ -2797,6 +2820,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           entityType: 'client_quote',
           entityId: idResult.value,
           details: { secondaryLabel: 'concurrent_send' },
+        });
+      }
+      if (result.concurrentConflict) {
+        return replyError(request, reply, {
+          statusCode: 409,
+          message: 'The quote changed while it was being saved',
+          action: 'client_quote.update.conflict',
+          entityType: 'client_quote',
+          entityId: idResult.value,
+          details: { secondaryLabel: 'concurrent_update' },
         });
       }
       if (!updatedQuote) {
@@ -3668,22 +3701,63 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requirePathSegment(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      if (await clientQuotesRepo.findLinkedOfferId(idResult.value)) {
-        return replyError(request, reply, {
-          statusCode: 409,
-          message: 'Cannot delete a quote once an offer has been created from it',
-          action: 'client_quote.delete.conflict',
-          entityType: 'client_quote',
-          entityId: idResult.value,
-          details: { secondaryLabel: 'offer_exists' },
-        });
-      }
+      type DeleteResult =
+        | { kind: 'not_found' }
+        | {
+            kind: 'conflict';
+            message: string;
+            secondaryLabel: string;
+            fromValue?: string;
+          }
+        | { kind: 'success'; clientName: string };
+      const result = await withDbTransaction<DeleteResult>(async (tx) => {
+        const current = await clientQuotesRepo.lockCurrentById(idResult.value, tx);
+        if (!current) return { kind: 'not_found' };
 
-      const [status, familyCandidates] = await Promise.all([
-        clientQuotesRepo.findStatusAndClientName(idResult.value),
-        quoteCandidatesRepo.listForQuote(idResult.value),
-      ]);
-      if (!status) {
+        const [linkedOfferId, status, familyCandidates] = await Promise.all([
+          clientQuotesRepo.findLinkedOfferId(idResult.value, tx),
+          clientQuotesRepo.findStatusAndClientName(idResult.value, tx),
+          quoteCandidatesRepo.listForQuote(idResult.value, tx),
+        ]);
+        if (!status) return { kind: 'not_found' };
+        if (linkedOfferId) {
+          return {
+            kind: 'conflict',
+            message: 'Cannot delete a quote once an offer has been created from it',
+            secondaryLabel: 'offer_exists',
+          };
+        }
+        if (normalizeQuoteStatus(status.status) !== 'draft') {
+          return {
+            kind: 'conflict',
+            message: 'Only draft quotes can be deleted',
+            secondaryLabel: 'non_draft_status',
+            fromValue: status.status,
+          };
+        }
+        // Expired is read-only EVERYWHERE under #779 — the UI already disables deletion, and the
+        // only exit is extending the expiration date. Derive it here too so a direct API caller
+        // cannot delete what the model freezes (#812 round 25).
+        const familyIsExpired =
+          !isTerminalQuoteStatus(status.status) &&
+          isCandidateFamilyExpired(
+            familyCandidates,
+            effectiveQuoteStatusFromDate(status.status, status.expirationDate) === 'expired',
+          );
+        if (familyIsExpired) {
+          return {
+            kind: 'conflict',
+            message:
+              'Expired quotes are read-only and cannot be deleted; extend the expiration date instead',
+            secondaryLabel: 'expired_read_only',
+          };
+        }
+
+        await clientQuotesRepo.deleteById(idResult.value, tx);
+        return { kind: 'success', clientName: status.clientName };
+      });
+
+      if (result.kind === 'not_found') {
         return replyError(request, reply, {
           statusCode: 404,
           message: 'Quote not found',
@@ -3692,38 +3766,19 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           entityId: idResult.value,
         });
       }
-      if (normalizeQuoteStatus(status.status) !== 'draft') {
+      if (result.kind === 'conflict') {
         return replyError(request, reply, {
           statusCode: 409,
-          message: 'Only draft quotes can be deleted',
+          message: result.message,
           action: 'client_quote.delete.conflict',
           entityType: 'client_quote',
           entityId: idResult.value,
-          details: { secondaryLabel: 'non_draft_status', fromValue: status.status },
+          details: {
+            secondaryLabel: result.secondaryLabel,
+            fromValue: result.fromValue,
+          },
         });
       }
-      // Expired is read-only EVERYWHERE under #779 — the UI already disables deletion, and the
-      // only exit is extending the expiration date. Derive it here too so a direct API caller
-      // cannot delete what the model freezes (#812 round 25).
-      const familyIsExpired =
-        !isTerminalQuoteStatus(status.status) &&
-        isCandidateFamilyExpired(
-          familyCandidates,
-          effectiveQuoteStatusFromDate(status.status, status.expirationDate) === 'expired',
-        );
-      if (familyIsExpired) {
-        return replyError(request, reply, {
-          statusCode: 409,
-          message:
-            'Expired quotes are read-only and cannot be deleted; extend the expiration date instead',
-          action: 'client_quote.delete.conflict',
-          entityType: 'client_quote',
-          entityId: idResult.value,
-          details: { secondaryLabel: 'expired_read_only' },
-        });
-      }
-
-      await clientQuotesRepo.deleteById(idResult.value);
 
       await logAudit({
         request,
@@ -3732,7 +3787,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         entityId: idResult.value,
         details: {
           targetLabel: idResult.value,
-          secondaryLabel: status.clientName ?? '',
+          secondaryLabel: result.clientName,
         },
       });
       return reply.code(204).send();

--- a/server/routes/client-quotes.ts
+++ b/server/routes/client-quotes.ts
@@ -3719,7 +3719,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           clientQuotesRepo.findStatusAndClientName(idResult.value, tx),
           quoteCandidatesRepo.listForQuote(idResult.value, tx),
         ]);
-        if (!status) return { kind: 'not_found' };
         if (linkedOfferId) {
           return {
             kind: 'conflict',
@@ -3727,6 +3726,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             secondaryLabel: 'offer_exists',
           };
         }
+        if (!status) return { kind: 'not_found' };
         if (normalizeQuoteStatus(status.status) !== 'draft') {
           return {
             kind: 'conflict',

--- a/server/test/routes/client-quotes-versions.test.ts
+++ b/server/test/routes/client-quotes-versions.test.ts
@@ -991,6 +991,7 @@ describe('PUT /api/sales/client-quotes/:id snapshots pre-update state', () => {
       status: 'draft',
       discount: 0,
       discountType: 'percentage',
+      expirationDate: SAMPLE_QUOTE.expirationDate,
     });
     cqFindFullForSnapshotMock.mockResolvedValue({
       quote: SAMPLE_QUOTE,
@@ -1020,6 +1021,7 @@ describe('PUT /api/sales/client-quotes/:id snapshots pre-update state', () => {
       status: 'draft',
       discount: 0,
       discountType: 'percentage',
+      expirationDate: SAMPLE_QUOTE.expirationDate,
     });
     cqRenameMock.mockResolvedValue({ ...SAMPLE_QUOTE, id: 'q-1-renamed' });
 

--- a/server/test/routes/client-quotes.test.ts
+++ b/server/test/routes/client-quotes.test.ts
@@ -652,6 +652,7 @@ describe('PUT /api/sales/client-quotes/:id status rules (issue #779)', () => {
 
   test('200 allows offer → draft (back-to-draft from offer)', async () => {
     cqFindCurrentMock.mockResolvedValue(gate({ status: 'offer' }));
+    cqLockCurrentByIdMock.mockResolvedValue(gate({ status: 'offer' }));
     cqUpdateMock.mockResolvedValue(updatedQuote({ status: 'draft' }));
 
     const res = await putStatus({ status: 'draft' });
@@ -678,6 +679,7 @@ describe('PUT /api/sales/client-quotes/:id status rules (issue #779)', () => {
 
   test('200 expired quote can be revalidated by extending the expiration date (no status change)', async () => {
     cqFindCurrentMock.mockResolvedValue(gate({ status: 'sent', expirationDate: '2000-01-01' }));
+    cqLockCurrentByIdMock.mockResolvedValue(gate({ status: 'sent', expirationDate: '2000-01-01' }));
     cqUpdateMock.mockResolvedValue(updatedQuote({ status: 'sent', expirationDate: '2027-01-01' }));
 
     const res = await putStatus({ expirationDate: '2027-01-01' });
@@ -705,6 +707,7 @@ describe('PUT /api/sales/client-quotes/:id status rules (issue #779)', () => {
     const revalidatedCandidate = { ...expiredCandidate, expirationDate: '2027-01-01' };
     const revalidatedQuote = updatedQuote({ status: 'sent', expirationDate: '2027-01-01' });
     cqFindCurrentMock.mockResolvedValue(gate({ status: 'sent', expirationDate: '2000-01-01' }));
+    cqLockCurrentByIdMock.mockResolvedValue(gate({ status: 'sent', expirationDate: '2000-01-01' }));
     cqUpdateMock.mockResolvedValue(revalidatedQuote);
     cqFindByIdMock.mockResolvedValue(revalidatedQuote);
     qcListForQuoteMock
@@ -811,6 +814,9 @@ describe('PUT /api/sales/client-quotes/:id status rules (issue #779)', () => {
     cqFindCurrentMock.mockResolvedValue(
       gate({ status: 'sent', linkedSupplierQuoteExpiration: '2000-01-01' }),
     );
+    cqLockCurrentByIdMock.mockResolvedValue(
+      gate({ status: 'sent', linkedSupplierQuoteExpiration: '2000-01-01' }),
+    );
     cqUpdateMock.mockResolvedValue(updatedQuote({ status: 'denied' }));
 
     const res = await putStatus({ status: 'denied' });
@@ -846,8 +852,37 @@ describe('PUT /api/sales/client-quotes/:id status rules (issue #779)', () => {
     expect(cqUpdateMock).not.toHaveBeenCalled();
   });
 
+  test('rechecks status under lock before a flat update', async () => {
+    cqFindCurrentMock.mockResolvedValue(gate({ status: 'draft' }));
+    cqLockCurrentByIdMock.mockResolvedValue(gate({ status: 'offer' }));
+    cqUpdateMock.mockResolvedValue(updatedQuote({ status: 'draft', notes: 'stale edit' }));
+
+    const res = await putStatus({ notes: 'stale edit' });
+
+    expect(res.statusCode).toBe(409);
+    expect(cqLockCurrentByIdMock).toHaveBeenCalledWith('q-1', expect.anything());
+    expect(cqUpdateMock).not.toHaveBeenCalled();
+  });
+
+  test('rechecks offer linkage under lock before a flat update', async () => {
+    cqFindCurrentMock.mockResolvedValue(gate({ status: 'draft' }));
+    cqLockCurrentByIdMock.mockResolvedValue(gate({ status: 'draft' }));
+    cqFindLinkedOfferIdMock.mockImplementation(async (_quoteId: string, exec?: unknown) =>
+      exec ? 'of-1' : null,
+    );
+    cqUpdateMock.mockResolvedValue(updatedQuote({ status: 'draft', notes: 'stale edit' }));
+
+    const res = await putStatus({ notes: 'stale edit' });
+
+    expect(res.statusCode).toBe(409);
+    expect(cqLockCurrentByIdMock).toHaveBeenCalledWith('q-1', expect.anything());
+    expect(cqFindLinkedOfferIdMock).toHaveBeenCalledWith('q-1', expect.anything());
+    expect(cqUpdateMock).not.toHaveBeenCalled();
+  });
+
   test('200 reverts a valid sent quote to draft', async () => {
     cqFindCurrentMock.mockResolvedValue(gate({ status: 'sent' }));
+    cqLockCurrentByIdMock.mockResolvedValue(gate({ status: 'sent' }));
     cqUpdateMock.mockResolvedValue(updatedQuote({ status: 'draft' }));
 
     const res = await putStatus({ status: 'draft' });
@@ -861,6 +896,7 @@ describe('PUT /api/sales/client-quotes/:id status rules (issue #779)', () => {
 
   test('200 a sent quote can renew its expiration date (date carved out of the lock)', async () => {
     cqFindCurrentMock.mockResolvedValue(gate({ status: 'sent' }));
+    cqLockCurrentByIdMock.mockResolvedValue(gate({ status: 'sent' }));
     cqUpdateMock.mockResolvedValue(updatedQuote({ status: 'sent', expirationDate: '2999-12-31' }));
 
     const res = await putStatus({ expirationDate: '2999-12-31' });
@@ -873,6 +909,9 @@ describe('PUT /api/sales/client-quotes/:id status rules (issue #779)', () => {
     // items) must NOT trip the guard even when the current sourced supplier quote is expired —
     // the guard fires only on a status advance or a line re-sourcing (issue #779 follow-up).
     cqFindCurrentMock.mockResolvedValue(
+      gate({ status: 'sent', linkedSupplierQuoteExpiration: '2000-01-01' }),
+    );
+    cqLockCurrentByIdMock.mockResolvedValue(
       gate({ status: 'sent', linkedSupplierQuoteExpiration: '2000-01-01' }),
     );
     cqUpdateMock.mockResolvedValue(updatedQuote({ status: 'sent' }));
@@ -916,6 +955,7 @@ describe('PUT /api/sales/client-quotes/:id status rules (issue #779)', () => {
     // The pre-#779 optimistic-restore override is gone: a body carrying only `isExpired` is a
     // no-op update (not a content edit) and the response reports the derived value.
     cqFindCurrentMock.mockResolvedValue(gate({ status: 'sent', expirationDate: '2000-01-01' }));
+    cqLockCurrentByIdMock.mockResolvedValue(gate({ status: 'sent', expirationDate: '2000-01-01' }));
     cqUpdateMock.mockResolvedValue(updatedQuote({ status: 'sent', expirationDate: '2000-01-01' }));
 
     const res = await putStatus({ isExpired: false });
@@ -943,7 +983,7 @@ describe('DELETE /api/sales/client-quotes/:id', () => {
 
     const res = await deleteQuote('q-1');
     expect(res.statusCode).toBe(204);
-    expect(cqDeleteByIdMock).toHaveBeenCalledWith('q-1');
+    expect(cqDeleteByIdMock).toHaveBeenCalledWith('q-1', expect.anything());
   });
 
   test('204 keeps a traversal-shaped legacy quote operable through one encoded segment', async () => {
@@ -953,7 +993,7 @@ describe('DELETE /api/sales/client-quotes/:id', () => {
     const res = await deleteQuote('legacy%2F..%2Fclient-quote');
 
     expect(res.statusCode).toBe(204);
-    expect(cqDeleteByIdMock).toHaveBeenCalledWith('legacy/../client-quote');
+    expect(cqDeleteByIdMock).toHaveBeenCalledWith('legacy/../client-quote', expect.anything());
   });
 
   test('409 when an offer was created from the quote', async () => {
@@ -961,6 +1001,35 @@ describe('DELETE /api/sales/client-quotes/:id', () => {
 
     const res = await deleteQuote('q-1');
     expect(res.statusCode).toBe(409);
+    expect(cqDeleteByIdMock).not.toHaveBeenCalled();
+  });
+
+  test('rechecks offer linkage under lock before deleting a draft quote', async () => {
+    cqFindLinkedOfferIdMock.mockImplementation(async (_quoteId: string, exec?: unknown) =>
+      exec ? 'of-1' : null,
+    );
+    cqFindStatusAndClientNameMock.mockResolvedValue({ status: 'draft', clientName: 'Client' });
+
+    const res = await deleteQuote('q-1');
+
+    expect(res.statusCode).toBe(409);
+    expect(cqLockCurrentByIdMock).toHaveBeenCalledWith('q-1', expect.anything());
+    expect(cqFindLinkedOfferIdMock).toHaveBeenCalledWith('q-1', expect.anything());
+    expect(cqDeleteByIdMock).not.toHaveBeenCalled();
+  });
+
+  test('rechecks status under lock before deleting a draft quote', async () => {
+    cqFindStatusAndClientNameMock.mockImplementation(async (_quoteId: string, exec?: unknown) => ({
+      status: exec ? 'accepted' : 'draft',
+      clientName: 'Client',
+      expirationDate: '2999-12-31',
+    }));
+
+    const res = await deleteQuote('q-1');
+
+    expect(res.statusCode).toBe(409);
+    expect(cqLockCurrentByIdMock).toHaveBeenCalledWith('q-1', expect.anything());
+    expect(cqFindStatusAndClientNameMock).toHaveBeenCalledWith('q-1', expect.anything());
     expect(cqDeleteByIdMock).not.toHaveBeenCalled();
   });
 
@@ -2261,6 +2330,20 @@ describe('client quote candidate-family create and update', () => {
     expect(cqUpdateMock).not.toHaveBeenCalled();
   });
 
+  test('rechecks offer linkage under lock before replacing candidate items', async () => {
+    setupLegacyCandidateUpdate();
+    cqFindLinkedOfferIdMock.mockImplementation(async (_quoteId: string, exec?: unknown) =>
+      exec ? 'of-1' : null,
+    );
+
+    const res = await putCandidateFamily(150);
+
+    expect(res.statusCode).toBe(409);
+    expect(cqLockCurrentByIdMock).toHaveBeenCalledWith('q-1', expect.anything());
+    expect(cqFindLinkedOfferIdMock).toHaveBeenCalledWith('q-1', expect.anything());
+    expect(cqReplaceItemsMock).not.toHaveBeenCalled();
+  });
+
   test('rejects a line id that belongs to a different candidate', async () => {
     setupCreate();
     cqFindCurrentMock.mockResolvedValue(gate({ status: 'draft' }));
@@ -2447,6 +2530,7 @@ describe('client quote candidate-family create and update', () => {
     const existingCandidate = activeCandidate();
     const deniedQuote = updatedQuote({ id: 'q-1', status: 'denied' });
     cqFindCurrentMock.mockResolvedValue(gate({ status: 'sent' }));
+    cqLockCurrentByIdMock.mockResolvedValue(gate({ status: 'sent' }));
     cqUpdateMock.mockResolvedValue(deniedQuote);
     cqFindByIdMock.mockResolvedValue(deniedQuote);
     qcListForQuoteMock.mockResolvedValue([existingCandidate]);
@@ -3558,7 +3642,7 @@ describe('DELETE /api/sales/client-quotes/:id expired guard (#812 round 25)', ()
   test('409 when a draft quote is effectively expired (read-only model)', async () => {
     cqFindLinkedOfferIdMock.mockResolvedValue(null);
     cqFindByIdMock.mockResolvedValue(null);
-    cqLockCurrentByIdMock.mockResolvedValue(null);
+    cqLockCurrentByIdMock.mockResolvedValue(gate({ status: 'draft' }));
     cqFindItemsForCandidateMock.mockResolvedValue([]);
     cqFindStatusAndClientNameMock.mockResolvedValue({
       status: 'draft',
@@ -3596,7 +3680,7 @@ describe('DELETE /api/sales/client-quotes/:id expired guard (#812 round 25)', ()
     });
 
     expect(res.statusCode).toBe(204);
-    expect(cqDeleteByIdMock).toHaveBeenCalledWith('q-1');
+    expect(cqDeleteByIdMock).toHaveBeenCalledWith('q-1', expect.anything());
   });
 
   test('409 when every active candidate is expired even if the parent date is still valid', async () => {

--- a/server/test/routes/client-quotes.test.ts
+++ b/server/test/routes/client-quotes.test.ts
@@ -1466,7 +1466,7 @@ describe('PUT /api/sales/client-quotes/:id supplier-item forward sync (#779)', (
     cqFindCurrentMock.mockResolvedValue(gate({ status: 'draft' }));
     cqFindLinkedOfferIdMock.mockResolvedValue(null);
     cqFindByIdMock.mockResolvedValue(null);
-    cqLockCurrentByIdMock.mockResolvedValue(null);
+    cqLockCurrentByIdMock.mockResolvedValue(gate({ status: 'draft' }));
     cqFindItemsForCandidateMock.mockResolvedValue([]);
     cqFindItemSnapshotsForQuoteMock.mockResolvedValue([EXISTING_SNAP]);
     cqUpdateMock.mockResolvedValue(updatedQuote({ status: 'draft' }));


### PR DESCRIPTION
## Summary

- Serializes client-quote edits, candidate item replacement, and deletion with promotion/finalization state changes.
- Prevents stale draft mutations from landing after a quote becomes read-only or gains a linked offer.

## Changes

- Locks the client quote before flat and candidate-family writes, then rechecks status, expiration, and offer linkage inside the transaction.
- Moves all delete eligibility gates and the delete itself into one transaction after the parent-row lock.
- Adds regressions for independent stale-status and stale-linkage races across update, replace, and delete paths.

## Testing

- `node_modules\\.bin\\biome.exe check server\\routes\\client-quotes.ts server\\test\\routes\\client-quotes.test.ts` (passed)
- Pre-commit scoped Biome hook (passed)
- `bun run test:react-doctor` (75/100, matches the verified pre-edit baseline)
- `bun test server/test/routes/client-quotes.test.ts` (local Windows run blocked before test execution because the bounded locked install hit `EBUSY` and left `drizzle-orm/node-postgres` unavailable; Linux CI is the authoritative full-suite gate)

## Risks / Rollout

- Low, scoped to client-quote mutation ordering. Concurrent stale writes now return HTTP 409 instead of mutating a progressed quote.
- No database migration, configuration, API shape, or documentation change is required.

## Issues

DeepSec finding `praetor-other-race-condition-116fb729d2` (not linked to a GitHub issue).
