### PR TITLE
supplier-invoices(fix): lock draft-only mutations

### DIFF
--- a/server/repositories/supplierInvoicesRepo.ts
+++ b/server/repositories/supplierInvoicesRepo.ts
@@ -124,21 +124,38 @@ export const findInvoiceForLinkedSale = async (
   return rows[0]?.id ?? null;
 };
 
-// Reads the minimal set of fields needed to gate updates / restores. Named `findExisting`
-// (not `findExistingForUpdate`) because it does not acquire a row lock - callers run the read,
-// validate, and then issue a separate UPDATE outside any locking scope. If you need true
-// SELECT ... FOR UPDATE semantics, wrap in `withDbTransaction` and add `.for('update')`.
-export const findExisting = async (
-  id: string,
-  exec: DbExecutor = db,
-): Promise<{
+export type ExistingSupplierInvoice = {
   id: string;
   status: string;
   issueDate: string;
   dueDate: string;
   total: number;
   amountPaid: number;
-} | null> => {
+};
+
+const mapExistingSupplierInvoice = (
+  row: Omit<ExistingSupplierInvoice, 'issueDate' | 'dueDate' | 'total' | 'amountPaid'> & {
+    issueDate: string;
+    dueDate: string;
+    total: string;
+    amountPaid: string;
+  },
+): ExistingSupplierInvoice => ({
+  id: row.id,
+  status: row.status,
+  issueDate: requireDateOnly(row.issueDate, 'supplierInvoice.issueDate'),
+  dueDate: requireDateOnly(row.dueDate, 'supplierInvoice.dueDate'),
+  total: parseDbNumber(row.total, 0),
+  amountPaid: parseDbNumber(row.amountPaid, 0),
+});
+
+// Reads the minimal set of fields needed to gate updates / restores. Does not acquire a row
+// lock - safe for non-mutating reads, but TOCTOU-prone when a write decision depends on it.
+// For SELECT ... FOR UPDATE semantics call `lockExistingById` inside `withDbTransaction`.
+export const findExisting = async (
+  id: string,
+  exec: DbExecutor = db,
+): Promise<ExistingSupplierInvoice | null> => {
   const rows = await exec
     .select({
       id: supplierInvoices.id,
@@ -150,15 +167,30 @@ export const findExisting = async (
     })
     .from(supplierInvoices)
     .where(eq(supplierInvoices.id, id));
-  if (!rows[0]) return null;
-  return {
-    id: rows[0].id,
-    status: rows[0].status,
-    issueDate: requireDateOnly(rows[0].issueDate, 'supplierInvoice.issueDate'),
-    dueDate: requireDateOnly(rows[0].dueDate, 'supplierInvoice.dueDate'),
-    total: parseDbNumber(rows[0].total, 0),
-    amountPaid: parseDbNumber(rows[0].amountPaid, 0),
-  };
+  return rows[0] ? mapExistingSupplierInvoice(rows[0]) : null;
+};
+
+// SELECT ... FOR UPDATE variant of `findExisting`. Must be called inside a transaction.
+export const lockExistingById = async (
+  id: string,
+  exec: DbExecutor = db,
+): Promise<(ExistingSupplierInvoice & { supplierName: string }) | null> => {
+  const rows = await exec
+    .select({
+      id: supplierInvoices.id,
+      status: supplierInvoices.status,
+      issueDate: supplierInvoices.issueDate,
+      dueDate: supplierInvoices.dueDate,
+      total: supplierInvoices.total,
+      amountPaid: supplierInvoices.amountPaid,
+      supplierName: supplierInvoices.supplierName,
+    })
+    .from(supplierInvoices)
+    .where(eq(supplierInvoices.id, id))
+    .for('update');
+  return rows[0]
+    ? { ...mapExistingSupplierInvoice(rows[0]), supplierName: rows[0].supplierName }
+    : null;
 };
 
 export const findStatusAndSupplierName = async (

--- a/server/routes/supplier-invoices.ts
+++ b/server/routes/supplier-invoices.ts
@@ -678,6 +678,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         });
       }
       const hasLockedFieldUpdates =
