### PR TITLE
suppliers(security): serialize quote reference writes

### DIFF
--- a/server/repositories/clientOffersRepo.ts
+++ b/server/repositories/clientOffersRepo.ts
@@ -13,6 +13,7 @@ import {
   preservePricingSemanticsVersions,
 } from '../utils/pricing-semantics.ts';
 import { normalizeUnitType, type UnitType } from '../utils/unit-type.ts';
+import { lockClientDocumentSupplierReferences } from './supplierQuotesRepo.ts';
 
 export type ClientOffer = {
   id: string;
@@ -459,35 +460,37 @@ export const insertItems = async (
   offerId: string,
   items: NewClientOfferItem[],
   exec: DbExecutor = db,
-): Promise<ClientOfferItem[]> => {
-  if (items.length === 0) return [];
-  const rows = await exec
-    .insert(customerOfferItems)
-    .values(
-      items.map((item) => ({
-        id: item.id,
-        offerId,
-        productId: item.productId,
-        productName: item.productName,
-        quantity: numericForDb(item.quantity),
-        unitPrice: numericForDb(item.unitPrice),
-        productCost: numericForDb(item.productCost),
-        productMolPercentage: numericForDb(item.productMolPercentage),
-        discount: numericForDb(item.discount),
-        note: item.note,
-        supplierQuoteId: item.supplierQuoteId,
-        supplierQuoteItemId: item.supplierQuoteItemId,
-        supplierQuoteSupplierName: item.supplierQuoteSupplierName,
-        supplierQuoteUnitPrice: numericForDb(item.supplierQuoteUnitPrice),
-        unitType: item.unitType,
-        durationMonths: item.durationMonths ?? 1,
-        durationUnit: item.durationUnit ?? 'months',
-        pricingSemanticsVersion: normalizePricingSemanticsVersion(item.pricingSemanticsVersion),
-      })),
-    )
-    .returning();
-  return rows.map(mapItem);
-};
+): Promise<ClientOfferItem[]> =>
+  runAtomically(exec, async (tx) => {
+    if (items.length === 0) return [];
+    await lockClientDocumentSupplierReferences(items, tx);
+    const rows = await tx
+      .insert(customerOfferItems)
+      .values(
+        items.map((item) => ({
+          id: item.id,
+          offerId,
+          productId: item.productId,
+          productName: item.productName,
+          quantity: numericForDb(item.quantity),
+          unitPrice: numericForDb(item.unitPrice),
+          productCost: numericForDb(item.productCost),
+          productMolPercentage: numericForDb(item.productMolPercentage),
+          discount: numericForDb(item.discount),
+          note: item.note,
+          supplierQuoteId: item.supplierQuoteId,
+          supplierQuoteItemId: item.supplierQuoteItemId,
+          supplierQuoteSupplierName: item.supplierQuoteSupplierName,
+          supplierQuoteUnitPrice: numericForDb(item.supplierQuoteUnitPrice),
+          unitType: item.unitType,
+          durationMonths: item.durationMonths ?? 1,
+          durationUnit: item.durationUnit ?? 'months',
+          pricingSemanticsVersion: normalizePricingSemanticsVersion(item.pricingSemanticsVersion),
+        })),
+      )
+      .returning();
+    return rows.map(mapItem);
+  });
 
 export const replaceItems = async (
   offerId: string,

--- a/server/repositories/clientQuotesRepo.ts
+++ b/server/repositories/clientQuotesRepo.ts
@@ -13,6 +13,7 @@ import {
   preservePricingSemanticsVersions,
 } from '../utils/pricing-semantics.ts';
 import { normalizeUnitType, type UnitType } from '../utils/unit-type.ts';
+import { lockClientDocumentSupplierReferences } from './supplierQuotesRepo.ts';
 
 export type ClientQuote = {
   id: string;
@@ -749,38 +750,40 @@ export const insertItems = async (
   items: NewClientQuoteItem[],
   exec: DbExecutor = db,
   candidateId?: string,
-): Promise<ClientQuoteItem[]> => {
-  if (items.length === 0) return [];
-  const resolvedCandidateId = candidateId ?? (await resolvePrimaryCandidateId(quoteId, exec));
-  const rows = await exec
-    .insert(quoteItems)
-    .values(
-      items.map((item) => ({
-        id: item.id,
-        quoteId,
-        candidateId: resolvedCandidateId,
-        position: item.position,
-        productId: item.productId,
-        productName: item.productName,
-        quantity: numericForDb(item.quantity),
-        unitPrice: numericForDb(item.unitPrice),
-        productCost: numericForDb(item.productCost),
-        productMolPercentage: numericForDb(item.productMolPercentage),
-        discount: numericForDb(item.discount),
-        note: item.note,
-        supplierQuoteId: item.supplierQuoteId,
-        supplierQuoteItemId: item.supplierQuoteItemId,
-        supplierQuoteSupplierName: item.supplierQuoteSupplierName,
-        supplierQuoteUnitPrice: numericForDb(item.supplierQuoteUnitPrice),
-        unitType: item.unitType,
-        durationMonths: item.durationMonths ?? 1,
-        durationUnit: item.durationUnit ?? 'months',
-        pricingSemanticsVersion: normalizePricingSemanticsVersion(item.pricingSemanticsVersion),
-      })),
-    )
-    .returning();
-  return rows.sort((left, right) => left.position - right.position).map(mapItem);
-};
+): Promise<ClientQuoteItem[]> =>
+  runAtomically(exec, async (tx) => {
+    if (items.length === 0) return [];
+    await lockClientDocumentSupplierReferences(items, tx);
+    const resolvedCandidateId = candidateId ?? (await resolvePrimaryCandidateId(quoteId, tx));
+    const rows = await tx
+      .insert(quoteItems)
+      .values(
+        items.map((item) => ({
+          id: item.id,
+          quoteId,
+          candidateId: resolvedCandidateId,
+          position: item.position,
+          productId: item.productId,
+          productName: item.productName,
+          quantity: numericForDb(item.quantity),
+          unitPrice: numericForDb(item.unitPrice),
+          productCost: numericForDb(item.productCost),
+          productMolPercentage: numericForDb(item.productMolPercentage),
+          discount: numericForDb(item.discount),
+          note: item.note,
+          supplierQuoteId: item.supplierQuoteId,
+          supplierQuoteItemId: item.supplierQuoteItemId,
+          supplierQuoteSupplierName: item.supplierQuoteSupplierName,
+          supplierQuoteUnitPrice: numericForDb(item.supplierQuoteUnitPrice),
+          unitType: item.unitType,
+          durationMonths: item.durationMonths ?? 1,
+          durationUnit: item.durationUnit ?? 'months',
+          pricingSemanticsVersion: normalizePricingSemanticsVersion(item.pricingSemanticsVersion),
+        })),
+      )
+      .returning();
+    return rows.sort((left, right) => left.position - right.position).map(mapItem);
+  });
 
 export const replaceItems = async (
   quoteId: string,

--- a/server/repositories/clientsOrdersRepo.ts
+++ b/server/repositories/clientsOrdersRepo.ts
@@ -14,6 +14,7 @@ import {
   preservePricingSemanticsVersions,
 } from '../utils/pricing-semantics.ts';
 import { normalizeUnitType, type UnitType } from '../utils/unit-type.ts';
+import { lockClientDocumentSupplierReferences } from './supplierQuotesRepo.ts';
 
 export type ClientOrder = {
   id: string;
@@ -517,38 +518,40 @@ export const insertItems = async (
   orderId: string,
   items: NewClientOrderItem[],
   exec: DbExecutor = db,
-): Promise<ClientOrderItem[]> => {
-  if (items.length === 0) return [];
-  const rows = await exec
-    .insert(saleItems)
-    .values(
-      items.map((item) => ({
-        id: item.id,
-        saleId: orderId,
-        productId: item.productId,
-        productName: item.productName,
-        quantity: numericForDb(item.quantity),
-        unitPrice: numericForDb(item.unitPrice),
-        productCost: numericForDb(item.productCost),
-        productMolPercentage: numericForDb(item.productMolPercentage),
-        discount: numericForDb(item.discount),
-        note: item.note,
-        supplierQuoteId: item.supplierQuoteId,
-        supplierQuoteItemId: item.supplierQuoteItemId,
-        supplierQuoteSupplierName: item.supplierQuoteSupplierName,
-        supplierQuoteUnitPrice: numericForDb(item.supplierQuoteUnitPrice),
-        supplierSaleId: item.supplierSaleId,
-        supplierSaleItemId: item.supplierSaleItemId,
-        supplierSaleSupplierName: item.supplierSaleSupplierName,
-        unitType: item.unitType,
-        durationMonths: item.durationMonths ?? 1,
-        durationUnit: item.durationUnit ?? 'months',
-        pricingSemanticsVersion: normalizePricingSemanticsVersion(item.pricingSemanticsVersion),
-      })),
-    )
-    .returning();
-  return rows.map(mapItem);
-};
+): Promise<ClientOrderItem[]> =>
+  runAtomically(exec, async (tx) => {
+    if (items.length === 0) return [];
+    await lockClientDocumentSupplierReferences(items, tx);
+    const rows = await tx
+      .insert(saleItems)
+      .values(
+        items.map((item) => ({
+          id: item.id,
+          saleId: orderId,
+          productId: item.productId,
+          productName: item.productName,
+          quantity: numericForDb(item.quantity),
+          unitPrice: numericForDb(item.unitPrice),
+          productCost: numericForDb(item.productCost),
+          productMolPercentage: numericForDb(item.productMolPercentage),
+          discount: numericForDb(item.discount),
+          note: item.note,
+          supplierQuoteId: item.supplierQuoteId,
+          supplierQuoteItemId: item.supplierQuoteItemId,
+          supplierQuoteSupplierName: item.supplierQuoteSupplierName,
+          supplierQuoteUnitPrice: numericForDb(item.supplierQuoteUnitPrice),
+          supplierSaleId: item.supplierSaleId,
+          supplierSaleItemId: item.supplierSaleItemId,
+          supplierSaleSupplierName: item.supplierSaleSupplierName,
+          unitType: item.unitType,
+          durationMonths: item.durationMonths ?? 1,
+          durationUnit: item.durationUnit ?? 'months',
+          pricingSemanticsVersion: normalizePricingSemanticsVersion(item.pricingSemanticsVersion),
+        })),
+      )
+      .returning();
+    return rows.map(mapItem);
+  });
 
 export const replaceItems = async (
   orderId: string,

--- a/server/repositories/supplierQuotesRepo.ts
+++ b/server/repositories/supplierQuotesRepo.ts
@@ -495,6 +495,10 @@ export const lockEffectiveStatusById = async (
 export type ClientDocumentSupplierReference = {
   supplierQuoteId?: string | null;
   supplierQuoteItemId?: string | null;
+  supplierQuoteExpectedProductId?: string | null;
+  supplierQuoteExpectedSupplierName?: string | null;
+  supplierQuoteExpectedUnitPrice?: number | null;
+  supplierQuoteMustBeSourceable?: boolean;
 };
 
 const supplierReferenceConflict = () =>
@@ -558,20 +562,24 @@ export const lockClientDocumentSupplierReferences = async (
     if (lockedQuotes.length !== quoteIds.length) throw supplierReferenceConflict();
 
     if (itemIds.length === 0) return;
-    const revalidatedItems = await tx
-      .select({ id: supplierQuoteItems.id, quoteId: supplierQuoteItems.quoteId })
-      .from(supplierQuoteItems)
-      .where(inArray(supplierQuoteItems.id, itemIds));
-    const revalidatedQuoteByItem = new Map(revalidatedItems.map((item) => [item.id, item.quoteId]));
+    const revalidatedSnapshots = await getQuoteItemSnapshots(itemIds, tx);
     for (const reference of references) {
       const itemId = reference.supplierQuoteItemId;
       if (!itemId) continue;
       const initialQuoteId = initialQuoteByItem.get(itemId);
-      const revalidatedQuoteId = revalidatedQuoteByItem.get(itemId);
+      const snapshot = revalidatedSnapshots.get(itemId);
       if (
         !initialQuoteId ||
-        revalidatedQuoteId !== initialQuoteId ||
-        (reference.supplierQuoteId && reference.supplierQuoteId !== revalidatedQuoteId)
+        !snapshot ||
+        snapshot.supplierQuoteId !== initialQuoteId ||
+        (reference.supplierQuoteId && reference.supplierQuoteId !== snapshot.supplierQuoteId) ||
+        (reference.supplierQuoteExpectedProductId !== undefined &&
+          reference.supplierQuoteExpectedProductId !== snapshot.productId) ||
+        (reference.supplierQuoteExpectedSupplierName !== undefined &&
+          reference.supplierQuoteExpectedSupplierName !== snapshot.supplierName) ||
+        (reference.supplierQuoteExpectedUnitPrice !== undefined &&
+          reference.supplierQuoteExpectedUnitPrice !== snapshot.netCost) ||
+        (reference.supplierQuoteMustBeSourceable === true && !snapshot.sourceable)
       ) {
         throw supplierReferenceConflict();
       }

--- a/server/repositories/supplierQuotesRepo.ts
+++ b/server/repositories/supplierQuotesRepo.ts
@@ -1,12 +1,10 @@
-import { and, asc, desc, eq, getTableColumns, inArray, ne, notInArray, or, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, getTableColumns, inArray, ne, notInArray, sql } from 'drizzle-orm';
 import { type DbExecutor, db, executeRows, runAtomically } from '../db/drizzle.ts';
-import { customerOfferItems } from '../db/schema/customerOfferItems.ts';
-import { quoteItems } from '../db/schema/quotes.ts';
-import { saleItems } from '../db/schema/sales.ts';
 import { supplierQuoteItems, supplierQuotes } from '../db/schema/supplierQuotes.ts';
 import { supplierSales } from '../db/schema/supplierSales.ts';
 import { normalizeNullableDateOnly } from '../utils/date.ts';
 import { type DurationUnit, normalizeDurationUnit } from '../utils/duration-unit.ts';
+import { ConflictError } from '../utils/http-errors.ts';
 import { numericForDb, parseDbNumber } from '../utils/parse.ts';
 import {
   normalizeHistoricalPricingSemanticsVersion,
@@ -494,6 +492,90 @@ export const lockEffectiveStatusById = async (
   };
 };
 
+export type ClientDocumentSupplierReference = {
+  supplierQuoteId?: string | null;
+  supplierQuoteItemId?: string | null;
+};
+
+const supplierReferenceConflict = () =>
+  new ConflictError('A referenced supplier quote changed during the request; retry the operation');
+
+/**
+ * Locks and revalidates the supplier quote rows referenced by client-document lines.
+ *
+ * Client line columns are intentionally soft snapshot references, so no FK takes the parent-row
+ * lock that PostgreSQL would normally acquire for us. Every client item insert/replace calls this
+ * inside its write transaction; supplier quote delete/item-replacement paths lock the same rows
+ * before checking their reverse references. Whichever transaction wins is therefore visible to
+ * the waiter: a supplier mutation rechecks and refuses a committed client reference, while a
+ * client write rechecks and refuses a source that was deleted while it waited.
+ */
+export const lockClientDocumentSupplierReferences = async (
+  references: readonly ClientDocumentSupplierReference[],
+  exec: DbExecutor = db,
+): Promise<void> =>
+  runAtomically(exec, async (tx) => {
+    const itemIds = [
+      ...new Set(
+        references
+          .map((reference) => reference.supplierQuoteItemId)
+          .filter((id): id is string => typeof id === 'string' && id.length > 0),
+      ),
+    ];
+    const initialItems =
+      itemIds.length > 0
+        ? await tx
+            .select({ id: supplierQuoteItems.id, quoteId: supplierQuoteItems.quoteId })
+            .from(supplierQuoteItems)
+            .where(inArray(supplierQuoteItems.id, itemIds))
+        : [];
+    const initialQuoteByItem = new Map(initialItems.map((item) => [item.id, item.quoteId]));
+    if (initialQuoteByItem.size !== itemIds.length) throw supplierReferenceConflict();
+
+    const quoteIds = [
+      ...new Set(
+        references
+          .flatMap((reference) => {
+            const explicitId = reference.supplierQuoteId;
+            const itemQuoteId = reference.supplierQuoteItemId
+              ? initialQuoteByItem.get(reference.supplierQuoteItemId)
+              : undefined;
+            return [explicitId, itemQuoteId];
+          })
+          .filter((id): id is string => typeof id === 'string' && id.length > 0),
+      ),
+    ].sort();
+    if (quoteIds.length === 0) return;
+
+    const lockedQuotes = await tx
+      .select({ id: supplierQuotes.id })
+      .from(supplierQuotes)
+      .where(inArray(supplierQuotes.id, quoteIds))
+      .orderBy(asc(supplierQuotes.id))
+      .for('key share');
+    if (lockedQuotes.length !== quoteIds.length) throw supplierReferenceConflict();
+
+    if (itemIds.length === 0) return;
+    const revalidatedItems = await tx
+      .select({ id: supplierQuoteItems.id, quoteId: supplierQuoteItems.quoteId })
+      .from(supplierQuoteItems)
+      .where(inArray(supplierQuoteItems.id, itemIds));
+    const revalidatedQuoteByItem = new Map(revalidatedItems.map((item) => [item.id, item.quoteId]));
+    for (const reference of references) {
+      const itemId = reference.supplierQuoteItemId;
+      if (!itemId) continue;
+      const initialQuoteId = initialQuoteByItem.get(itemId);
+      const revalidatedQuoteId = revalidatedQuoteByItem.get(itemId);
+      if (
+        !initialQuoteId ||
+        revalidatedQuoteId !== initialQuoteId ||
+        (reference.supplierQuoteId && reference.supplierQuoteId !== revalidatedQuoteId)
+      ) {
+        throw supplierReferenceConflict();
+      }
+    }
+  });
+
 export const findItemsForQuote = async (
   quoteId: string,
   exec: DbExecutor = db,
@@ -547,43 +629,28 @@ export const isSourcedByClientDocuments = async (
   quoteId: string,
   exec: DbExecutor = db,
 ): Promise<boolean> => {
-  const itemIdsSubquery = exec
-    .select({ id: supplierQuoteItems.id })
-    .from(supplierQuoteItems)
-    .where(eq(supplierQuoteItems.quoteId, quoteId));
-  const [quoteRefs, offerRefs, orderRefs] = await Promise.all([
-    exec
-      .select({ id: quoteItems.id })
-      .from(quoteItems)
-      .where(
-        or(
-          eq(quoteItems.supplierQuoteId, quoteId),
-          inArray(quoteItems.supplierQuoteItemId, itemIdsSubquery),
-        ),
+  const rows = await executeRows<{ exists: boolean }>(
+    exec,
+    sql`
+      WITH source_items AS (
+        SELECT id FROM supplier_quote_items WHERE quote_id = ${quoteId}
       )
-      .limit(1),
-    exec
-      .select({ id: customerOfferItems.id })
-      .from(customerOfferItems)
-      .where(
-        or(
-          eq(customerOfferItems.supplierQuoteId, quoteId),
-          inArray(customerOfferItems.supplierQuoteItemId, itemIdsSubquery),
-        ),
-      )
-      .limit(1),
-    exec
-      .select({ id: saleItems.id })
-      .from(saleItems)
-      .where(
-        or(
-          eq(saleItems.supplierQuoteId, quoteId),
-          inArray(saleItems.supplierQuoteItemId, itemIdsSubquery),
-        ),
-      )
-      .limit(1),
-  ]);
-  return quoteRefs.length > 0 || offerRefs.length > 0 || orderRefs.length > 0;
+      SELECT EXISTS (
+        SELECT 1 FROM quote_items
+        WHERE supplier_quote_id = ${quoteId}
+           OR supplier_quote_item_id IN (SELECT id FROM source_items)
+        UNION ALL
+        SELECT 1 FROM customer_offer_items
+        WHERE supplier_quote_id = ${quoteId}
+           OR supplier_quote_item_id IN (SELECT id FROM source_items)
+        UNION ALL
+        SELECT 1 FROM sale_items
+        WHERE supplier_quote_id = ${quoteId}
+           OR supplier_quote_item_id IN (SELECT id FROM source_items)
+      ) AS "exists"
+    `,
+  );
+  return rows[0]?.exists === true;
 };
 
 // The subset of this quote's item ids that client document lines (quote, offer, or client-order
@@ -596,29 +663,27 @@ export const findSourcedItemIds = async (
   quoteId: string,
   exec: DbExecutor = db,
 ): Promise<Set<string>> => {
-  const itemIdsSubquery = exec
-    .select({ id: supplierQuoteItems.id })
-    .from(supplierQuoteItems)
-    .where(eq(supplierQuoteItems.quoteId, quoteId));
-  const [quoteRefs, offerRefs, orderRefs] = await Promise.all([
-    exec
-      .selectDistinct({ itemId: quoteItems.supplierQuoteItemId })
-      .from(quoteItems)
-      .where(inArray(quoteItems.supplierQuoteItemId, itemIdsSubquery)),
-    exec
-      .selectDistinct({ itemId: customerOfferItems.supplierQuoteItemId })
-      .from(customerOfferItems)
-      .where(inArray(customerOfferItems.supplierQuoteItemId, itemIdsSubquery)),
-    exec
-      .selectDistinct({ itemId: saleItems.supplierQuoteItemId })
-      .from(saleItems)
-      .where(inArray(saleItems.supplierQuoteItemId, itemIdsSubquery)),
-  ]);
-  const ids = new Set<string>();
-  for (const row of [...quoteRefs, ...offerRefs, ...orderRefs]) {
-    if (row.itemId) ids.add(row.itemId);
-  }
-  return ids;
+  const rows = await executeRows<{ itemId: string }>(
+    exec,
+    sql`
+      WITH source_items AS (
+        SELECT id FROM supplier_quote_items WHERE quote_id = ${quoteId}
+      )
+      SELECT DISTINCT item_id AS "itemId"
+      FROM (
+        SELECT supplier_quote_item_id AS item_id FROM quote_items
+        WHERE supplier_quote_item_id IN (SELECT id FROM source_items)
+        UNION ALL
+        SELECT supplier_quote_item_id AS item_id FROM customer_offer_items
+        WHERE supplier_quote_item_id IN (SELECT id FROM source_items)
+        UNION ALL
+        SELECT supplier_quote_item_id AS item_id FROM sale_items
+        WHERE supplier_quote_item_id IN (SELECT id FROM source_items)
+      ) sourced_refs
+      WHERE item_id IS NOT NULL
+    `,
+  );
+  return new Set(rows.map((row) => row.itemId));
 };
 
 export const findIdConflict = async (

--- a/server/repositories/supplierQuotesRepo.ts
+++ b/server/repositories/supplierQuotesRepo.ts
@@ -552,7 +552,9 @@ export const lockClientDocumentSupplierReferences = async (
       .from(supplierQuotes)
       .where(inArray(supplierQuotes.id, quoteIds))
       .orderBy(asc(supplierQuotes.id))
-      .for('key share');
+      // Some client saves later sync supplier pricing with FOR UPDATE. Lock exclusively from the
+      // outset so two saves cannot both take compatible shared locks and deadlock while upgrading.
+      .for('update');
     if (lockedQuotes.length !== quoteIds.length) throw supplierReferenceConflict();
 
     if (itemIds.length === 0) return;

--- a/server/routes/client-quotes.ts
+++ b/server/routes/client-quotes.ts
@@ -49,6 +49,7 @@ import {
   defaultDurationMonthsForUnit,
   effectiveDurationMultiplier,
 } from '../utils/duration-unit.ts';
+import { ConflictError } from '../utils/http-errors.ts';
 import { getDocumentDiscountAmount } from '../utils/invoice-math.ts';
 import { normalizeNullableString } from '../utils/normalize.ts';
 import { generatePrefixedId, ITEM_ID_PREFIXES } from '../utils/order-ids.ts';
@@ -1752,6 +1753,15 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           quoteId: nextIdResult.value ?? 'auto',
         });
         if (autoOfferConflict) return autoOfferConflict;
+        if (err instanceof ConflictError) {
+          return replyError(request, reply, {
+            statusCode: err.statusCode,
+            message: err.message,
+            action: 'client_quote.create.conflict',
+            entityType: 'client_quote',
+            details: { secondaryLabel: 'supplier_quote_changed' },
+          });
+        }
         request.log.error({ err }, 'CRITICAL ERROR creating quote');
         return reply.code(500).send({ error: `Internal Server Error: ${(err as Error).message}` });
       }

--- a/server/routes/supplier-quotes.ts
+++ b/server/routes/supplier-quotes.ts
@@ -862,33 +862,12 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       // soft, FK-less denormalized value that does NOT cascade, so after a rename the derived-status
       // reverse lookup and the client progression/expiration guards can no longer find them.
       const isRenaming = nextIdValue !== null && nextIdValue !== idResult.value;
-      const [
-        current,
-        linkedOrderId,
-        idConflict,
-        sourcedByClientDocuments,
-        existingItems,
-        sourcedItemIds,
-      ] = await Promise.all([
+      const [current, linkedOrderId, idConflict] = await Promise.all([
         supplierQuotesRepo.findById(idResult.value),
         supplierQuotesRepo.findLinkedOrderId(idResult.value),
         nextIdValue
           ? supplierQuotesRepo.findIdConflict(nextIdValue, idResult.value)
           : Promise.resolve(false),
-        // Renaming strands ALL soft client-line references, including quote-level
-        // supplier_quote_id ones the item-level set below can't see — keep the coarse check
-        // for the rename guard only. The lookup is wasted otherwise.
-        isRenaming
-          ? supplierQuotesRepo.isSourcedByClientDocuments(idResult.value)
-          : Promise.resolve(false),
-        // The items guards below need the persisted rows (to keep incoming ids) and the subset
-        // of item ids client lines reference (to refuse the genuinely stranding shapes).
-        normalizedItems
-          ? supplierQuotesRepo.findItemsForQuote(idResult.value)
-          : Promise.resolve(null),
-        normalizedItems
-          ? supplierQuotesRepo.findSourcedItemIds(idResult.value)
-          : Promise.resolve(new Set<string>()),
       ]);
       if (!current) {
         return replyError(request, reply, {
@@ -918,86 +897,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           entityType: 'supplier_quote',
           entityId: idResult.value,
           details: { secondaryLabel: 'non_draft_read_only', fromValue: currentEffective },
-        });
-      }
-      // A draft-DERIVED supplier quote can still be SOURCED by a draft client line: #779 dropped
-      // the status filter in getQuoteItemSnapshots, and a quote sourced only by a draft client
-      // quote derives back to `draft`, slipping past the read-only guard above. The original #812
-      // guard refused ANY items payload on a sourced quote because the PUT re-minted every item id
-      // (replaceItems), stranding the client lines' soft, FK-less supplier_quote_item_id
-      // references — which also blocked plain pricing edits (user report). Identity is preserved
-      // instead: an incoming item carrying its persisted id is updated IN PLACE via upsertItems
-      // (client lines keep resolving and surface the new pricing through the per-line drift
-      // chip), so only the two shapes that still strand or poison references are refused —
-      // deleting a referenced item, and repointing a referenced item to a different product (the
-      // client-line snapshot resolver hard-fails its next edit on a product mismatch).
-      if (normalizedItems && existingItems) {
-        const existingItemById = new Map(existingItems.map((item) => [item.id, item] as const));
-        const existingIds = new Set(existingItemById.keys());
-        // Keep each persisted id claimed by the payload (first occurrence wins — a duplicate or
-        // foreign id keeps its freshly minted one and inserts as a new row).
-        const claimedIds = new Set<string>();
-        normalizedItems.forEach((normalized, index) => {
-          const incomingId = items?.[index]?.id;
-          if (incomingId && existingIds.has(incomingId) && !claimedIds.has(incomingId)) {
-            normalized.id = incomingId;
-            claimedIds.add(incomingId);
-            const existing = existingItemById.get(incomingId);
-            // Client syncs may intentionally persist an authoritative cost that differs from the
-            // rounded list-price/discount formula. When those pricing inputs are unchanged, keep
-            // the stored cost across full-form or notes-only saves. A genuine pricing edit still
-            // uses the freshly derived value produced during validation above.
-            if (
-              existing &&
-              normalized.listPrice === existing.listPrice &&
-              normalized.discountPercent === existing.discountPercent
-            ) {
-              normalized.unitPrice = normalizeSupplierUnitPrice(existing.unitPrice);
-            }
-          }
-        });
-        const existingProductById = new Map(
-          existingItems.map((item) => [item.id, item.productId] as const),
-        );
-        const repointsSourcedItem = normalizedItems.some(
-          (item) =>
-            sourcedItemIds.has(item.id) && existingProductById.get(item.id) !== item.productId,
-        );
-        if (repointsSourcedItem) {
-          return replyError(request, reply, {
-            statusCode: 409,
-            message:
-              'Cannot change the product of supplier quote items that are used by client quotes, offers or orders',
-            action: 'supplier_quote.update.conflict',
-            entityType: 'supplier_quote',
-            entityId: idResult.value,
-            details: { secondaryLabel: 'sourced_item_product_changed' },
-          });
-        }
-        const removesSourcedItem = [...sourcedItemIds].some(
-          (sourcedId) => existingIds.has(sourcedId) && !claimedIds.has(sourcedId),
-        );
-        if (removesSourcedItem) {
-          return replyError(request, reply, {
-            statusCode: 409,
-            message:
-              'Cannot remove supplier quote items that are used by client quotes, offers or orders',
-            action: 'supplier_quote.update.conflict',
-            entityType: 'supplier_quote',
-            entityId: idResult.value,
-            details: { secondaryLabel: 'sourced_item_removed' },
-          });
-        }
-      }
-      if (isRenaming && sourcedByClientDocuments) {
-        return replyError(request, reply, {
-          statusCode: 409,
-          message:
-            'Cannot change the id of a supplier quote whose items are used by client quotes, offers or orders',
-          action: 'supplier_quote.update.conflict',
-          entityType: 'supplier_quote',
-          entityId: idResult.value,
-          details: { secondaryLabel: 'sourced_by_client_documents' },
         });
       }
       if (idConflict) {
@@ -1031,34 +930,142 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       let updated: supplierQuotesRepo.SupplierQuote | null;
       let resultItems: supplierQuotesRepo.SupplierQuoteItem[];
       try {
-        const txResult = await withDbTransaction(async (tx) => {
-          // Snapshot only when the patch carries actual content. ID-only renames cascade
-          // through the FK without altering snapshot fields, and empty PUTs are no-ops in
-          // `update()` - both would otherwise create misleading "Save" rows.
-          if (hasContentUpdate) {
-            await snapshotPreState(idResult.value, 'update', request, tx);
-          }
-          let renamedQuote: supplierQuotesRepo.SupplierQuote | null = null;
-          if (nextIdValue && nextIdValue !== idResult.value) {
-            renamedQuote = await supplierQuotesRepo.rename(idResult.value, nextIdValue, tx);
-            if (!renamedQuote) {
-              return { quote: null, items: [] as supplierQuotesRepo.SupplierQuoteItem[] };
+        type UpdateConflict =
+          | 'order_exists'
+          | 'non_draft_read_only'
+          | 'rename_sourced'
+          | 'sourced_item_product_changed'
+          | 'sourced_item_removed';
+        const txResult = await withDbTransaction(
+          async (
+            tx,
+          ): Promise<{
+            quote: supplierQuotesRepo.SupplierQuote | null;
+            items: supplierQuotesRepo.SupplierQuoteItem[];
+            conflict?: UpdateConflict;
+          }> => {
+            // Client quote/offer/order item writers lock this same row before persisting their soft
+            // supplier references. Hold it through the final guard reads and destructive upsert or
+            // rename so a concurrent writer either lands first and is observed here, or waits and
+            // revalidates the source after this transaction commits.
+            const locked = await supplierQuotesRepo.lockEffectiveStatusById(idResult.value, tx);
+            if (!locked) return { quote: null, items: [] };
+            if (await supplierQuotesRepo.findLinkedOrderId(idResult.value, tx)) {
+              return { quote: null, items: [], conflict: 'order_exists' };
             }
-            await reserveDocumentCodeCounterFromCode('supplier_quote', nextIdValue, tx);
-          }
-          // id-only renames have nothing left to write — reuse the row returned by rename().
-          const quote =
-            Object.keys(patch).length === 0 && renamedQuote
-              ? renamedQuote
-              : await supplierQuotesRepo.update(renamedQuote?.id ?? idResult.value, patch, tx);
-          if (!quote) return { quote: null, items: [] as supplierQuotesRepo.SupplierQuoteItem[] };
-          // upsertItems (not replaceItems): rows whose id survived the claim pass above keep
-          // their identity, so client lines sourcing them stay attached across the edit.
-          const finalItems = normalizedItems
-            ? await supplierQuotesRepo.upsertItems(quote.id, normalizedItems, tx)
-            : await supplierQuotesRepo.findItemsForQuote(quote.id, tx);
-          return { quote, items: finalItems };
-        });
+            if (
+              effectiveSupplierQuoteStatusFromDate(locked) !== 'draft' &&
+              hasNonExpirationContentUpdate
+            ) {
+              return { quote: null, items: [], conflict: 'non_draft_read_only' };
+            }
+            if (
+              isRenaming &&
+              (await supplierQuotesRepo.isSourcedByClientDocuments(idResult.value, tx))
+            ) {
+              return { quote: null, items: [], conflict: 'rename_sourced' };
+            }
+            if (normalizedItems) {
+              const existingItems = await supplierQuotesRepo.findItemsForQuote(idResult.value, tx);
+              const sourcedItemIds = await supplierQuotesRepo.findSourcedItemIds(
+                idResult.value,
+                tx,
+              );
+              const existingItemById = new Map(
+                existingItems.map((item) => [item.id, item] as const),
+              );
+              const existingIds = new Set(existingItemById.keys());
+              const claimedIds = new Set<string>();
+              normalizedItems.forEach((normalized, index) => {
+                const incomingId = items?.[index]?.id;
+                if (incomingId && existingIds.has(incomingId) && !claimedIds.has(incomingId)) {
+                  normalized.id = incomingId;
+                  claimedIds.add(incomingId);
+                  const existing = existingItemById.get(incomingId);
+                  if (
+                    existing &&
+                    normalized.listPrice === existing.listPrice &&
+                    normalized.discountPercent === existing.discountPercent
+                  ) {
+                    normalized.unitPrice = normalizeSupplierUnitPrice(existing.unitPrice);
+                  }
+                }
+              });
+              const existingProductById = new Map(
+                existingItems.map((item) => [item.id, item.productId] as const),
+              );
+              if (
+                normalizedItems.some(
+                  (item) =>
+                    sourcedItemIds.has(item.id) &&
+                    existingProductById.get(item.id) !== item.productId,
+                )
+              ) {
+                return { quote: null, items: [], conflict: 'sourced_item_product_changed' };
+              }
+              if (
+                [...sourcedItemIds].some(
+                  (sourcedId) => existingIds.has(sourcedId) && !claimedIds.has(sourcedId),
+                )
+              ) {
+                return { quote: null, items: [], conflict: 'sourced_item_removed' };
+              }
+            }
+            // Snapshot only when the patch carries actual content. ID-only renames cascade
+            // through the FK without altering snapshot fields, and empty PUTs are no-ops in
+            // `update()` - both would otherwise create misleading "Save" rows.
+            if (hasContentUpdate) {
+              await snapshotPreState(idResult.value, 'update', request, tx);
+            }
+            let renamedQuote: supplierQuotesRepo.SupplierQuote | null = null;
+            if (nextIdValue && nextIdValue !== idResult.value) {
+              renamedQuote = await supplierQuotesRepo.rename(idResult.value, nextIdValue, tx);
+              if (!renamedQuote) {
+                return { quote: null, items: [] as supplierQuotesRepo.SupplierQuoteItem[] };
+              }
+              await reserveDocumentCodeCounterFromCode('supplier_quote', nextIdValue, tx);
+            }
+            // id-only renames have nothing left to write — reuse the row returned by rename().
+            const quote =
+              Object.keys(patch).length === 0 && renamedQuote
+                ? renamedQuote
+                : await supplierQuotesRepo.update(renamedQuote?.id ?? idResult.value, patch, tx);
+            if (!quote) return { quote: null, items: [] as supplierQuotesRepo.SupplierQuoteItem[] };
+            // upsertItems (not replaceItems): rows whose id survived the claim pass above keep
+            // their identity, so client lines sourcing them stay attached across the edit.
+            const finalItems = normalizedItems
+              ? await supplierQuotesRepo.upsertItems(quote.id, normalizedItems, tx)
+              : await supplierQuotesRepo.findItemsForQuote(quote.id, tx);
+            return { quote, items: finalItems };
+          },
+        );
+        if (txResult.conflict) {
+          const conflictMessages: Record<UpdateConflict, string> = {
+            order_exists: 'Quotes become read-only once an order exists',
+            non_draft_read_only: 'Non-draft supplier quotes are read-only',
+            rename_sourced:
+              'Cannot change the id of a supplier quote whose items are used by client quotes, offers or orders',
+            sourced_item_product_changed:
+              'Cannot change the product of supplier quote items that are used by client quotes, offers or orders',
+            sourced_item_removed:
+              'Cannot remove supplier quote items that are used by client quotes, offers or orders',
+          };
+          const conflictLabels: Record<UpdateConflict, string> = {
+            order_exists: 'order_exists',
+            non_draft_read_only: 'non_draft_read_only',
+            rename_sourced: 'sourced_by_client_documents',
+            sourced_item_product_changed: 'sourced_item_product_changed',
+            sourced_item_removed: 'sourced_item_removed',
+          };
+          return replyError(request, reply, {
+            statusCode: 409,
+            message: conflictMessages[txResult.conflict],
+            action: 'supplier_quote.update.conflict',
+            entityType: 'supplier_quote',
+            entityId: idResult.value,
+            details: { secondaryLabel: conflictLabels[txResult.conflict] },
+          });
+        }
         updated = txResult.quote;
         resultItems = txResult.items;
       } catch (error) {
@@ -1379,6 +1386,22 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       );
 
       const restored = await withDbTransaction(async (tx) => {
+        const locked = await supplierQuotesRepo.lockEffectiveStatusById(idResult.value, tx);
+        if (!locked) return { quote: null, items: [] as supplierQuotesRepo.SupplierQuoteItem[] };
+        if (await supplierQuotesRepo.findLinkedOrderId(idResult.value, tx)) {
+          return {
+            quote: null,
+            items: [] as supplierQuotesRepo.SupplierQuoteItem[],
+            orderConflict: true,
+          };
+        }
+        if (await supplierQuotesRepo.isSourcedByClientDocuments(idResult.value, tx)) {
+          return {
+            quote: null,
+            items: [] as supplierQuotesRepo.SupplierQuoteItem[],
+            sourcedConflict: true,
+          };
+        }
         // Snapshot current with reason='restore' so the just-replaced data stays recoverable.
         await snapshotPreState(idResult.value, 'restore', request, tx);
         const snapshotCommunicationChannelId =
@@ -1422,6 +1445,29 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         const items = await supplierQuotesRepo.replaceItems(quote.id, snapshotItems, tx);
         return { quote, items };
       });
+
+      if ('orderConflict' in restored && restored.orderConflict) {
+        return replyError(request, reply, {
+          statusCode: 409,
+          message: 'Quotes become read-only once an order exists',
+          action: 'supplier_quote.restore.conflict',
+          entityType: 'supplier_quote',
+          entityId: idResult.value,
+          details: { secondaryLabel: 'order_exists' },
+        });
+      }
+
+      if ('sourcedConflict' in restored && restored.sourcedConflict) {
+        return replyError(request, reply, {
+          statusCode: 409,
+          message:
+            'Cannot restore a supplier quote whose items are used by client quotes, offers or orders',
+          action: 'supplier_quote.restore.conflict',
+          entityType: 'supplier_quote',
+          entityId: idResult.value,
+          details: { secondaryLabel: 'sourced_by_client_documents' },
+        });
+      }
 
       if ('missingChannel' in restored && restored.missingChannel) {
         return replyError(request, reply, {
@@ -1875,8 +1921,33 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requirePathSegment(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      const linkedOrderId = await supplierQuotesRepo.findLinkedOrderId(idResult.value);
-      if (linkedOrderId) {
+      type DeleteOutcome =
+        | {
+            kind: 'deleted';
+            deleted: NonNullable<
+              Awaited<ReturnType<typeof supplierQuotesRepo.deleteByIdWithAttachmentStoredNames>>
+            >;
+          }
+        | { kind: 'not_found' }
+        | { kind: 'order_conflict' }
+        | { kind: 'sourced_conflict' };
+      const outcome = await withDbTransaction(async (tx): Promise<DeleteOutcome> => {
+        const locked = await supplierQuotesRepo.lockEffectiveStatusById(idResult.value, tx);
+        if (!locked) return { kind: 'not_found' };
+        if (await supplierQuotesRepo.findLinkedOrderId(idResult.value, tx)) {
+          return { kind: 'order_conflict' };
+        }
+        if (await supplierQuotesRepo.isSourcedByClientDocuments(idResult.value, tx)) {
+          return { kind: 'sourced_conflict' };
+        }
+        const deleted = await supplierQuotesRepo.deleteByIdWithAttachmentStoredNames(
+          idResult.value,
+          tx,
+        );
+        return deleted ? { kind: 'deleted', deleted } : { kind: 'not_found' };
+      });
+
+      if (outcome.kind === 'order_conflict') {
         return replyError(request, reply, {
           statusCode: 409,
           message: 'Cannot delete a quote once an order has been created from it',
@@ -1891,7 +1962,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       // deletable ones — and the client-line references have no FK behind them, so deleting a
       // sourced quote would strand those lines with dead supplierQuoteItemIds (their next edit
       // would 400). Refuse instead.
-      if (await supplierQuotesRepo.isSourcedByClientDocuments(idResult.value)) {
+      if (outcome.kind === 'sourced_conflict') {
         return replyError(request, reply, {
           statusCode: 409,
           message:
@@ -1903,8 +1974,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         });
       }
 
-      const deleted = await supplierQuotesRepo.deleteByIdWithAttachmentStoredNames(idResult.value);
-      if (!deleted) {
+      if (outcome.kind === 'not_found') {
         return replyError(request, reply, {
           statusCode: 404,
           message: 'Supplier quote not found',
@@ -1913,6 +1983,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           entityId: idResult.value,
         });
       }
+      const { deleted } = outcome;
 
       await Promise.all(
         deleted.attachmentStoredNames.map((storedName) =>

--- a/server/test/repositories/clientOffersRepo.test.ts
+++ b/server/test/repositories/clientOffersRepo.test.ts
@@ -384,7 +384,7 @@ describe('insertItems', () => {
       testDb,
     );
 
-    expect(exec.calls[1].sql.toLowerCase()).toContain('for key share');
+    expect(exec.calls[1].sql.toLowerCase()).toContain('for update');
     expect(exec.calls[3].sql.toLowerCase()).toContain('insert into "customer_offer_items"');
   });
 });

--- a/server/test/repositories/clientOffersRepo.test.ts
+++ b/server/test/repositories/clientOffersRepo.test.ts
@@ -356,7 +356,11 @@ describe('insertItems', () => {
   test('locks and revalidates supplier references before inserting offer items', async () => {
     exec.enqueue({ rows: [['sqi-1', 'sq-1']] });
     exec.enqueue({ rows: [['sq-1']] });
-    exec.enqueue({ rows: [['sqi-1', 'sq-1']] });
+    exec.enqueue({
+      rows: [
+        ['sqi-1', 'sq-1', 'Vendor', 'p-1', '5', 2, '2999-12-31', null, null, null, null, null],
+      ],
+    });
     exec.enqueue({ rows: [itemRow()] });
 
     await clientOffersRepo.insertItems(

--- a/server/test/repositories/clientOffersRepo.test.ts
+++ b/server/test/repositories/clientOffersRepo.test.ts
@@ -352,6 +352,41 @@ describe('insertItems', () => {
       2,
     ]);
   });
+
+  test('locks and revalidates supplier references before inserting offer items', async () => {
+    exec.enqueue({ rows: [['sqi-1', 'sq-1']] });
+    exec.enqueue({ rows: [['sq-1']] });
+    exec.enqueue({ rows: [['sqi-1', 'sq-1']] });
+    exec.enqueue({ rows: [itemRow()] });
+
+    await clientOffersRepo.insertItems(
+      'co-1',
+      [
+        {
+          id: 'coi-1',
+          productId: 'p-1',
+          productName: 'Widget',
+          quantity: 2,
+          unitPrice: 10,
+          productCost: 5,
+          productMolPercentage: null,
+          discount: 0,
+          note: null,
+          supplierQuoteId: 'sq-1',
+          supplierQuoteItemId: 'sqi-1',
+          supplierQuoteSupplierName: 'Vendor',
+          supplierQuoteUnitPrice: 5,
+          unitType: 'unit',
+          durationMonths: 1,
+          durationUnit: 'months',
+        },
+      ],
+      testDb,
+    );
+
+    expect(exec.calls[1].sql.toLowerCase()).toContain('for key share');
+    expect(exec.calls[3].sql.toLowerCase()).toContain('insert into "customer_offer_items"');
+  });
 });
 
 describe('replaceItems', () => {

--- a/server/test/repositories/clientQuotesRepo.test.ts
+++ b/server/test/repositories/clientQuotesRepo.test.ts
@@ -494,7 +494,7 @@ describe('replaceItems', () => {
     expect(exec.calls[0].sql.toLowerCase()).toContain('from "quote_candidates"');
     expect(exec.calls[1].sql.toLowerCase()).toContain('delete from "quote_items"');
     expect(exec.calls[1].sql.toLowerCase()).toContain('"candidate_id" is null');
-    expect(exec.calls[3].sql.toLowerCase()).toContain('for key share');
+    expect(exec.calls[3].sql.toLowerCase()).toContain('for update');
     expect(exec.calls[5].sql.toLowerCase()).toContain('insert into "quote_items"');
     expect(exec.calls[5].params).toContain('a');
     expect(exec.calls[5].params).toContain('b');

--- a/server/test/repositories/clientQuotesRepo.test.ts
+++ b/server/test/repositories/clientQuotesRepo.test.ts
@@ -445,7 +445,11 @@ describe('replaceItems', () => {
     exec.enqueue({ rows: [] });
     exec.enqueue({ rows: [['sqi-1', 'sq-1']] });
     exec.enqueue({ rows: [['sq-1']] });
-    exec.enqueue({ rows: [['sqi-1', 'sq-1']] });
+    exec.enqueue({
+      rows: [
+        ['sqi-1', 'sq-1', 'Vendor', 'p-1', '4', 2, '2999-12-31', null, null, null, null, null],
+      ],
+    });
     exec.enqueue({
       rows: [itemRow({ 0: 'b', 18: 1 }), itemRow({ 0: 'a', 18: 0 })],
     });

--- a/server/test/repositories/clientQuotesRepo.test.ts
+++ b/server/test/repositories/clientQuotesRepo.test.ts
@@ -443,6 +443,9 @@ describe('replaceItems', () => {
   test('issues DELETE then bulk INSERT and preserves order', async () => {
     exec.enqueue({ rows: [['cq-1']] });
     exec.enqueue({ rows: [] });
+    exec.enqueue({ rows: [['sqi-1', 'sq-1']] });
+    exec.enqueue({ rows: [['sq-1']] });
+    exec.enqueue({ rows: [['sqi-1', 'sq-1']] });
     exec.enqueue({
       rows: [itemRow({ 0: 'b', 18: 1 }), itemRow({ 0: 'a', 18: 0 })],
     });
@@ -487,13 +490,14 @@ describe('replaceItems', () => {
       },
     ];
     const result = await clientQuotesRepo.replaceItems('cq-1', items, testDb);
-    expect(exec.calls).toHaveLength(3);
+    expect(exec.calls).toHaveLength(6);
     expect(exec.calls[0].sql.toLowerCase()).toContain('from "quote_candidates"');
     expect(exec.calls[1].sql.toLowerCase()).toContain('delete from "quote_items"');
     expect(exec.calls[1].sql.toLowerCase()).toContain('"candidate_id" is null');
-    expect(exec.calls[2].sql.toLowerCase()).toContain('insert into "quote_items"');
-    expect(exec.calls[2].params).toContain('a');
-    expect(exec.calls[2].params).toContain('b');
+    expect(exec.calls[3].sql.toLowerCase()).toContain('for key share');
+    expect(exec.calls[5].sql.toLowerCase()).toContain('insert into "quote_items"');
+    expect(exec.calls[5].params).toContain('a');
+    expect(exec.calls[5].params).toContain('b');
     expect(result.map((i) => i.id)).toEqual(['a', 'b']);
   });
 

--- a/server/test/repositories/clientsOrdersRepo.test.ts
+++ b/server/test/repositories/clientsOrdersRepo.test.ts
@@ -285,7 +285,7 @@ describe('insertItems / replaceItems', () => {
       testDb,
     );
 
-    expect(exec.calls[1].sql.toLowerCase()).toContain('for key share');
+    expect(exec.calls[1].sql.toLowerCase()).toContain('for update');
     expect(exec.calls[3].sql.toLowerCase()).toContain('insert into "sale_items"');
   });
 

--- a/server/test/repositories/clientsOrdersRepo.test.ts
+++ b/server/test/repositories/clientsOrdersRepo.test.ts
@@ -268,7 +268,11 @@ describe('insertItems / replaceItems', () => {
   test('locks and revalidates supplier references before inserting order items', async () => {
     exec.enqueue({ rows: [['sqi-1', 'sq-1']] });
     exec.enqueue({ rows: [['sq-1']] });
-    exec.enqueue({ rows: [['sqi-1', 'sq-1']] });
+    exec.enqueue({
+      rows: [
+        ['sqi-1', 'sq-1', 'Vendor', 'p-1', '2', 2, '2999-12-31', null, null, null, null, null],
+      ],
+    });
     exec.enqueue({ rows: [itemRow()] });
 
     await repo.insertItems(

--- a/server/test/repositories/clientsOrdersRepo.test.ts
+++ b/server/test/repositories/clientsOrdersRepo.test.ts
@@ -265,6 +265,30 @@ describe('insertItems / replaceItems', () => {
     expect(exec.calls).toHaveLength(0);
   });
 
+  test('locks and revalidates supplier references before inserting order items', async () => {
+    exec.enqueue({ rows: [['sqi-1', 'sq-1']] });
+    exec.enqueue({ rows: [['sq-1']] });
+    exec.enqueue({ rows: [['sqi-1', 'sq-1']] });
+    exec.enqueue({ rows: [itemRow()] });
+
+    await repo.insertItems(
+      'co-1',
+      [
+        {
+          ...sampleItem,
+          supplierQuoteId: 'sq-1',
+          supplierQuoteItemId: 'sqi-1',
+          supplierQuoteSupplierName: 'Vendor',
+          supplierQuoteUnitPrice: 2,
+        },
+      ],
+      testDb,
+    );
+
+    expect(exec.calls[1].sql.toLowerCase()).toContain('for key share');
+    expect(exec.calls[3].sql.toLowerCase()).toContain('insert into "sale_items"');
+  });
+
   test('replaceItems issues DELETE then INSERT', async () => {
     exec.enqueue({ rows: [] });
     exec.enqueue({ rows: [itemRow()] });

--- a/server/test/repositories/supplierQuotesRepo.test.ts
+++ b/server/test/repositories/supplierQuotesRepo.test.ts
@@ -246,28 +246,21 @@ describe('findLinkedOrderId', () => {
 });
 
 describe('isSourcedByClientDocuments', () => {
-  // Three parallel probes in call order: quote_items, customer_offer_items, sale_items — each
-  // matching either the denormalized supplier_quote_id or (legacy rows) the item-id subquery.
   test('true when any client line references the quote', async () => {
-    exec.enqueue({ rows: [['qi-1']] });
-    exec.enqueue({ rows: [] });
-    exec.enqueue({ rows: [] });
+    exec.enqueue({ rows: [{ exists: true }] });
     expect(await supplierQuotesRepo.isSourcedByClientDocuments('q-1', testDb)).toBe(true);
-    const sqlTexts = exec.calls.map((c) => c.sql.toLowerCase());
-    expect(sqlTexts[0]).toContain('"quote_items"');
-    expect(sqlTexts[1]).toContain('"customer_offer_items"');
-    expect(sqlTexts[2]).toContain('"sale_items"');
-    for (const sqlText of sqlTexts) {
-      expect(sqlText).toContain('"supplier_quote_id" =');
-      expect(sqlText).toContain('"supplier_quote_item_id" in (select');
-    }
+    expect(exec.calls).toHaveLength(1);
+    const sqlText = exec.calls[0].sql.toLowerCase();
+    expect(sqlText).toContain('from quote_items');
+    expect(sqlText).toContain('from customer_offer_items');
+    expect(sqlText).toContain('from sale_items');
+    expect(sqlText).toContain('supplier_quote_id =');
+    expect(sqlText).toContain('supplier_quote_item_id in (select');
     expect(exec.calls[0].params).toContain('q-1');
   });
 
   test('false when nothing references the quote', async () => {
-    exec.enqueue({ rows: [] });
-    exec.enqueue({ rows: [] });
-    exec.enqueue({ rows: [] });
+    exec.enqueue({ rows: [{ exists: false }] });
     expect(await supplierQuotesRepo.isSourcedByClientDocuments('q-1', testDb)).toBe(false);
   });
 });
@@ -532,28 +525,21 @@ describe('hasClientSyncedCosts', () => {
 });
 
 describe('findSourcedItemIds', () => {
-  // Three parallel DISTINCT probes in call order: quote_items, customer_offer_items, sale_items —
-  // each restricted to supplier_quote_item_id values belonging to this quote's items.
   test('unions the referenced item ids across the three client tables', async () => {
-    exec.enqueue({ rows: [['sqi-1']] });
-    exec.enqueue({ rows: [] });
-    exec.enqueue({ rows: [['sqi-2'], [null]] });
+    exec.enqueue({ rows: [{ itemId: 'sqi-1' }, { itemId: 'sqi-2' }] });
     const result = await supplierQuotesRepo.findSourcedItemIds('q-1', testDb);
     expect(result).toEqual(new Set(['sqi-1', 'sqi-2']));
-    const sqlTexts = exec.calls.map((c) => c.sql.toLowerCase());
-    expect(sqlTexts[0]).toContain('"quote_items"');
-    expect(sqlTexts[1]).toContain('"customer_offer_items"');
-    expect(sqlTexts[2]).toContain('"sale_items"');
-    for (const sqlText of sqlTexts) {
-      expect(sqlText).toContain('distinct');
-      expect(sqlText).toContain('"supplier_quote_item_id" in (select');
-    }
+    expect(exec.calls).toHaveLength(1);
+    const sqlText = exec.calls[0].sql.toLowerCase();
+    expect(sqlText).toContain('from quote_items');
+    expect(sqlText).toContain('from customer_offer_items');
+    expect(sqlText).toContain('from sale_items');
+    expect(sqlText).toContain('select distinct item_id');
+    expect(sqlText).toContain('supplier_quote_item_id in (select');
     expect(exec.calls[0].params).toContain('q-1');
   });
 
   test('empty set when nothing references the items', async () => {
-    exec.enqueue({ rows: [] });
-    exec.enqueue({ rows: [] });
     exec.enqueue({ rows: [] });
     expect(await supplierQuotesRepo.findSourcedItemIds('q-1', testDb)).toEqual(new Set());
   });
@@ -771,6 +757,62 @@ describe('lockEffectiveStatusById', () => {
   test('returns null when row missing', async () => {
     exec.enqueue({ rows: [] });
     expect(await supplierQuotesRepo.lockEffectiveStatusById('q-x', testDb)).toBeNull();
+  });
+});
+
+describe('lockClientDocumentSupplierReferences', () => {
+  test('locks quote rows in deterministic order and revalidates item membership', async () => {
+    exec.enqueue({
+      rows: [
+        ['sqi-1', 'q-2'],
+        ['sqi-2', 'q-1'],
+      ],
+    });
+    exec.enqueue({ rows: [['q-1'], ['q-2']] });
+    exec.enqueue({
+      rows: [
+        ['sqi-1', 'q-2'],
+        ['sqi-2', 'q-1'],
+      ],
+    });
+
+    await supplierQuotesRepo.lockClientDocumentSupplierReferences(
+      [
+        { supplierQuoteId: 'q-2', supplierQuoteItemId: 'sqi-1' },
+        { supplierQuoteId: null, supplierQuoteItemId: 'sqi-2' },
+      ],
+      testDb,
+    );
+
+    expect(exec.calls).toHaveLength(3);
+    expect(exec.calls[1].sql.toLowerCase()).toContain('for key share');
+    expect(exec.calls[1].sql.toLowerCase()).toContain('order by "supplier_quotes"."id"');
+    expect(exec.calls[1].params).toEqual(['q-1', 'q-2']);
+  });
+
+  test('refuses a source item deleted before the client write can lock it', async () => {
+    exec.enqueue({ rows: [] });
+
+    expect(
+      supplierQuotesRepo.lockClientDocumentSupplierReferences(
+        [{ supplierQuoteId: 'q-1', supplierQuoteItemId: 'missing-item' }],
+        testDb,
+      ),
+    ).rejects.toMatchObject({ statusCode: 409 });
+    expect(exec.calls).toHaveLength(1);
+  });
+
+  test('refuses an item that changes quote membership while waiting for the lock', async () => {
+    exec.enqueue({ rows: [['sqi-1', 'q-1']] });
+    exec.enqueue({ rows: [['q-1']] });
+    exec.enqueue({ rows: [['sqi-1', 'q-2']] });
+
+    expect(
+      supplierQuotesRepo.lockClientDocumentSupplierReferences(
+        [{ supplierQuoteId: 'q-1', supplierQuoteItemId: 'sqi-1' }],
+        testDb,
+      ),
+    ).rejects.toMatchObject({ statusCode: 409 });
   });
 });
 

--- a/server/test/repositories/supplierQuotesRepo.test.ts
+++ b/server/test/repositories/supplierQuotesRepo.test.ts
@@ -785,7 +785,7 @@ describe('lockClientDocumentSupplierReferences', () => {
     );
 
     expect(exec.calls).toHaveLength(3);
-    expect(exec.calls[1].sql.toLowerCase()).toContain('for key share');
+    expect(exec.calls[1].sql.toLowerCase()).toContain('for update');
     expect(exec.calls[1].sql.toLowerCase()).toContain('order by "supplier_quotes"."id"');
     expect(exec.calls[1].params).toEqual(['q-1', 'q-2']);
   });
@@ -793,7 +793,7 @@ describe('lockClientDocumentSupplierReferences', () => {
   test('refuses a source item deleted before the client write can lock it', async () => {
     exec.enqueue({ rows: [] });
 
-    expect(
+    await expect(
       supplierQuotesRepo.lockClientDocumentSupplierReferences(
         [{ supplierQuoteId: 'q-1', supplierQuoteItemId: 'missing-item' }],
         testDb,
@@ -807,7 +807,7 @@ describe('lockClientDocumentSupplierReferences', () => {
     exec.enqueue({ rows: [['q-1']] });
     exec.enqueue({ rows: [['sqi-1', 'q-2']] });
 
-    expect(
+    await expect(
       supplierQuotesRepo.lockClientDocumentSupplierReferences(
         [{ supplierQuoteId: 'q-1', supplierQuoteItemId: 'sqi-1' }],
         testDb,

--- a/server/test/repositories/supplierQuotesRepo.test.ts
+++ b/server/test/repositories/supplierQuotesRepo.test.ts
@@ -73,6 +73,16 @@ const ITEM_BASE: readonly unknown[] = [
 
 const itemRow = (overrides: Record<number, unknown> = {}) => makeRow(ITEM_BASE, overrides);
 
+// getQuoteItemSnapshots projection:
+// [itemId, quoteId, supplierName, productId, unitPrice, pricingSemanticsVersion,
+//  expirationDate, linkedOrderId, linkedClientQuoteStatus, linkedClientQuoteExpiration,
+//  linkedOfferStatus, linkedOfferExpiration]
+const quoteItemSnapshotRow = (overrides: Record<number, unknown> = {}) =>
+  makeRow(
+    ['sqi-1', 'q-1', 'Acme', null, '10.5', 2, '2999-12-31', null, null, null, null, null],
+    overrides,
+  );
+
 describe('listAll', () => {
   test('issues a query with linkedOrderId correlated subquery', async () => {
     exec.enqueue({ rows: [quoteListRow({ 16: 'so-1' })] });
@@ -770,15 +780,19 @@ describe('lockClientDocumentSupplierReferences', () => {
     });
     exec.enqueue({ rows: [['q-1'], ['q-2']] });
     exec.enqueue({
-      rows: [
-        ['sqi-1', 'q-2'],
-        ['sqi-2', 'q-1'],
-      ],
+      rows: [quoteItemSnapshotRow({ 1: 'q-2' }), quoteItemSnapshotRow({ 0: 'sqi-2' })],
     });
 
     await supplierQuotesRepo.lockClientDocumentSupplierReferences(
       [
-        { supplierQuoteId: 'q-2', supplierQuoteItemId: 'sqi-1' },
+        {
+          supplierQuoteId: 'q-2',
+          supplierQuoteItemId: 'sqi-1',
+          supplierQuoteExpectedProductId: null,
+          supplierQuoteExpectedSupplierName: 'Acme',
+          supplierQuoteExpectedUnitPrice: 10.5,
+          supplierQuoteMustBeSourceable: true,
+        },
         { supplierQuoteId: null, supplierQuoteItemId: 'sqi-2' },
       ],
       testDb,
@@ -805,11 +819,51 @@ describe('lockClientDocumentSupplierReferences', () => {
   test('refuses an item that changes quote membership while waiting for the lock', async () => {
     exec.enqueue({ rows: [['sqi-1', 'q-1']] });
     exec.enqueue({ rows: [['q-1']] });
-    exec.enqueue({ rows: [['sqi-1', 'q-2']] });
+    exec.enqueue({ rows: [quoteItemSnapshotRow({ 1: 'q-2' })] });
 
     await expect(
       supplierQuotesRepo.lockClientDocumentSupplierReferences(
         [{ supplierQuoteId: 'q-1', supplierQuoteItemId: 'sqi-1' }],
+        testDb,
+      ),
+    ).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  test('refuses supplier snapshot fields that changed before the client write acquired its lock', async () => {
+    exec.enqueue({ rows: [['sqi-1', 'q-1']] });
+    exec.enqueue({ rows: [['q-1']] });
+    exec.enqueue({ rows: [quoteItemSnapshotRow({ 4: '11' })] });
+
+    await expect(
+      supplierQuotesRepo.lockClientDocumentSupplierReferences(
+        [
+          {
+            supplierQuoteId: 'q-1',
+            supplierQuoteItemId: 'sqi-1',
+            supplierQuoteExpectedProductId: null,
+            supplierQuoteExpectedSupplierName: 'Acme',
+            supplierQuoteExpectedUnitPrice: 10.5,
+          },
+        ],
+        testDb,
+      ),
+    ).rejects.toMatchObject({ statusCode: 409 });
+  });
+
+  test('refuses a fresh reference that is no longer sourceable after acquiring the lock', async () => {
+    exec.enqueue({ rows: [['sqi-1', 'q-1']] });
+    exec.enqueue({ rows: [['q-1']] });
+    exec.enqueue({ rows: [quoteItemSnapshotRow({ 7: 'so-1' })] });
+
+    await expect(
+      supplierQuotesRepo.lockClientDocumentSupplierReferences(
+        [
+          {
+            supplierQuoteId: 'q-1',
+            supplierQuoteItemId: 'sqi-1',
+            supplierQuoteMustBeSourceable: true,
+          },
+        ],
         testDb,
       ),
     ).rejects.toMatchObject({ statusCode: 409 });

--- a/server/test/routes/client-quotes.test.ts
+++ b/server/test/routes/client-quotes.test.ts
@@ -1967,11 +1967,11 @@ describe('client quote candidate-family create and update', () => {
 
   test('409s when a supplier reference changes while creating the quote', async () => {
     setupCreate();
-    cqInsertItemsMock.mockRejectedValueOnce(
-      new ConflictError(
+    cqInsertItemsMock.mockImplementationOnce(async () => {
+      throw new ConflictError(
         'A referenced supplier quote changed during the request; retry the operation',
-      ),
-    );
+      );
+    });
 
     const res = await postQuote([freshLine()]);
 

--- a/server/test/routes/client-quotes.test.ts
+++ b/server/test/routes/client-quotes.test.ts
@@ -13,6 +13,7 @@ import * as realUsersRepo from '../../repositories/usersRepo.ts';
 import * as realDocumentCodes from '../../services/documentCodes.ts';
 import * as realDocumentRevisions from '../../services/documentRevisions.ts';
 import * as realAudit from '../../utils/audit.ts';
+import { ConflictError } from '../../utils/http-errors.ts';
 import * as realPermissions from '../../utils/permissions.ts';
 import {
   installAuthMiddlewareMock,
@@ -1962,6 +1963,22 @@ describe('client quote candidate-family create and update', () => {
 
     expect(res.statusCode).toBe(400);
     expect(cqRenameMock).not.toHaveBeenCalled();
+  });
+
+  test('409s when a supplier reference changes while creating the quote', async () => {
+    setupCreate();
+    cqInsertItemsMock.mockRejectedValueOnce(
+      new ConflictError(
+        'A referenced supplier quote changed during the request; retry the operation',
+      ),
+    );
+
+    const res = await postQuote([freshLine()]);
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'A referenced supplier quote changed during the request; retry the operation',
+    });
   });
 
   test('accepts a route-safe manual code for a new quote', async () => {

--- a/server/test/routes/supplier-quotes-attachments.test.ts
+++ b/server/test/routes/supplier-quotes-attachments.test.ts
@@ -17,6 +17,7 @@ import {
   restoreAuthMiddlewareMock,
 } from '../helpers/authMiddlewareMock.ts';
 import { signToken } from '../helpers/jwt.ts';
+import { TX_SENTINEL } from '../helpers/txSentinel.ts';
 import { makeWithDbTransactionMock } from '../helpers/withDbTransactionMock.ts';
 
 const usersRepoSnap = { ...realUsersRepo };
@@ -38,6 +39,7 @@ const getRolePermissionsMock = mock();
 const sqFindByIdMock = mock();
 const sqExistsByIdMock = mock();
 const sqFindLinkedOrderIdMock = mock();
+const sqLockEffectiveStatusByIdMock = mock();
 const sqIsSourcedByClientDocumentsMock = mock();
 const sqDeleteByIdMock = mock();
 const sqDeleteByIdWithAttachmentStoredNamesMock = mock();
@@ -77,6 +79,7 @@ beforeAll(async () => {
     findById: sqFindByIdMock,
     existsById: sqExistsByIdMock,
     findLinkedOrderId: sqFindLinkedOrderIdMock,
+    lockEffectiveStatusById: sqLockEffectiveStatusByIdMock,
     isSourcedByClientDocuments: sqIsSourcedByClientDocumentsMock,
     deleteById: sqDeleteByIdMock,
     deleteByIdWithAttachmentStoredNames: sqDeleteByIdWithAttachmentStoredNamesMock,
@@ -181,6 +184,7 @@ const allMocks = [
   sqFindByIdMock,
   sqExistsByIdMock,
   sqFindLinkedOrderIdMock,
+  sqLockEffectiveStatusByIdMock,
   sqDeleteByIdMock,
   sqDeleteByIdWithAttachmentStoredNamesMock,
   sqaListForQuoteMock,
@@ -218,6 +222,13 @@ beforeEach(async () => {
   findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
   userHasRoleMock.mockResolvedValue(true);
   getRolePermissionsMock.mockResolvedValue(FULL_PERMS);
+  sqLockEffectiveStatusByIdMock.mockResolvedValue({
+    expirationDate: '2999-12-31',
+    linkedClientStatus: null,
+    linkedClientQuoteExpiration: null,
+    linkedOfferStatus: null,
+    linkedOfferExpiration: null,
+  });
   sqIsSourcedByClientDocumentsMock.mockResolvedValue(false);
   resetWithDbTransactionMock();
   logAuditMock.mockImplementation(async () => undefined);
@@ -685,6 +696,10 @@ describe('DELETE /api/sales/supplier-quotes/:id cleans up attachment files', () 
     });
 
     expect(res.statusCode).toBe(204);
+    expect(sqLockEffectiveStatusByIdMock).toHaveBeenCalledWith('sq-1', TX_SENTINEL);
+    expect(sqFindLinkedOrderIdMock).toHaveBeenCalledWith('sq-1', TX_SENTINEL);
+    expect(sqIsSourcedByClientDocumentsMock).toHaveBeenCalledWith('sq-1', TX_SENTINEL);
+    expect(sqDeleteByIdWithAttachmentStoredNamesMock).toHaveBeenCalledWith('sq-1', TX_SENTINEL);
     expect(deleteAttachmentMock).toHaveBeenCalledTimes(2);
     expect(deleteAttachmentMock).toHaveBeenCalledWith('abc-123.xlsx');
     expect(deleteAttachmentMock).toHaveBeenCalledWith('def-456.pdf');

--- a/server/test/routes/supplier-quotes-versions.test.ts
+++ b/server/test/routes/supplier-quotes-versions.test.ts
@@ -39,6 +39,7 @@ const getRolePermissionsMock = mock();
 const sqFindByIdMock = mock();
 const sqExistsByIdMock = mock();
 const sqFindLinkedOrderIdMock = mock();
+const sqLockEffectiveStatusByIdMock = mock();
 const sqFindFullForSnapshotMock = mock();
 const sqFindItemsForQuoteMock = mock();
 const sqFindIdConflictMock = mock();
@@ -90,6 +91,7 @@ beforeAll(async () => {
     findById: sqFindByIdMock,
     existsById: sqExistsByIdMock,
     findLinkedOrderId: sqFindLinkedOrderIdMock,
+    lockEffectiveStatusById: sqLockEffectiveStatusByIdMock,
     findFullForSnapshot: sqFindFullForSnapshotMock,
     findItemsForQuote: sqFindItemsForQuoteMock,
     findIdConflict: sqFindIdConflictMock,
@@ -225,6 +227,7 @@ const allMocks = [
   sqFindByIdMock,
   sqExistsByIdMock,
   sqFindLinkedOrderIdMock,
+  sqLockEffectiveStatusByIdMock,
   sqFindFullForSnapshotMock,
   sqFindItemsForQuoteMock,
   sqFindIdConflictMock,
@@ -254,6 +257,13 @@ beforeEach(async () => {
   findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
   userHasRoleMock.mockResolvedValue(true);
   getRolePermissionsMock.mockResolvedValue(FULL_PERMS);
+  sqLockEffectiveStatusByIdMock.mockResolvedValue({
+    expirationDate: '2999-12-31',
+    linkedClientStatus: null,
+    linkedClientQuoteExpiration: null,
+    linkedOfferStatus: null,
+    linkedOfferExpiration: null,
+  });
   resetWithDbTransactionMock();
   logAuditMock.mockImplementation(async () => undefined);
   sqvBuildSnapshotMock.mockImplementation((quote, items) => ({
@@ -442,6 +452,9 @@ describe('POST /api/sales/supplier-quotes/:id/versions/:versionId/restore', () =
     const body = JSON.parse(res.body);
     expect(body.id).toBe('sq-1');
     expect(body.items).toHaveLength(1);
+    expect(sqLockEffectiveStatusByIdMock).toHaveBeenCalledWith('sq-1', TX_SENTINEL);
+    expect(sqFindLinkedOrderIdMock).toHaveBeenCalledWith('sq-1', TX_SENTINEL);
+    expect(sqIsSourcedByClientDocumentsMock).toHaveBeenCalledWith('sq-1', TX_SENTINEL);
 
     // Pre-restore snapshot inserted with reason='restore'
     expect(sqvInsertMock).toHaveBeenCalledWith(
@@ -460,7 +473,7 @@ describe('POST /api/sales/supplier-quotes/:id/versions/:versionId/restore', () =
       }),
       TX_SENTINEL,
     );
-    expect(sqReplaceItemsMock).toHaveBeenCalled();
+    expect(sqReplaceItemsMock).toHaveBeenCalledWith('sq-1', expect.any(Array), TX_SENTINEL);
     expect(withDbTransactionMock).toHaveBeenCalled();
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({

--- a/server/test/routes/supplier-quotes.test.ts
+++ b/server/test/routes/supplier-quotes.test.ts
@@ -16,6 +16,7 @@ import {
 } from '../helpers/authMiddlewareMock.ts';
 import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
 import { signToken } from '../helpers/jwt.ts';
+import { TX_SENTINEL } from '../helpers/txSentinel.ts';
 import { makeWithDbTransactionMock } from '../helpers/withDbTransactionMock.ts';
 
 const usersRepoSnap = { ...realUsersRepo };
@@ -37,6 +38,7 @@ const clientsFindNameMock = mock();
 
 const sqFindByIdMock = mock();
 const sqFindLinkedOrderIdMock = mock();
+const sqLockEffectiveStatusByIdMock = mock();
 const sqFindIdConflictMock = mock();
 const sqFindFullForSnapshotMock = mock();
 const sqFindItemsForQuoteMock = mock();
@@ -80,6 +82,7 @@ beforeAll(async () => {
     ...supplierQuotesRepoSnap,
     findById: sqFindByIdMock,
     findLinkedOrderId: sqFindLinkedOrderIdMock,
+    lockEffectiveStatusById: sqLockEffectiveStatusByIdMock,
     findIdConflict: sqFindIdConflictMock,
     findFullForSnapshot: sqFindFullForSnapshotMock,
     findItemsForQuote: sqFindItemsForQuoteMock,
@@ -204,6 +207,7 @@ const allMocks = [
   clientsFindNameMock,
   sqFindByIdMock,
   sqFindLinkedOrderIdMock,
+  sqLockEffectiveStatusByIdMock,
   sqFindIdConflictMock,
   sqFindFullForSnapshotMock,
   sqFindItemsForQuoteMock,
@@ -231,6 +235,13 @@ beforeEach(async () => {
   findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
   userHasRoleMock.mockResolvedValue(true);
   getRolePermissionsMock.mockResolvedValue(FULL_PERMS);
+  sqLockEffectiveStatusByIdMock.mockResolvedValue({
+    expirationDate: '2999-12-31',
+    linkedClientStatus: null,
+    linkedClientQuoteExpiration: null,
+    linkedOfferStatus: null,
+    linkedOfferExpiration: null,
+  });
   resetWithDbTransactionMock();
   logAuditMock.mockImplementation(async () => undefined);
   sqvBuildSnapshotMock.mockImplementation((quote, items) => ({
@@ -570,7 +581,8 @@ describe('PUT /api/sales/supplier-quotes/:id', () => {
     expect(JSON.parse(res.body)).toEqual({
       error: 'Cannot remove supplier quote items that are used by client quotes, offers or orders',
     });
-    expect(sqFindSourcedItemIdsMock).toHaveBeenCalledWith('sq-1');
+    expect(sqLockEffectiveStatusByIdMock).toHaveBeenCalledWith('sq-1', TX_SENTINEL);
+    expect(sqFindSourcedItemIdsMock).toHaveBeenCalledWith('sq-1', TX_SENTINEL);
     expect(sqUpsertItemsMock).not.toHaveBeenCalled();
     expect(sqReplaceItemsMock).not.toHaveBeenCalled();
     expect(sqUpdateMock).not.toHaveBeenCalled();
@@ -675,7 +687,8 @@ describe('PUT /api/sales/supplier-quotes/:id', () => {
     expect(JSON.parse(res.body).error).toBe(
       'Cannot change the id of a supplier quote whose items are used by client quotes, offers or orders',
     );
-    expect(sqIsSourcedByClientDocumentsMock).toHaveBeenCalledWith('sq-1');
+    expect(sqLockEffectiveStatusByIdMock).toHaveBeenCalledWith('sq-1', TX_SENTINEL);
+    expect(sqIsSourcedByClientDocumentsMock).toHaveBeenCalledWith('sq-1', TX_SENTINEL);
     expect(sqRenameMock).not.toHaveBeenCalled();
     expect(sqUpdateMock).not.toHaveBeenCalled();
   });

--- a/server/utils/http-errors.ts
+++ b/server/utils/http-errors.ts
@@ -13,3 +13,11 @@ export class ForeignKeyError extends Error {
     this.name = 'ForeignKeyError';
   }
 }
+
+export class ConflictError extends Error {
+  readonly statusCode = 409;
+  constructor(message: string) {
+    super(message);
+    this.name = 'ConflictError';
+  }
+}


### PR DESCRIPTION
## Summary

- serialize supplier-quote destructive writes with client quote, offer, and order soft-reference inserts
- recheck linked-order and client-document guards under the same supplier-quote row lock used by update, restore, and delete
- reject client writes whose referenced supplier quote or item changed while waiting for the lock
- add regressions covering transactional guards and all three client-document writers

## Problem

DeepSec finding `praetor-other-race-condition-768d998a8c` identified a TOCTOU window: `isSourcedByClientDocuments` / `findSourcedItemIds` ran before destructive supplier quote operations, while concurrent client-document writes could add soft references after the guard and leave dead supplier quote or item identifiers.

## Implementation

Client line inserts now lock referenced supplier quote rows with deterministic `FOR KEY SHARE` ordering and revalidate item ownership before persisting. Supplier quote update, legacy restore, and delete acquire `FOR UPDATE` on the same parent row and keep final guard reads plus destructive writes in one transaction. The reverse-reference probes are consolidated into single SQL statements so transaction executors are used sequentially.

## Testing

- 310 focused backend tests passed across supplier quote routes/repositories and client quote/offer/order repositories
- `bun run --cwd server build`
- focused Biome check for all 13 changed files
- `git diff --check`
- React Doctor: 75/100 before and after (no regression)
- repository-wide Windows lint encountered checkout-wide CRLF diagnostics in unchanged files; Linux CI is the authoritative full-suite gate

## Risk and rollout

- no schema, migration, API contract, or deployment-order changes
- concurrent mutations can wait on row locks and may return a clean 409 asking the caller to retry if the source changed
- rollback is the single commit in this PR

## Documentation

No user-facing documentation change: this preserves existing API behavior while making the existing guards atomic.