### PR TITLE
fix(supplier-invoices): enforce row-level locking in draft-only mutations

### DIFF
--- a/server/repositories/supplierInvoicesRepo.ts
+++ b/server/repositories/supplierInvoicesRepo.ts
@@ -293,23 +293,32 @@ export const update = async (
   if (!Object.values(patch).some((v) => v !== undefined)) {
     return findById(id, exec);
   }
-  const [row] = await exec
-    .update(supplierInvoices)
-    .set({
-      supplierId: sql`COALESCE(${patch.supplierId ?? null}, ${supplierInvoices.supplierId})`,
-      supplierName: sql`COALESCE(${patch.supplierName ?? null}, ${supplierInvoices.supplierName})`,
-      issueDate: sql`COALESCE(${patch.issueDate ?? null}::date, ${supplierInvoices.issueDate})`,
-      dueDate: sql`COALESCE(${patch.dueDate ?? null}::date, ${supplierInvoices.dueDate})`,
-      status: sql`COALESCE(${patch.status ?? null}, ${supplierInvoices.status})`,
-      subtotal: sql`COALESCE(${numericForDb(patch.subtotal) ?? null}::numeric, ${supplierInvoices.subtotal})`,
-      total: sql`COALESCE(${numericForDb(patch.total) ?? null}::numeric, ${supplierInvoices.total})`,
-      amountPaid: sql`COALESCE(${numericForDb(patch.amountPaid) ?? null}::numeric, ${supplierInvoices.amountPaid})`,
-      notes: sql`COALESCE(${patch.notes ?? null}, ${supplierInvoices.notes})`,
-      updatedAt: sql`CURRENT_TIMESTAMP`,
-    })
-    .where(eq(supplierInvoices.id, id))
-    .returning();
-  return row ? mapInvoice(row) : null;
+
+  return runAtomically(exec, async (tx) => {
+    // Lock the row before mutation so concurrent updates serialize against
+    // this write — prevents TOCTOU between a caller's pre-flight read and the
+    // actual UPDATE.
+    const locked = await lockExistingById(id, tx);
+    if (!locked) return null;
+
+    const [row] = await tx
+      .update(supplierInvoices)
+      .set({
+        supplierId: sql`COALESCE(${patch.supplierId ?? null}, ${supplierInvoices.supplierId})`,
+        supplierName: sql`COALESCE(${patch.supplierName ?? null}, ${supplierInvoices.supplierName})`,
+        issueDate: sql`COALESCE(${patch.issueDate ?? null}::date, ${supplierInvoices.issueDate})`,
+        dueDate: sql`COALESCE(${patch.dueDate ?? null}::date, ${supplierInvoices.dueDate})`,
+        status: sql`COALESCE(${patch.status ?? null}, ${supplierInvoices.status})`,
+        subtotal: sql`COALESCE(${numericForDb(patch.subtotal) ?? null}::numeric, ${supplierInvoices.subtotal})`,
+        total: sql`COALESCE(${numericForDb(patch.total) ?? null}::numeric, ${supplierInvoices.total})`,
+        amountPaid: sql`COALESCE(${numericForDb(patch.amountPaid) ?? null}::numeric, ${supplierInvoices.amountPaid})`,
+        notes: sql`COALESCE(${patch.notes ?? null}, ${supplierInvoices.notes})`,
+        updatedAt: sql`CURRENT_TIMESTAMP`,
+      })
+      .where(eq(supplierInvoices.id, id))
+      .returning();
+    return row ? mapInvoice(row) : null;
+  });
 };
 
 // Separate from update() so generic patches can't mutate the PK (issue #621). Relies on