+        (nextIdValue !== null && nextIdValue !== idResult.value) ||
         supplierId !== undefined ||
         supplierName !== undefined ||
         issueDate !== undefined ||
@@ -697,13 +698,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           details: { secondaryLabel: 'non_draft_read_only', fromValue: existingInvoice.status },
           extraBody: { currentStatus: existingInvoice.status },
         });
-      }
-
-      const effectiveIssueDate = patch.issueDate ?? existingInvoice.issueDate;
-      const effectiveDueDate = patch.dueDate ?? existingInvoice.dueDate;
-
-      if (effectiveDueDate < effectiveIssueDate) {
-        return badRequest(reply, 'dueDate must be on or after issueDate');
       }
 
       if (subtotal !== undefined) {
@@ -728,18 +722,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       if (typeof status === 'string') patch.status = status;
       if (typeof notes === 'string') patch.notes = notes;
 
-      const effectiveTotal = patch.total ?? existingInvoice.total;
-      const effectiveAmountPaid = patch.amountPaid ?? existingInvoice.amountPaid;
-      if (
-        (patch.total !== undefined || patch.amountPaid !== undefined || patch.status === 'paid') &&
-        effectiveAmountPaid > effectiveTotal
-      ) {
-        return badRequest(reply, AMOUNT_PAID_EXCEEDS_TOTAL_ERROR);
-      }
-      if (patch.status === 'paid' && effectiveAmountPaid < effectiveTotal) {
-        return badRequest(reply, PAID_INVOICE_UNDERPAID_ERROR);
-      }
-
       let normalizedItems: supplierInvoicesRepo.NewSupplierInvoiceItem[] | null = null;
       let sourceItemIds: Array<string | undefined> | null = null;
       let itemInputs: SupplierInvoiceItemInput[] | null = null;
@@ -753,50 +735,92 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         sourceItemIds = items.map((item) => item.id);
       }
 
