### PR TITLE
server(security): refuse demo seeding in production

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,6 +34,7 @@ LOG_LEVEL=info
 # Optional demo refresh on backend startup.
 # When true, the backend provisions the demo manager/user credentials plus the canonical
 # demo business dataset. Intended for demo/test Docker stacks and reused volumes.
+# Refused outright when NODE_ENV=production.
 DEMO_SEEDING=false
 # Required whenever demo seeding runs. Use a unique value; the published legacy default is rejected.
 # Generate with: openssl rand -base64 24

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ official PG18 container layout. Do not point this compose file at an existing Po
 data volume.
 
 The compose setup defaults backend `TRUST_PROXY=1` for the bundled Caddy -> API hop.
-Set `DEMO_SEEDING=true` and a unique `DEMO_USER_PASSWORD` in `.env` when you want the stack to provision the canonical demo users and demo business data. The demo refresh fails before cleaning or reseeding demo data when the password is blank or matches the published legacy default.
+Set `DEMO_SEEDING=true` and a unique `DEMO_USER_PASSWORD` in `.env` when you want the stack to provision the canonical demo users and demo business data. The demo refresh fails before cleaning or reseeding demo data when the password is blank or matches the published legacy default, and it is refused outright when `NODE_ENV=production`.
 That refresh flow is intended for demo and test stacks, owns the canonical demo namespace,
 refreshes compatibility clients/projects/tasks, deletes financial documents and dependent
 resales backed by demo products, and resets the seeded demo users' assignments, notifications, and time entries so

--- a/deploy/.env.customer.example
+++ b/deploy/.env.customer.example
@@ -34,8 +34,9 @@ ADMIN_DEFAULT_PASSWORD=
 # `1` matches the built-in frontend proxy -> backend hop in this deployment.
 TRUST_PROXY=1
 
-# Optional demo data. Keep false for production. When enabled, set a unique demo password;
-# Praetor rejects blank values and published legacy defaults before refreshing demo data.
+# Optional demo data. Keep false for production; it is refused outright when NODE_ENV=production.
+# When enabled, set a unique demo password; Praetor rejects blank values and published legacy
+# defaults before refreshing demo data.
 DEMO_SEEDING=false
 # Generate with: openssl rand -base64 24
 DEMO_USER_PASSWORD=

--- a/docs/frontend/index.html
+++ b/docs/frontend/index.html
@@ -66,7 +66,7 @@ AI Reporting is optional. If you enable it, configure the provider + API key + m
 official PG18 container layout. Do not point this compose file at an existing PostgreSQL 17
 data volume.</p>
 <p>The compose setup defaults backend <code>TRUST_PROXY=1</code> for the bundled Caddy -&gt; API hop.
-Set <code>DEMO_SEEDING=true</code> and a unique <code>DEMO_USER_PASSWORD</code> in <code>.env</code> when you want the stack to provision the canonical demo users and demo business data. The demo refresh fails before cleaning or reseeding demo data when the password is blank or matches the published legacy default.
+Set <code>DEMO_SEEDING=true</code> and a unique <code>DEMO_USER_PASSWORD</code> in <code>.env</code> when you want the stack to provision the canonical demo users and demo business data. The demo refresh fails before cleaning or reseeding demo data when the password is blank or matches the published legacy default, and it is refused outright when <code>NODE_ENV=production</code>.
 That refresh flow is intended for demo and test stacks, owns the canonical demo namespace,
 refreshes compatibility clients/projects/tasks, deletes financial documents and dependent
 resales backed by demo products, and resets the seeded demo users' assignments, notifications, and time entries so

--- a/server/.env.example
+++ b/server/.env.example
@@ -26,6 +26,7 @@ JWT_SECRET=change-me-long-random-jwt-secret
 # Optional demo refresh on startup.
 # When true, the backend provisions the demo manager/user credentials plus the canonical
 # demo business dataset. Intended for demo/test environments and reused demo volumes.
+# Refused outright when NODE_ENV=production.
 DEMO_SEEDING=false
 # Required whenever demo seeding runs. Use a unique value; the published legacy default is rejected.
 # Generate with: openssl rand -base64 24

--- a/server/db/demoSeed.ts
+++ b/server/db/demoSeed.ts
@@ -37,6 +37,19 @@ import pool from './index.ts';
 
 const logger = createChildLogger({ module: 'db:demo-seed' });
 
+// Demo seeding provisions shared demo accounts (manager, user, and the top_manager `topmanager`)
+// that all share one credential, so refuse to run it in production even if DEMO_SEEDING is toggled
+// on by mistake.
+export const assertDemoSeedingAllowedForEnvironment = (
+  nodeEnv: string | undefined = process.env.NODE_ENV,
+): void => {
+  if (nodeEnv?.trim().toLowerCase() === 'production') {
+    throw new Error(
+      'Demo seeding is disabled when NODE_ENV=production because it provisions shared demo accounts. Unset DEMO_SEEDING or run outside production.',
+    );
+  }
+};
+
 const DEMO_SEED_MARKER = '-- Refreshable demo dataset.';
 const seedPath = new URL('./seed.sql', import.meta.url);
 
