### PR TITLE
orders(security): make draft deletion atomic

### DIFF
--- a/server/repositories/clientsOrdersRepo.ts
+++ b/server/repositories/clientsOrdersRepo.ts
@@ -564,9 +564,15 @@ export const replaceItems = async (
     return insertItems(orderId, versionedItems, tx);
   });
 
-export const deleteById = async (id: string, exec: DbExecutor = db): Promise<boolean> => {
-  const result = await exec.delete(sales).where(eq(sales.id, id));
-  return (result.rowCount ?? 0) > 0;
+export const deleteDraftById = async (
+  id: string,
+  exec: DbExecutor = db,
+): Promise<{ clientName: string } | null> => {
+  const rows = await exec
+    .delete(sales)
+    .where(and(eq(sales.id, id), eq(sales.status, 'draft')))
+    .returning({ clientName: sales.clientName });
+  return rows[0] ?? null;
 };
 
 export type NewSupplierOrderForAutoCreate = {

--- a/server/routes/clients-orders.ts
+++ b/server/routes/clients-orders.ts
@@ -1869,8 +1869,20 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      const order = await clientsOrdersRepo.findStatusAndClientName(idResult.value);
-      if (!order) {
+      const deleted = await clientsOrdersRepo.deleteDraftById(idResult.value);
+      if (!deleted) {
+        const current = await clientsOrdersRepo.findStatusAndClientName(idResult.value);
+        if (current && current.status !== 'draft') {
+          return replyError(request, reply, {
+            statusCode: 409,
+            message: 'Only draft clients_orders can be deleted',
+            action: 'client_order.delete.conflict',
+            entityType: 'client_order',
+            entityId: idResult.value,
+            details: { secondaryLabel: 'non_draft_status', fromValue: current.status },
+            extraBody: { currentStatus: current.status },
+          });
+        }
         return replyError(request, reply, {
           statusCode: 404,
           message: 'Order not found',
@@ -1879,19 +1891,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           entityId: idResult.value,
         });
       }
-      if (order.status !== 'draft') {
-        return replyError(request, reply, {
-          statusCode: 409,
-          message: 'Only draft clients_orders can be deleted',
-          action: 'client_order.delete.conflict',
-          entityType: 'client_order',
-          entityId: idResult.value,
-          details: { secondaryLabel: 'non_draft_status', fromValue: order.status },
-          extraBody: { currentStatus: order.status },
-        });
-      }
-
-      await clientsOrdersRepo.deleteById(idResult.value);
 
       await logAudit({
         request,
@@ -1900,7 +1899,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         entityId: idResult.value,
         details: {
           targetLabel: idResult.value,
-          secondaryLabel: order.clientName ?? '',
+          secondaryLabel: deleted.clientName,
         },
       });
       return reply.code(204).send();

--- a/server/test/repositories/clientsOrdersRepo.test.ts
+++ b/server/test/repositories/clientsOrdersRepo.test.ts
@@ -438,15 +438,19 @@ describe('supplier-order auto-creation flow', () => {
   });
 });
 
-describe('deleteById', () => {
-  test('returns true when row deleted', async () => {
-    exec.enqueue({ rows: [], rowCount: 1 });
-    expect(await repo.deleteById('co-1', testDb)).toBe(true);
+describe('deleteDraftById', () => {
+  test('returns the client name only when a draft row is deleted', async () => {
+    exec.enqueue({ rows: [['Acme']] });
+    expect(await repo.deleteDraftById('co-1', testDb)).toEqual({ clientName: 'Acme' });
+
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('"sales"."status" =');
+    expect(exec.calls[0].params).toEqual(expect.arrayContaining(['co-1', 'draft']));
   });
 
-  test('returns false when no row matched', async () => {
-    exec.enqueue({ rows: [], rowCount: 0 });
-    expect(await repo.deleteById('co-x', testDb)).toBe(false);
+  test('returns null when no draft row matched', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await repo.deleteDraftById('co-x', testDb)).toBeNull();
   });
 });
 

--- a/server/test/routes/clients-orders-versions.test.ts
+++ b/server/test/routes/clients-orders-versions.test.ts
@@ -41,10 +41,12 @@ const coFindItemsForOrderMock = mock();
 const coFindIdConflictMock = mock();
 const coFindOfferDetailsMock = mock();
 const coFindExistingForOfferMock = mock();
+const coFindStatusAndClientNameMock = mock();
 const coUpdateMock = mock();
 const coRenameMock = mock();
 const coRestoreSnapshotOrderMock = mock();
 const coReplaceItemsMock = mock();
+const coDeleteDraftByIdMock = mock();
 
 const clientsExistsByIdMock = mock();
 const productsGetSnapshotsMock = mock();
@@ -88,10 +90,12 @@ beforeAll(async () => {
     findIdConflict: coFindIdConflictMock,
     findOfferDetails: coFindOfferDetailsMock,
     findExistingForOffer: coFindExistingForOfferMock,
+    findStatusAndClientName: coFindStatusAndClientNameMock,
     update: coUpdateMock,
     rename: coRenameMock,
     restoreSnapshotOrder: coRestoreSnapshotOrderMock,
     replaceItems: coReplaceItemsMock,
+    deleteDraftById: coDeleteDraftByIdMock,
   }));
   mock.module('../../repositories/productsRepo.ts', () => ({
     ...productsRepoSnap,
@@ -227,10 +231,12 @@ const allMocks = [
   coFindIdConflictMock,
   coFindOfferDetailsMock,
   coFindExistingForOfferMock,
+  coFindStatusAndClientNameMock,
   coUpdateMock,
   coRenameMock,
   coRestoreSnapshotOrderMock,
   coReplaceItemsMock,
+  coDeleteDraftByIdMock,
   clientsExistsByIdMock,
   productsGetSnapshotsMock,
   sqGetQuoteItemSnapshotsMock,
@@ -266,6 +272,8 @@ beforeEach(async () => {
     status: 'accepted',
   });
   coFindExistingForOfferMock.mockResolvedValue(null);
+  coFindStatusAndClientNameMock.mockResolvedValue({ status: 'draft', clientName: 'Client' });
+  coDeleteDraftByIdMock.mockResolvedValue({ clientName: 'Client' });
   sqGetQuoteItemSnapshotsMock.mockResolvedValue(
     new Map([
       [
@@ -289,6 +297,66 @@ afterEach(async () => {
 });
 
 const authHeader = () => ({ authorization: `Bearer ${signToken({ userId: 'u1' })}` });
+
+describe('DELETE /api/clients-orders/:id', () => {
+  test('204 atomically deletes a draft and audits the returned client name', async () => {
+    coDeleteDraftByIdMock.mockResolvedValue({ clientName: 'Deleted Client' });
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/clients-orders/o-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(coDeleteDraftByIdMock).toHaveBeenCalledWith('o-1');
+    expect(coFindStatusAndClientNameMock).not.toHaveBeenCalled();
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'client_order.deleted',
+        details: expect.objectContaining({ secondaryLabel: 'Deleted Client' }),
+      }),
+    );
+  });
+
+  test('409 when a concurrent confirmation wins before the atomic draft delete', async () => {
+    coFindStatusAndClientNameMock.mockResolvedValue({
+      status: 'confirmed',
+      clientName: 'Client',
+    });
+    coDeleteDraftByIdMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/clients-orders/o-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body).error).toContain('Only draft clients_orders can be deleted');
+    expect(coDeleteDraftByIdMock).toHaveBeenCalledWith('o-1');
+    expect(logAuditMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'client_order.deleted' }),
+    );
+  });
+
+  test('404 when the draft disappears before the atomic delete', async () => {
+    coFindStatusAndClientNameMock.mockResolvedValue(null);
+    coDeleteDraftByIdMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/clients-orders/o-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(coDeleteDraftByIdMock).toHaveBeenCalledWith('o-1');
+    expect(logAuditMock).not.toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'client_order.deleted' }),
+    );
+  });
+});
 
 describe('PUT /api/clients-orders/:id document discount validation', () => {
   test('200 allows unrelated updates to preserve a legacy percentage discount above 100', async () => {


### PR DESCRIPTION
## Summary
- Prevents client-order deletion from racing with order confirmation.
- Preserves the existing `204`, `404`, and `409` response semantics.

## Changes
- Replaces the unconditional ID-only delete with an atomic `DELETE` predicate requiring `status = 'draft'`.
- Returns the deleted row's client name for accurate audit logging without a pre-read.
- Re-reads only after a failed conditional delete to distinguish a non-draft conflict from a missing order.
- Adds repository and route regressions for successful draft deletion, concurrent confirmation, and concurrent removal.

## Testing
- `bun test server/test/repositories/clientsOrdersRepo.test.ts`
- `bun test server/test/routes/clients-orders-versions.test.ts`
- `bun test server/test/repositories/clientsOrdersRepo.test.ts server/test/routes/clients-orders-versions.test.ts` (103 passed)
- `bun run typecheck`
- `bun run test:server` (4,611 passed; 28 skipped; 0 failed)
- `bunx biome check server/repositories/clientsOrdersRepo.ts server/routes/clients-orders.ts server/test/repositories/clientsOrdersRepo.test.ts server/test/routes/clients-orders-versions.test.ts`
- `bun run test:react-doctor` (75/100 before and after; unchanged pre-existing diagnostics)

## Risks / Rollout
- Low risk and backend-only. No schema migration, configuration change, or compatibility window is required.
- API status behavior is unchanged; documentation was reviewed and does not require updates.

## Issues
- DeepSec finding `praetor-other-race-condition-aa33f06691` (no GitHub issue linked).