-      let updated: supplierInvoicesRepo.SupplierInvoice | null;
-      let resultItems: supplierInvoicesRepo.SupplierInvoiceItem[];
+      type UpdateTransactionResult =
+        | {
+            kind: 'success';
+            invoice: supplierInvoicesRepo.SupplierInvoice;
+            items: supplierInvoicesRepo.SupplierInvoiceItem[];
+            previousStatus: string;
+          }
+        | { kind: 'not_found' }
+        | { kind: 'non_draft'; currentStatus: string }
+        | { kind: 'bad_request'; message: string };
+
+      let transactionResult: UpdateTransactionResult;
       try {
-        const txResult = await withDbTransaction(async (tx) => {
-          let renamedInvoice: supplierInvoicesRepo.SupplierInvoice | null = null;
-          if (nextIdValue && nextIdValue !== idResult.value) {
-            renamedInvoice = await supplierInvoicesRepo.rename(idResult.value, nextIdValue, tx);
-            if (!renamedInvoice) {
-              return { invoice: null, items: [] as supplierInvoicesRepo.SupplierInvoiceItem[] };
+        transactionResult = await withDbTransaction(
+          async (tx): Promise<UpdateTransactionResult> => {
+            const lockedInvoice = await supplierInvoicesRepo.lockExistingById(idResult.value, tx);
+            if (!lockedInvoice) return { kind: 'not_found' };
+            if (lockedInvoice.status !== 'draft' && hasLockedFieldUpdates) {
+              return { kind: 'non_draft', currentStatus: lockedInvoice.status };
             }
-            await reserveDocumentCodeCounterFromCode('supplier_invoice', nextIdValue, tx);
-          }
-          // id-only renames have nothing left to write — reuse the row returned by rename().
-          const invoice =
-            Object.keys(patch).length === 0 && renamedInvoice
-              ? renamedInvoice
-              : await supplierInvoicesRepo.update(renamedInvoice?.id ?? idResult.value, patch, tx);
-          if (!invoice)
-            return { invoice: null, items: [] as supplierInvoicesRepo.SupplierInvoiceItem[] };
-          const existingItems = normalizedItems
-            ? await supplierInvoicesRepo.findItemsForInvoice(invoice.id, tx)
-            : null;
-          let versionedItems = normalizedItems;
-          if (normalizedItems && existingItems && sourceItemIds?.some((id) => id)) {
-            const sourceMarkers = inheritPricingSemanticsVersions(
-              sourceItemIds.map((id) => ({ id })),
-              existingItems,
-            );
-            versionedItems = normalizedItems.map((item, index) => ({
-              ...item,
-              pricingSemanticsVersion: sourceMarkers[index].pricingSemanticsVersion,
-            }));
-          }
-          const replacementItems =
-            versionedItems && itemInputs && existingItems
-              ? preserveLegacyDiscountRounding(versionedItems, itemInputs, existingItems)
-              : versionedItems;
-          const finalItems = replacementItems
-            ? await supplierInvoicesRepo.replaceItems(invoice.id, replacementItems, tx)
-            : await supplierInvoicesRepo.findItemsForInvoice(invoice.id, tx);
-          return { invoice, items: finalItems };
-        });
-        updated = txResult.invoice;
-        resultItems = txResult.items;
+
+            const effectiveIssueDate = patch.issueDate ?? lockedInvoice.issueDate;
+            const effectiveDueDate = patch.dueDate ?? lockedInvoice.dueDate;
+            if (effectiveDueDate < effectiveIssueDate) {
+              return { kind: 'bad_request', message: 'dueDate must be on or after issueDate' };
+            }
+
+            const effectiveTotal = patch.total ?? lockedInvoice.total;
+            const effectiveAmountPaid = patch.amountPaid ?? lockedInvoice.amountPaid;
+            if (
+              (patch.total !== undefined ||
+                patch.amountPaid !== undefined ||
+                patch.status === 'paid') &&
+              effectiveAmountPaid > effectiveTotal
+            ) {
+              return { kind: 'bad_request', message: AMOUNT_PAID_EXCEEDS_TOTAL_ERROR };
+            }
+            if (patch.status === 'paid' && effectiveAmountPaid < effectiveTotal) {
+              return { kind: 'bad_request', message: PAID_INVOICE_UNDERPAID_ERROR };
+            }
+
+            let renamedInvoice: supplierInvoicesRepo.SupplierInvoice | null = null;
+            if (nextIdValue && nextIdValue !== idResult.value) {
+              renamedInvoice = await supplierInvoicesRepo.rename(idResult.value, nextIdValue, tx);
+              if (!renamedInvoice) return { kind: 'not_found' };
+              await reserveDocumentCodeCounterFromCode('supplier_invoice', nextIdValue, tx);
+            }
+            // id-only renames have nothing left to write — reuse the row returned by rename().
+            const invoice =
+              Object.keys(patch).length === 0 && renamedInvoice
+                ? renamedInvoice
+                : await supplierInvoicesRepo.update(
+                    renamedInvoice?.id ?? idResult.value,
+                    patch,
+                    tx,
+                  );
+            if (!invoice) return { kind: 'not_found' };
+            const existingItems = normalizedItems
+              ? await supplierInvoicesRepo.findItemsForInvoice(invoice.id, tx)
+              : null;
+            let versionedItems = normalizedItems;
+            if (normalizedItems && existingItems && sourceItemIds?.some((id) => id)) {
+              const sourceMarkers = inheritPricingSemanticsVersions(
+                sourceItemIds.map((id) => ({ id })),
+                existingItems,
+              );
+              versionedItems = normalizedItems.map((item, index) => ({
+                ...item,
+                pricingSemanticsVersion: sourceMarkers[index].pricingSemanticsVersion,
+              }));
+            }
+            const replacementItems =
+              versionedItems && itemInputs && existingItems
+                ? preserveLegacyDiscountRounding(versionedItems, itemInputs, existingItems)
+                : versionedItems;
+            const finalItems = replacementItems
+              ? await supplierInvoicesRepo.replaceItems(invoice.id, replacementItems, tx)
+              : await supplierInvoicesRepo.findItemsForInvoice(invoice.id, tx);
+            return {
+              kind: 'success',
+              invoice,
+              items: finalItems,
+              previousStatus: lockedInvoice.status,
+            };
+          },
+        );
       } catch (error) {
         const dup = getUniqueViolation(error);
         if (dup) {
@@ -812,7 +836,24 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         throw error;
       }
 
-      if (!updated) {
+      if (transactionResult.kind === 'bad_request') {
+        return badRequest(reply, transactionResult.message);
+      }
+      if (transactionResult.kind === 'non_draft') {
+        return replyError(request, reply, {
+          statusCode: 409,
+          message: 'Non-draft invoices are read-only',
+          action: 'supplier_invoice.update.conflict',
+          entityType: 'supplier_invoice',
+          entityId: idResult.value,
+          details: {
+            secondaryLabel: 'non_draft_read_only',
+            fromValue: transactionResult.currentStatus,
+          },
+          extraBody: { currentStatus: transactionResult.currentStatus },
+        });
+      }
+      if (transactionResult.kind === 'not_found') {
         return replyError(request, reply, {
           statusCode: 404,
           message: 'Invoice not found',
@@ -822,8 +863,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         });
       }
 
-      const didStatusChange =
-        typeof status === 'string' && existingInvoice.status !== updated.status;
+      const { invoice: updated, items: resultItems, previousStatus } = transactionResult;
+      const didStatusChange = typeof status === 'string' && previousStatus !== updated.status;
       await logAudit({
         request,
         action: 'supplier_invoice.updated',
@@ -832,7 +873,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         details: {
           targetLabel: updated.id,
           secondaryLabel: updated.supplierName,
-          fromValue: didStatusChange ? existingInvoice.status : undefined,
+          fromValue: didStatusChange ? previousStatus : undefined,
           toValue: didStatusChange ? updated.status : undefined,
         },
       });
@@ -883,7 +924,46 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         });
       }
 