@@ -1423,6 +1436,8 @@ export const runDemoSeedRefresh = async ({
 }: {
   source: DemoSeedSource;
 }): Promise<DemoSeedResult> => {
+  // Fail fast before touching the database: refuse production outright.
+  assertDemoSeedingAllowedForEnvironment();
   const demoUserPassword = readRequiredNonDefaultEnv(
     'DEMO_USER_PASSWORD',
     INSECURE_DEFAULT_DEMO_USER_PASSWORDS,

--- a/server/test/db/demoSeed.test.ts
+++ b/server/test/db/demoSeed.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import type { PoolClient } from 'pg';
 import {
+  assertDemoSeedingAllowedForEnvironment,
   assertNoDemoDocumentIdConflicts,
   cleanupDemoNamespace,
   insertCompatibilityDefaults,
@@ -740,5 +741,22 @@ describe('DEMO_USERS HR profiles', () => {
         expect(user.hireDate <= user.terminationDate).toBe(true);
       }
     }
+  });
+});
+
+describe('assertDemoSeedingAllowedForEnvironment', () => {
+  test('refuses to seed shared demo accounts in production', () => {
+    expect(() => assertDemoSeedingAllowedForEnvironment('production')).toThrow(
+      /NODE_ENV=production/,
+    );
+    expect(() => assertDemoSeedingAllowedForEnvironment(' Production ')).toThrow(
+      /NODE_ENV=production/,
+    );
+  });
+
+  test('allows demo seeding outside production', () => {
+    expect(() => assertDemoSeedingAllowedForEnvironment('development')).not.toThrow();
+    expect(() => assertDemoSeedingAllowedForEnvironment('test')).not.toThrow();
+    expect(() => assertDemoSeedingAllowedForEnvironment(undefined)).not.toThrow();
   });
 });

--- a/server/test/db/demoSeedTransaction.test.ts
+++ b/server/test/db/demoSeedTransaction.test.ts
@@ -122,6 +122,27 @@ beforeEach(() => {
 });
 
 describe('demo seed transaction finalization', () => {
+  test('refuses to seed in production before reading the password or touching the database', async () => {
+    const originalNodeEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+
+    try {
+      await expect(demoSeed.runDemoSeedRefresh({ source: 'startup' })).rejects.toThrow(
+        /NODE_ENV=production/,
+      );
+    } finally {
+      if (originalNodeEnv === undefined) {
+        delete process.env.NODE_ENV;
+      } else {
+        process.env.NODE_ENV = originalNodeEnv;
+      }
+    }
+
+    expect(bcryptHashMock).not.toHaveBeenCalled();
+    expect(ensureBootstrapAdminMock).not.toHaveBeenCalled();
+    expect(connectMock).not.toHaveBeenCalled();
+  });
+
   test('refuses to seed without an operator-provided demo password', async () => {
     delete process.env[DEMO_PASSWORD_ENV];
 


### PR DESCRIPTION
## Summary
- Demo seeding provisions shared demo accounts — including the `top_manager` user `topmanager` — that all authenticate with a single credential.
- The known-password exposure (a committed bcrypt hash for `password`) was already closed on `main` by requiring a non-default `DEMO_USER_PASSWORD`. This PR closes the remaining gap from the finding: demo seeding could still run in a **production** deployment if `DEMO_SEEDING` was toggled on by mistake.

## Changes
- `server/db/demoSeed.ts`: add `assertDemoSeedingAllowedForEnvironment` and call it at the very start of `runDemoSeedRefresh`, so the refresh fails fast when `NODE_ENV=production` — before reading the password or opening a DB connection.
- Document the production refusal across `.env.example`, `server/.env.example`, `deploy/.env.customer.example`, `README.md`, and the generated frontend docs page.
- Add a unit test for the guard (production vs development/test/undefined, case/whitespace tolerant) and an end-to-end transaction test asserting the refresh aborts in production before any password/DB work.

## Testing
- `bun test test/db/demoSeed.test.ts test/db/demoSeedTransaction.test.ts` (from `server/`) — 37 pass.
- `bun run typecheck` — pass.

## Risks / Rollout
- Behavior change: `runDemoSeedRefresh` now throws when `NODE_ENV=production`, even if `DEMO_SEEDING=true`. Default deployments keep `DEMO_SEEDING=false` and are unaffected; non-production demo/test stacks are unaffected.
- No schema/migration changes.

## Issues
Issue: Not linked — resolves DeepSec finding `praetor-secrets-exposure-068b364352` (production fail-fast portion; the shared-password portion was already resolved on `main`).
