### PR TITLE
reports(security): gate AI client contact details

### DIFF
--- a/docs-site/src/content/docs/ai-reporting.md
+++ b/docs-site/src/content/docs/ai-reporting.md
@@ -52,6 +52,8 @@ AI Reporting costruisce per ogni richiesta un dataset aggiornato e limitato ai p
 
 Le sezioni non autorizzate non vengono inserite nel contesto AI. Se la domanda riguarda un'area specifica, Praetor carica soltanto le sezioni pertinenti; una richiesta di panoramica usa tutte quelle disponibili. Gli importi dei documenti con righe a durata includono il valore visualizzato come moltiplicatore, senza conversioni tra mesi e anni; i documenti storici conservano invece il contratto di calcolo attivo quando sono stati salvati. Per i preventivi con più candidati viene analizzato il candidato selezionato oppure il primo candidato attivo.
 
+Nel dataset clienti, nome del contatto, email, telefono e indirizzo sono inclusi solo con `crm.clients.view`. Gli altri permessi che rendono disponibile la sezione clienti, ad esempio quelli per consuntivi, progetti o documenti commerciali, rispettano l'ambito clienti già autorizzato ma non espongono questi dettagli anagrafici.
+
 Nel dataset fornitori, i dettagli dell'anagrafica sono inclusi solo con `crm.suppliers_all.view`. Con un permesso base fornitori o con la sola visualizzazione di documenti fornitore, AI Reporting e lo strumento MCP `praetor_list_suppliers` ricevono soltanto identificativo, nome e stato del fornitore.
 
 ## Visualizzazioni interattive

--- a/docs-site/src/content/docs/en/ai-reporting.md
+++ b/docs-site/src/content/docs/en/ai-reporting.md
@@ -52,6 +52,8 @@ For every request, AI Reporting builds a fresh dataset restricted to the view pe
 
 Unauthorized sections are never added to the AI context. When a question targets one area, Praetor loads only the relevant sections; an overview request uses every available section. Document totals for duration-based lines use the displayed value as their multiplier without converting months and years; historical documents retain the calculation contract that was active when they were saved. For quotes with multiple candidates, reporting analyzes the selected candidate or the first active candidate.
 
+Within the client dataset, contact name, email, phone, and address are included only with `crm.clients.view`. Other permissions that make the client section available, such as timesheet, project, or commercial-document permissions, preserve the already authorized client row scope without exposing these master-data details.
+
 Within the supplier dataset, master-data details are included only with `crm.suppliers_all.view`. With a base supplier permission or supplier-document view permission alone, AI Reporting and the `praetor_list_suppliers` MCP tool receive only the supplier identifier, name, and status.
 
 ## Interactive visualizations

--- a/server/repositories/reportsClientsRepo.ts
+++ b/server/repositories/reportsClientsRepo.ts
@@ -13,10 +13,10 @@ type ClientRow = {
   name: string | null;
   client_code: string | null;
   type: string | null;
-  contact_name: string | null;
-  email: string | null;
-  phone: string | null;
-  address: string | null;
+  contact_name?: string | null;
+  email?: string | null;
+  phone?: string | null;
+  address?: string | null;
   is_disabled: boolean | null;
 };
 