-      await supplierInvoicesRepo.deleteById(idResult.value);
+      type DeleteTransactionResult =
+        | { kind: 'success'; supplierName: string }
+        | { kind: 'not_found' }
+        | { kind: 'non_draft'; currentStatus: string };
+      const transactionResult = await withDbTransaction(
+        async (tx): Promise<DeleteTransactionResult> => {
+          const lockedInvoice = await supplierInvoicesRepo.lockExistingById(idResult.value, tx);
+          if (!lockedInvoice) return { kind: 'not_found' };
+          if (lockedInvoice.status !== 'draft') {
+            return { kind: 'non_draft', currentStatus: lockedInvoice.status };
+          }
+          if (!(await supplierInvoicesRepo.deleteById(idResult.value, tx))) {
+            return { kind: 'not_found' };
+          }
+          return { kind: 'success', supplierName: lockedInvoice.supplierName };
+        },
+      );
+
+      if (transactionResult.kind === 'non_draft') {
+        return replyError(request, reply, {
+          statusCode: 409,
+          message: 'Only draft invoices can be deleted',
+          action: 'supplier_invoice.delete.conflict',
+          entityType: 'supplier_invoice',
+          entityId: idResult.value,
+          details: {
+            secondaryLabel: 'non_draft_status',
+            fromValue: transactionResult.currentStatus,
+          },
+        });
+      }
+      if (transactionResult.kind === 'not_found') {
+        return replyError(request, reply, {
+          statusCode: 404,
+          message: 'Invoice not found',
+          action: 'supplier_invoice.delete.not_found',
+          entityType: 'supplier_invoice',
+          entityId: idResult.value,
+        });
+      }
 
       await logAudit({
         request,
@@ -892,7 +972,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         entityId: idResult.value,
         details: {
           targetLabel: idResult.value,
-          secondaryLabel: existing.supplierName,
+          secondaryLabel: transactionResult.supplierName,
         },
       });
       return reply.code(204).send();

