### PR TITLE
invoices(perf): bound invoice item list query

### DIFF
--- a/server/repositories/invoicesRepo.ts
+++ b/server/repositories/invoicesRepo.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, ne, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, ne, sql } from 'drizzle-orm';
 import { type DbExecutor, db, executeRows, runAtomically } from '../db/drizzle.ts';
 import { invoiceItems, invoices } from '../db/schema/invoices.ts';
 import { requireDateOnly } from '../utils/date.ts';
@@ -116,8 +116,26 @@ export const listAllItems = async (exec: DbExecutor = db): Promise<InvoiceItem[]
   return rows.map(mapItem);
 };
 
+const listItemsForInvoices = async (
+  invoiceIds: string[],
+  exec: DbExecutor,
+): Promise<InvoiceItem[]> => {
+  const rows = await exec
+    .select()
+    .from(invoiceItems)
+    .where(inArray(invoiceItems.invoiceId, invoiceIds))
+    .orderBy(asc(invoiceItems.createdAt), asc(invoiceItems.id));
+  return rows.map(mapItem);
+};
+
 export const listAllWithItems = async (exec: DbExecutor = db): Promise<InvoiceWithItems[]> => {
-  const [invoiceList, items] = await Promise.all([listAll(exec), listAllItems(exec)]);
+  const invoiceList = await listAll(exec);
+  if (invoiceList.length === 0) return [];
+
+  const items = await listItemsForInvoices(
+    invoiceList.map((invoice) => invoice.id),
+    exec,
+  );
   const itemsByInvoice = new Map<string, InvoiceItem[]>();
   for (const item of items) {
     const list = itemsByInvoice.get(item.invoiceId);

--- a/server/test/repositories/invoicesRepo.test.ts
+++ b/server/test/repositories/invoicesRepo.test.ts
@@ -139,6 +139,21 @@ describe('listAllItems', () => {
 });
 
 describe('listAllWithItems', () => {
+  test('queries items only for the capped invoice ids with deterministic ordering', async () => {
+    exec.enqueue({
+      rows: [invoiceRow({ 0: 'INV-2' }), invoiceRow({ 0: 'INV-1' })],
+    });
+    exec.enqueue({ rows: [] });
+
+    await invoicesRepo.listAllWithItems(testDb);
+
+    const itemQuery = exec.calls[1];
+    expect(itemQuery.sql.toLowerCase()).toContain('where "invoice_items"."invoice_id" in');
+    expect(itemQuery.params).toContain('INV-2');
+    expect(itemQuery.params).toContain('INV-1');
+    expect(itemQuery.sql.toLowerCase()).toMatch(/order by.*"created_at".*,.*"id"/);
+  });
+
   test('groups items by invoiceId and preserves invoice order', async () => {
     exec.enqueue({
       rows: [invoiceRow({ 0: 'INV-1' }), invoiceRow({ 0: 'INV-2' })],
@@ -161,6 +176,12 @@ describe('listAllWithItems', () => {
     exec.enqueue({ rows: [] });
     const result = await invoicesRepo.listAllWithItems(testDb);
     expect(result[0].items).toEqual([]);
+  });
+
+  test('skips the item query when the capped invoice list is empty', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await invoicesRepo.listAllWithItems(testDb)).toEqual([]);
+    expect(exec.calls).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
## Summary
- Fixes DeepSec finding `praetor-other-unbounded-query-987a0e90a2` by preventing client invoice listings from loading every historical invoice item.
- Preserves the REST and MCP response shapes while making item ordering deterministic.

## Changes
- Fetches the capped invoice list before querying child rows.
- Restricts the item query to those invoice IDs using the existing `invoice_items.invoice_id` index.
- Skips the child query for an empty invoice list and orders items by creation time and ID.
- Adds regression coverage for the bounded SQL and empty-list behavior.

## Testing
- Fail before fix: `bun test server/test/repositories/invoicesRepo.test.ts` (1 expected regression failure, 44 passes)
- Pass after fix: `bun test server/test/repositories/invoicesRepo.test.ts` (46 passes)
- `bunx --bun biome check server/repositories/invoicesRepo.ts server/test/repositories/invoicesRepo.test.ts`
- `bun run typecheck`
- `bun run test:react-doctor` (75/100 before and after; expected nonzero exit from 98 pre-existing findings)
- Three consecutive clean review + simplify cycles completed on the final diff.

## Risks / Rollout
- Low risk. No schema, migration, configuration, permission, REST, or MCP contract changes.
- The query is bounded by the existing 1,000-invoice cap and uses an existing foreign-key index.
- Documentation reviewed; no updates are needed because behavior and response contracts are unchanged.

## Issues
Issue: Not linked