@@ -319,17 +328,32 @@ export const rename = async (
   newId: string,
   exec: DbExecutor = db,
 ): Promise<SupplierInvoice | null> => {
-  const [row] = await exec
-    .update(supplierInvoices)
-    .set({ id: newId, updatedAt: sql`CURRENT_TIMESTAMP` })
-    .where(eq(supplierInvoices.id, currentId))
-    .returning();
-  return row ? mapInvoice(row) : null;
+  return runAtomically(exec, async (tx) => {
+    // Lock the source row so a concurrent rename or delete serializes against this
+    // mutation — prevents double-rename races.
+    const locked = await lockExistingById(currentId, tx);
+    if (!locked) return null;
+
+    const [row] = await tx
+      .update(supplierInvoices)
+      .set({ id: newId, updatedAt: sql`CURRENT_TIMESTAMP` })
+      .where(eq(supplierInvoices.id, currentId))
+      .returning();
+    return row ? mapInvoice(row) : null;
+  });
 };
 
 export const deleteById = async (id: string, exec: DbExecutor = db): Promise<boolean> => {
-  const result = await exec.delete(supplierInvoices).where(eq(supplierInvoices.id, id));
-  return (result.rowCount ?? 0) > 0;
+  return runAtomically(exec, async (tx) => {
+    // Lock before delete so a concurrent status transition (e.g. draft → paid)
+    // serializes against this deletion — prevents deleting a row that was verified
+    // as draft by a caller's pre-flight read.
+    const locked = await lockExistingById(id, tx);
+    if (!locked) return false;
+
+    const result = await tx.delete(supplierInvoices).where(eq(supplierInvoices.id, id));
+    return (result.rowCount ?? 0) > 0;
+  });
 };
 
 export type NewSupplierInvoiceItem = {

--- a/server/test/repositories/supplierInvoicesRepo.test.ts
+++ b/server/test/repositories/supplierInvoicesRepo.test.ts
@@ -45,6 +45,18 @@ const ITEM_BASE: readonly unknown[] = [
 
 const itemRow = (overrides: Record<number, unknown> = {}) => makeRow(ITEM_BASE, overrides);
 
+// lockExistingById select({...}) returns array-mode rows in Drizzle's node-postgres driver.
+// Order: [id, status, issueDate, dueDate, total, amountPaid, supplierName]
+const LOCK_ROW: unknown[] = [
+  'SINV-2026-0001',
+  'draft',
+  '2026-04-01',
+  '2026-04-30',
+  '120.60',
+  '0',
+  'Acme',
+];
+
 describe('listAll mapInvoice', () => {
   test('coerces numeric subtotal/total/amountPaid', async () => {
     exec.enqueue({ rows: [invoiceRow()] });
@@ -191,9 +203,6 @@ describe('maxSequenceForYear', () => {
 
 describe('create', () => {
   test('does NOT swallow unique-violation errors (propagates with cause preserved)', async () => {
-    // Drizzle wraps thrown driver errors in DrizzleQueryError("Failed query: ...") with the
-    // original error available via `.cause`. The repo doesn't catch - verify propagation by
-    // unwrapping the cause and inspecting the original code/constraint.
     exec.enqueue(() => {
       const err = new Error('duplicate key') as Error & { code?: string; constraint?: string };
       err.code = '23505';
@@ -253,6 +262,8 @@ describe('create', () => {
 
 describe('update', () => {
   test('binds patch values via COALESCE, WHERE id last - no id in SET (issue #621)', async () => {
+    // lockExistingById inside runAtomically — array-mode select({...})
+    exec.enqueue({ rows: [LOCK_ROW] });
     exec.enqueue({ rows: [invoiceRow()] });
     await supplierInvoicesRepo.update(
       'SINV-2026-0001',
@@ -260,19 +271,22 @@ describe('update', () => {
       testDb,
     );
     const sql = exec.calls[0].sql;
-    expect(sql).toContain('update "supplier_invoices"');
-    expect(sql).toContain('COALESCE');
-    expect(sql).toContain('CURRENT_TIMESTAMP');
-    // The SET clause must NOT touch the primary key column.
-    expect(sql).not.toMatch(/set[^"]*"id"\s*=/i);
-    expect(sql).toContain('"id" = $10');
-    expect(exec.calls[0].params).toHaveLength(10);
-    expect(exec.calls[0].params[4]).toBe('paid'); // status
-    expect(exec.calls[0].params[7]).toBe('100'); // amountPaid via numericForDb
-    expect(exec.calls[0].params[9]).toBe('SINV-2026-0001'); // where id
+    expect(sql).toContain('select');
+    expect(sql).toContain('for update');
+    // The UPDATE is the second call (call index 1)
+    const updateSql = exec.calls[1].sql;
+    expect(updateSql).toContain('update "supplier_invoices"');
+    expect(updateSql).toContain('COALESCE');
+    expect(updateSql).toContain('CURRENT_TIMESTAMP');
+    expect(updateSql).not.toMatch(/set[^"]*"id"\s*=/i);
+    expect(updateSql).toContain('"id" = $10');
+    expect(exec.calls[1].params).toHaveLength(10);
+    expect(exec.calls[1].params[4]).toBe('paid');
+    expect(exec.calls[1].params[7]).toBe('100');
+    expect(exec.calls[1].params[9]).toBe('SINV-2026-0001');
   });
 
-  test('returns null when no row updated', async () => {
+  test('returns null when lock finds no row', async () => {
     exec.enqueue({ rows: [] });
     expect(await supplierInvoicesRepo.update('SINV-X', { status: 'paid' }, testDb)).toBeNull();
   });
@@ -299,14 +313,19 @@ describe('update', () => {
 
 describe('rename', () => {
   test('issues a dedicated UPDATE that sets the id column and returns the mapped invoice', async () => {
+    // lockExistingById inside runAtomically
+    exec.enqueue({ rows: [LOCK_ROW] });
     exec.enqueue({ rows: [invoiceRow({ 0: 'SINV-2026-0002' })] });
     const result = await supplierInvoicesRepo.rename('SINV-2026-0001', 'SINV-2026-0002', testDb);
-    const sql = exec.calls[0].sql.toLowerCase();
-    expect(sql).toContain('update "supplier_invoices"');
-    expect(sql).toMatch(/set[^"]*"id"\s*=/);
-    expect(sql).toContain('current_timestamp');
-    expect(exec.calls[0].params).toContain('SINV-2026-0002'); // new id
-    expect(exec.calls[0].params).toContain('SINV-2026-0001'); // where current id
+    // Call 0 is the lock query
+    expect(exec.calls[0].sql.toLowerCase()).toContain('for update');
+    // Call 1 is the rename UPDATE
+    const renameSql = exec.calls[1].sql.toLowerCase();
+    expect(renameSql).toContain('update "supplier_invoices"');
+    expect(renameSql).toMatch(/set[^"]*"id"\s*=/);
+    expect(renameSql).toContain('current_timestamp');
+    expect(exec.calls[1].params).toContain('SINV-2026-0002');
+    expect(exec.calls[1].params).toContain('SINV-2026-0001');
     expect(result?.id).toBe('SINV-2026-0002');
   });
 
@@ -354,12 +373,15 @@ describe('replaceItems', () => {
 
 describe('deleteById', () => {
   test('returns true when row deleted', async () => {
+    // lockExistingById inside runAtomically
+    exec.enqueue({ rows: [LOCK_ROW] });
     exec.enqueue({ rows: [], rowCount: 1 });
     expect(await supplierInvoicesRepo.deleteById('SINV-2026-0001', testDb)).toBe(true);
+    expect(exec.calls[0].sql.toLowerCase()).toContain('for update');
   });
 
-  test('returns false when nothing deleted', async () => {
-    exec.enqueue({ rows: [], rowCount: 0 });
+  test('returns false when lock finds no row', async () => {
+    exec.enqueue({ rows: [] });
     expect(await supplierInvoicesRepo.deleteById('SINV-2026-9999', testDb)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Draft-only supplier invoice mutations (update(), rename(), deleteById()) now acquire a row lock (SELECT ... FOR UPDATE) inside each mutation, preventing TOCTOU race conditions when concurrent requests operate on the same invoice.

## Changes
- server/repositories/supplierInvoicesRepo.ts: Wrapped update(), rename(), and deleteById() in runAtomically + lockExistingById so the target row is locked before the actual write.
- server/test/repositories/supplierInvoicesRepo.test.ts: Updated test assertions to queue the lock response and verify FOR UPDATE SQL is emitted; added coverage for lock-failure paths (returns null/false).

## Testing
- cd server && bun test ./test/repositories/supplierInvoicesRepo.test.ts -- 29/29 pass
- cd server && bun test ./test/repositories/replaceItemsTransactional.test.ts -- 14/14 pass

## Risks / Rollout
- Low risk. All mutation code paths already run inside withDbTransaction or runAtomically in the route layer; the lock is an additional guard that serializes correctly with the existing transaction scopes.
- The lock acquires a row-level FOR UPDATE which blocks concurrent writers but does not block readers.

## Issues
- Fixes DeepSec finding praetor-other-race-condition-c5ff081b08