--- a/server/routes/supplier-invoices.ts
+++ b/server/routes/supplier-invoices.ts
@@ -752,9 +752,21 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           async (tx): Promise<UpdateTransactionResult> => {
             const lockedInvoice = await supplierInvoicesRepo.lockExistingById(idResult.value, tx);
             if (!lockedInvoice) return { kind: 'not_found' };
-            if (lockedInvoice.status !== 'draft' && hasLockedFieldUpdates) {
+            // Lifecycle-only transitions remain valid after draft, but a status write based on a
+            // stale preflight read must not overwrite a concurrent transition. Re-sending the
+            // status already held by the locked row is an idempotent no-op and remains safe.
+            const hasStaleStatusUpdate =
+              patch.status !== undefined &&
+              patch.status !== lockedInvoice.status &&
+              existingInvoice.status !== lockedInvoice.status;
+            if (
+              lockedInvoice.status !== 'draft' &&
+              (hasLockedFieldUpdates || hasStaleStatusUpdate)
+            ) {
               return { kind: 'non_draft', currentStatus: lockedInvoice.status };
             }
+            const patchForWrite =
+              patch.status === lockedInvoice.status && !hasLockedFieldUpdates ? {} : patch;
 
             const effectiveIssueDate = patch.issueDate ?? lockedInvoice.issueDate;
             const effectiveDueDate = patch.dueDate ?? lockedInvoice.dueDate;
@@ -784,11 +796,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             }
             // id-only renames have nothing left to write — reuse the row returned by rename().
             const invoice =
-              Object.keys(patch).length === 0 && renamedInvoice
+              Object.keys(patchForWrite).length === 0 && renamedInvoice
                 ? renamedInvoice
                 : await supplierInvoicesRepo.update(
                     renamedInvoice?.id ?? idResult.value,
-                    patch,
+                    patchForWrite,
                     tx,
                   );
             if (!invoice) return { kind: 'not_found' };

--- a/server/test/repositories/supplierInvoicesRepo.test.ts
+++ b/server/test/repositories/supplierInvoicesRepo.test.ts
@@ -135,6 +135,25 @@ describe('findExisting', () => {
   });
 });
 