@@ -25,6 +25,7 @@ export type ClientsSectionOptions = {
   fromDate: string;
   toDate: string;
   canViewAllClients: boolean;
+  canViewClientDetails: boolean;
   canViewQuotes: boolean;
   canViewOffers: boolean;
   canViewOrders: boolean;
@@ -40,10 +41,10 @@ export type ClientInfo = {
   name: string;
   clientCode: string;
   type: string;
-  contactName: string;
-  email: string;
-  phone: string;
-  address: string;
+  contactName?: string;
+  email?: string;
+  phone?: string;
+  address?: string;
   isDisabled: boolean;
 };
 
@@ -76,6 +77,7 @@ export const getClientsSection = async (
     fromDate,
     toDate,
     canViewAllClients,
+    canViewClientDetails,
     canViewQuotes,
     canViewOffers,
     canViewOrders,
@@ -85,6 +87,10 @@ export const getClientsSection = async (
     allowedTimesheetUserIds,
     itemsLimit,
   } = opts;
+
+  const clientDetailsSelect = canViewClientDetails
+    ? sql`, c.contact_name, c.email, c.phone, c.address`
+    : sql``;
 
   const countQuery = canViewAllClients
     ? executeRows<{ count: string }>(exec, sql`SELECT COUNT(*) as count FROM clients`)
@@ -104,11 +110,8 @@ export const getClientsSection = async (
               c.name,
               c.client_code,
               c.type,
-              c.contact_name,
-              c.email,
-              c.phone,
-              c.address,
               c.is_disabled
+              ${clientDetailsSelect}
              FROM clients c
             ORDER BY c.name ASC
             LIMIT ${itemsLimit}`,
@@ -120,11 +123,8 @@ export const getClientsSection = async (
               c.name,
               c.client_code,
               c.type,
-              c.contact_name,
-              c.email,
-              c.phone,
-              c.address,
               c.is_disabled
+              ${clientDetailsSelect}
              FROM clients c
              JOIN user_clients uc ON uc.client_id = c.id
             WHERE uc.user_id = ${viewerId}
@@ -139,11 +139,15 @@ export const getClientsSection = async (
     name: toDbText(r.name),
     clientCode: toDbText(r.client_code),
     type: toDbText(r.type),
-    contactName: toDbText(r.contact_name),
-    email: toDbText(r.email),
-    phone: toDbText(r.phone),
-    address: toDbText(r.address),
     isDisabled: Boolean(r.is_disabled),
+    ...(canViewClientDetails
+      ? {
+          contactName: toDbText(r.contact_name),
+          email: toDbText(r.email),
+          phone: toDbText(r.phone),
+          address: toDbText(r.address),
+        }
+      : {}),
   }));
 
   const clientIds = items.flatMap((i) => (i.id ? [i.id] : []));

--- a/server/routes/reports.ts
+++ b/server/routes/reports.ts
@@ -1775,12 +1775,14 @@ export const buildBusinessDataset = async (
       addGrantedPermissions(request, clientListPermissions, permissionsApplied);
 
       const canViewAllClients = hasPermission(request, 'crm.clients_all.view');
+      const canViewClientDetails = hasPermission(request, 'crm.clients.view');
       dataset.clients = await reportsClientsRepo.getClientsSection(
         {
           viewerId,
           fromDate,
           toDate,
           canViewAllClients,
+          canViewClientDetails,
           canViewQuotes,
           canViewOffers: canViewClientOffers,
           canViewOrders,

--- a/server/test/repositories/reportsClientsRepo.test.ts
+++ b/server/test/repositories/reportsClientsRepo.test.ts
@@ -17,6 +17,7 @@ const baseOpts = {
   fromDate: FROM,
   toDate: TO,
   canViewAllClients: true,
+  canViewClientDetails: true,
   canViewOffers: false,
   canViewQuotes: false,
   canViewOrders: false,
@@ -74,6 +75,44 @@ describe('getClientsSection', () => {
         email: 'j@a.co',
         phone: '+1',
         address: '1 St',
+        isDisabled: false,
+      },
+    ]);
+  });
+
+  test('omits client contact details without crm.clients.view', async () => {
+    exec.enqueue({ rows: [{ count: '1' }] });
+    exec.enqueue({
+      rows: [
+        {
+          id: 'c1',
+          name: 'Acme',
+          client_code: 'AC',
+          type: 'company',
+          contact_name: 'Jane',
+          email: 'j@a.co',
+          phone: '+1',
+          address: '1 St',
+          is_disabled: false,
+        },
+      ],
+    });
+
+    const result = await repo.getClientsSection(
+      { ...baseOpts, canViewClientDetails: false },
+      testDb,
+    );
+
+    expect(exec.calls[1].sql).not.toContain('c.contact_name');
+    expect(exec.calls[1].sql).not.toContain('c.email');
+    expect(exec.calls[1].sql).not.toContain('c.phone');
+    expect(exec.calls[1].sql).not.toContain('c.address');
+    expect(result.items).toEqual([
+      {
+        id: 'c1',
+        name: 'Acme',
+        clientCode: 'AC',
+        type: 'company',
         isDisabled: false,
       },
     ]);

--- a/server/test/routes/reports.test.ts
+++ b/server/test/routes/reports.test.ts
@@ -449,6 +449,44 @@ describe('determineRequestedSections', () => {
 });
 
 describe('buildBusinessDataset modern sections', () => {
+  test('marks client details unavailable for non-CRM workflow viewers', async () => {
+    await buildBusinessDataset(
+      { user: { id: 'u1', permissions: ['timesheets.tracker.view'] } } as never,
+      AI_ENABLED_SETTINGS as never,
+      '2026-04-01',
+      '2026-07-31',
+      new Set(['clients']),
+    );
+
+    expect(getClientsSectionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        viewerId: 'u1',
+        canViewAllClients: false,
+        canViewClientDetails: false,
+      }),
+      expect.anything(),
+    );
+  });
+
+  test('marks client details available for CRM client viewers', async () => {
+    await buildBusinessDataset(
+      { user: { id: 'u1', permissions: ['crm.clients.view'] } } as never,
+      AI_ENABLED_SETTINGS as never,
+      '2026-04-01',
+      '2026-07-31',
+      new Set(['clients']),
+    );
+
+    expect(getClientsSectionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        viewerId: 'u1',
+        canViewAllClients: false,
+        canViewClientDetails: true,
+      }),
+      expect.anything(),
+    );
+  });
+
   test('loads newly available sections only when their view permissions are granted', async () => {
     getClientOffersSectionMock.mockResolvedValue({ source: 'client-offers' });
     getSupplierOrdersSectionMock.mockResolvedValue({ source: 'supplier-orders' });


### PR DESCRIPTION
## Summary
- Prevent AI reporting from exposing client contact fields to users without `crm.clients.view`.
- Keep client row scope and non-contact reporting data unchanged.

## Changes
- Pass a dedicated client-detail permission into the reporting repository.
- Avoid selecting or serializing contact name, email, phone, and address for non-CRM viewers.
- Add route and repository regression tests and document the behavior in Italian and English.

## Testing
- `bun run test:server` (4667 passed, 29 skipped, 0 failed)
- `bun run typecheck`
- `bun run docs:user`
- `bunx biome lint server/repositories/reportsClientsRepo.ts server/routes/reports.ts server/test/repositories/reportsClientsRepo.test.ts server/test/routes/reports.test.ts`
- `bun run test:react-doctor` (75/100, unchanged from baseline; exits 1 for pre-existing findings)

## Risks / Rollout
- Low-risk permission tightening limited to AI reporting client contact fields. No migration, configuration, or dependency changes.

## Issues
- DeepSec finding `praetor-acl-check-806f46e531`; no GitHub issue linked.