+describe('lockExistingById', () => {
+  test('locks and returns the fields needed by mutation gates', async () => {
+    exec.enqueue({
+      rows: [['SINV-2026-0001', 'draft', '2026-04-01', '2026-04-30', '120.60', '20.10', 'Acme']],
+    });
+
+    expect(await supplierInvoicesRepo.lockExistingById('SINV-2026-0001', testDb)).toEqual({
+      id: 'SINV-2026-0001',
+      status: 'draft',
+      issueDate: '2026-04-01',
+      dueDate: '2026-04-30',
+      total: 120.6,
+      amountPaid: 20.1,
+      supplierName: 'Acme',
+    });
+    expect(exec.calls[0].sql.toLowerCase()).toContain('for update');
+  });
+});
+
 describe('maxSequenceForYear', () => {
   test('parses string maxSequence to BigInt', async () => {
     exec.enqueue({ rows: [{ maxSequence: '42' }] });

--- a/server/test/routes/supplier-invoices.test.ts
+++ b/server/test/routes/supplier-invoices.test.ts
@@ -15,6 +15,7 @@ import {
 import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
 import { makeDbError } from '../helpers/dbErrors.ts';
 import { signToken } from '../helpers/jwt.ts';
+import { TX_SENTINEL } from '../helpers/txSentinel.ts';
 import { makeWithDbTransactionMock } from '../helpers/withDbTransactionMock.ts';
 
 const usersRepoSnap = { ...realUsersRepo };
@@ -37,6 +38,7 @@ const maxSequenceForYearMock = mock();
 const createMock = mock();
 const insertItemsMock = mock();
 const findExistingMock = mock();
+const lockExistingByIdMock = mock();
 const findIdConflictMock = mock();
 const updateMock = mock();
 const renameMock = mock();
@@ -79,6 +81,7 @@ beforeAll(async () => {
     create: createMock,
     insertItems: insertItemsMock,
     findExisting: findExistingMock,
+    lockExistingById: lockExistingByIdMock,
     findIdConflict: findIdConflictMock,
     update: updateMock,
     rename: renameMock,
@@ -194,6 +197,7 @@ const allMocks = [
   createMock,
   insertItemsMock,
   findExistingMock,
+  lockExistingByIdMock,
   findIdConflictMock,
   updateMock,
   renameMock,
@@ -221,6 +225,10 @@ beforeEach(async () => {
   allocateDocumentCodeMock.mockResolvedValue('SINV-2025-0001');
   lockOrderExistingByIdMock.mockResolvedValue(null);
   findOrderItemsMock.mockResolvedValue([]);
+  lockExistingByIdMock.mockResolvedValue({
+    ...existingInvoiceForUpdate(),
+    supplierName: 'Acme Supply',
+  });
 
   testApp = await buildRouteTestApp(routePlugin, '/api/supplier-invoices');
 });
@@ -919,6 +927,95 @@ describe('PUT /api/supplier-invoices/:id', () => {
     expect(body.error).toBe('Non-draft invoices are read-only');
   });
 
+  test('409 when the invoice becomes non-draft before the transactional update', async () => {
+    findExistingMock.mockResolvedValue(existingInvoiceForUpdate());
+    lockExistingByIdMock.mockResolvedValue({
+      ...existingInvoiceForUpdate({ status: 'sent' }),
+      supplierName: 'Acme Supply',
+    });
+    updateMock.mockResolvedValue({ ...SAMPLE_INVOICE, supplierName: 'Renamed' });
+    findItemsForInvoiceMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+      headers: authHeader(),
+      payload: { supplierName: 'Renamed' },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Non-draft invoices are read-only' });
+    expect(lockExistingByIdMock).toHaveBeenCalledWith('SINV-2025-0001', TX_SENTINEL);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  test('409 when the invoice becomes non-draft before a transactional rename', async () => {
+    findExistingMock.mockResolvedValue(existingInvoiceForUpdate());
+    lockExistingByIdMock.mockResolvedValue({
+      ...existingInvoiceForUpdate({ status: 'sent' }),
+      supplierName: 'Acme Supply',
+    });
+    renameMock.mockResolvedValue({ ...SAMPLE_INVOICE, id: 'SINV-2025-0002' });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+      headers: authHeader(),
+      payload: { id: 'SINV-2025-0002' },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Non-draft invoices are read-only' });
+    expect(lockExistingByIdMock).toHaveBeenCalledWith('SINV-2025-0001', TX_SENTINEL);
+    expect(renameMock).not.toHaveBeenCalled();
+  });
+
+  test('200 allows a non-draft status update that resends the unchanged invoice id', async () => {
+    findExistingMock.mockResolvedValue(existingInvoiceForUpdate({ status: 'sent' }));
+    lockExistingByIdMock.mockResolvedValue({
+      ...existingInvoiceForUpdate({ status: 'sent' }),
+      supplierName: 'Acme Supply',
+    });
+    updateMock.mockResolvedValue({ ...SAMPLE_INVOICE, status: 'sent' });
+    findItemsForInvoiceMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+      headers: authHeader(),
+      payload: { id: 'SINV-2025-0001', status: 'sent' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(renameMock).not.toHaveBeenCalled();
+    expect(updateMock).toHaveBeenCalledWith('SINV-2025-0001', { status: 'sent' }, TX_SENTINEL);
+  });
+
+  test('audits a status transition from the transactionally locked status', async () => {
+    findExistingMock.mockResolvedValue(existingInvoiceForUpdate());
+    lockExistingByIdMock.mockResolvedValue({
+      ...existingInvoiceForUpdate({ status: 'sent' }),
+      supplierName: 'Acme Supply',
+    });
+    updateMock.mockResolvedValue({ ...SAMPLE_INVOICE, status: 'cancelled' });
+    findItemsForInvoiceMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+      headers: authHeader(),
+      payload: { status: 'cancelled' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'supplier_invoice.updated',
+        details: expect.objectContaining({ fromValue: 'sent', toValue: 'cancelled' }),
+      }),
+    );
+  });
+
   test('409 id conflict on rename', async () => {
     findExistingMock.mockResolvedValue(existingInvoiceForUpdate());
     findIdConflictMock.mockResolvedValue(true);
@@ -1002,6 +1099,10 @@ describe('PUT /api/supplier-invoices/:id', () => {
 
   test('400 total cannot be lowered below existing amountPaid', async () => {
     findExistingMock.mockResolvedValue(existingInvoiceForUpdate({ amountPaid: 80 }));
+    lockExistingByIdMock.mockResolvedValue({
+      ...existingInvoiceForUpdate({ amountPaid: 80 }),
+      supplierName: 'Acme Supply',
+    });
 
     const res = await testApp.inject({
       method: 'PUT',
@@ -1034,6 +1135,10 @@ describe('PUT /api/supplier-invoices/:id', () => {
 
   test('400 paid status rejects existing amountPaid above total', async () => {
     findExistingMock.mockResolvedValue(existingInvoiceForUpdate({ amountPaid: 101 }));
+    lockExistingByIdMock.mockResolvedValue({
+      ...existingInvoiceForUpdate({ amountPaid: 101 }),
+      supplierName: 'Acme Supply',
+    });
 
     const res = await testApp.inject({
       method: 'PUT',
@@ -1112,7 +1217,7 @@ describe('DELETE /api/supplier-invoices/:id', () => {
     });
 
     expect(res.statusCode).toBe(204);
-    expect(deleteByIdMock).toHaveBeenCalledWith('SINV-2025-0001');
+    expect(deleteByIdMock).toHaveBeenCalledWith('SINV-2025-0001', TX_SENTINEL);
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({
         action: 'supplier_invoice.deleted',
@@ -1150,6 +1255,31 @@ describe('DELETE /api/supplier-invoices/:id', () => {
     expect(JSON.parse(res.body)).toEqual({
       error: 'Only draft invoices can be deleted',
     });
+    expect(deleteByIdMock).not.toHaveBeenCalled();
+  });
+
+  test('409 when the invoice becomes non-draft before the transactional delete', async () => {
+    findStatusAndSupplierNameMock.mockResolvedValue({
+      status: 'draft',
+      supplierName: 'Acme Supply',
+    });
+    lockExistingByIdMock.mockResolvedValue({
+      ...existingInvoiceForUpdate({ status: 'sent' }),
+      supplierName: 'Acme Supply',
+    });
+    deleteByIdMock.mockResolvedValue(true);
+
+    const res = await testApp.inject({
+      method: 'DELETE',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'Only draft invoices can be deleted',
+    });
+    expect(lockExistingByIdMock).toHaveBeenCalledWith('SINV-2025-0001', TX_SENTINEL);
     expect(deleteByIdMock).not.toHaveBeenCalled();
   });
 

--- a/server/test/routes/supplier-invoices.test.ts
+++ b/server/test/routes/supplier-invoices.test.ts
@@ -949,6 +949,47 @@ describe('PUT /api/supplier-invoices/:id', () => {
     expect(updateMock).not.toHaveBeenCalled();
   });
 
+  test('409 when the status changes before a conflicting transactional status update', async () => {
+    findExistingMock.mockResolvedValue(existingInvoiceForUpdate());
+    lockExistingByIdMock.mockResolvedValue({
+      ...existingInvoiceForUpdate({ status: 'sent' }),
+      supplierName: 'Acme Supply',
+    });
+    updateMock.mockResolvedValue({ ...SAMPLE_INVOICE, status: 'cancelled' });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+      headers: authHeader(),
+      payload: { status: 'cancelled' },
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Non-draft invoices are read-only' });
+    expect(lockExistingByIdMock).toHaveBeenCalledWith('SINV-2025-0001', TX_SENTINEL);
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+
+  test('200 when a concurrent status update already applied the requested status', async () => {
+    findExistingMock.mockResolvedValue(existingInvoiceForUpdate());
+    lockExistingByIdMock.mockResolvedValue({
+      ...existingInvoiceForUpdate({ status: 'sent' }),
+      supplierName: 'Acme Supply',
+    });
+    updateMock.mockResolvedValue({ ...SAMPLE_INVOICE, status: 'sent' });
+    findItemsForInvoiceMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+      headers: authHeader(),
+      payload: { status: 'sent' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(updateMock).toHaveBeenCalledWith('SINV-2025-0001', {}, TX_SENTINEL);
+  });
+
   test('409 when the invoice becomes non-draft before a transactional rename', async () => {
     findExistingMock.mockResolvedValue(existingInvoiceForUpdate());
     lockExistingByIdMock.mockResolvedValue({
@@ -988,11 +1029,11 @@ describe('PUT /api/supplier-invoices/:id', () => {
 
     expect(res.statusCode).toBe(200);
     expect(renameMock).not.toHaveBeenCalled();
-    expect(updateMock).toHaveBeenCalledWith('SINV-2025-0001', { status: 'sent' }, TX_SENTINEL);
+    expect(updateMock).toHaveBeenCalledWith('SINV-2025-0001', {}, TX_SENTINEL);
   });
 
   test('audits a status transition from the transactionally locked status', async () => {
-    findExistingMock.mockResolvedValue(existingInvoiceForUpdate());
+    findExistingMock.mockResolvedValue(existingInvoiceForUpdate({ status: 'sent' }));
     lockExistingByIdMock.mockResolvedValue({
       ...existingInvoiceForUpdate({ status: 'sent' }),
       supplierName: 'Acme Supply',


### PR DESCRIPTION
## Summary
- Prevents supplier-invoice updates, renames, and deletes from bypassing draft-only protections during concurrent status changes.
- Makes locked database state authoritative for invoice invariants and audit transitions.

## Changes
- Adds a transaction-scoped `SELECT ... FOR UPDATE` repository reader for supplier invoices.
- Rechecks read-only/delete status inside the same transaction as each mutation.
- Validates effective dates and payment totals against the locked row, and audits status changes from that authoritative state.
- Adds route regressions for update, rename, delete, unchanged-ID compatibility, and concurrent audit state, plus repository lock coverage.

## Testing
- `bun test server/test/routes/supplier-invoices.test.ts server/test/repositories/supplierInvoicesRepo.test.ts` (83 passed)
- `bun run typecheck`
- `bun x @biomejs/biome check server/repositories/supplierInvoicesRepo.ts server/routes/supplier-invoices.ts server/test/repositories/supplierInvoicesRepo.test.ts server/test/routes/supplier-invoices.test.ts`
- `bun test server/test` (4,614 passed, 28 skipped, 0 failed)
- `bun run test:react-doctor` (75/100, unchanged from baseline; exits nonzero for pre-existing frontend findings)

## Risks / Rollout
- Low, scoped backend concurrency change with no schema, API, configuration, or migration changes.
- PUT and DELETE now hold a row lock for the duration of their mutation transaction; conflicting requests serialize and receive the existing 404/409 responses as appropriate.
- User documentation is unchanged because this enforces the existing non-draft read-only contract rather than changing supported behavior.

## Issues
Issue: Not linked. DeepSec finding `praetor-other-race-condition-5a8ebd2300`.