### PR TITLE
server(security): reject default database passwords

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,7 +7,9 @@ SERVER_IP=localhost
 # Fresh PostgreSQL 18 installs only. This compose file is not an in-place upgrade path for
 # an existing PostgreSQL 17 volume.
 POSTGRES_USER=praetor
-POSTGRES_PASSWORD=praetor
+# Replace this published placeholder with a unique value before startup.
+# Generate with: openssl rand -base64 24
+POSTGRES_PASSWORD=change-me-strong-password
 POSTGRES_DB=praetor
 
 # Application Secrets

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -406,6 +406,7 @@ jobs:
         run: |
           cp .env.example .env
           sed -i \
+            -e 's/^POSTGRES_PASSWORD=.*/POSTGRES_PASSWORD=ci-docker-stack-postgres-password/' \
             -e 's/^JWT_SECRET=.*/JWT_SECRET=ci-docker-stack-jwt-secret/' \
             -e 's/^ENCRYPTION_KEY=.*/ENCRYPTION_KEY=ci-docker-stack-encryption-key/' \
             -e 's/^ADMIN_DEFAULT_PASSWORD=.*/ADMIN_DEFAULT_PASSWORD=ci-docker-stack-admin-password/' \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,7 +88,7 @@ jobs:
         image: postgres:16
         env:
           POSTGRES_USER: praetor
-          POSTGRES_PASSWORD: praetor
+          POSTGRES_PASSWORD: ci-postgres-password
           POSTGRES_DB: praetor_test
         ports:
           - 5432:5432
@@ -121,7 +121,7 @@ jobs:
           DB_PORT: '5432'
           DB_NAME: praetor_test
           DB_USER: praetor
-          DB_PASSWORD: praetor
+          DB_PASSWORD: ci-postgres-password
         run: bun run db:migrate
 
       # Re-uses the existing readiness probe (db/readiness.ts): connects, asserts every
@@ -135,7 +135,7 @@ jobs:
           DB_PORT: '5432'
           DB_NAME: praetor_test
           DB_USER: praetor
-          DB_PASSWORD: praetor
+          DB_PASSWORD: ci-postgres-password
         run: bun run db:ready
 
       - name: Verify legacy time-entry duplicate upgrade
@@ -145,7 +145,7 @@ jobs:
           DB_PORT: '5432'
           DB_NAME: praetor_test
           DB_USER: praetor
-          DB_PASSWORD: praetor
+          DB_PASSWORD: ci-postgres-password
           RUN_TIME_ENTRY_KEY_MIGRATION_TEST: '1'
         run: bun test ./test/db/migration0121TimeEntryKeys.postgres.test.ts
 
@@ -155,7 +155,7 @@ jobs:
           PGPORT: '5432'
           PGDATABASE: praetor_test
           PGUSER: praetor
-          PGPASSWORD: praetor
+          PGPASSWORD: ci-postgres-password
         run: |
           psql --set=ON_ERROR_STOP=1 <<'SQL'
           INSERT INTO roles (id, name, is_system, is_admin)
@@ -174,7 +174,7 @@ jobs:
           DB_PORT: '5432'
           DB_NAME: praetor_test
           DB_USER: praetor
-          DB_PASSWORD: praetor
+          DB_PASSWORD: ci-postgres-password
           ADMIN_DEFAULT_PASSWORD: ci-migration-admin-password
           DEMO_USER_PASSWORD: ci-migration-demo-password
         run: bun run seed:demo

--- a/README.md
+++ b/README.md
@@ -60,6 +60,11 @@ cp .env.example .env
 docker compose up -d --build
 ```
 
+Before startup, replace `POSTGRES_PASSWORD` in `.env` with a unique generated value.
+Compose refuses an unset value, and the backend always requires an explicit database password.
+Outside explicit local development or test runtimes, it also rejects published defaults and
+placeholders.
+
 The bundled database now targets fresh PostgreSQL 18 installs and pins `PGDATA` to the
 official PG18 container layout. Do not point this compose file at an existing PostgreSQL 17
 data volume.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -20,6 +20,10 @@ Set at least:
 - `FRONTEND_URL`
 - `ADMIN_DEFAULT_PASSWORD` for a fresh installation
 
+Generate a unique `POSTGRES_PASSWORD`; do not leave the published example placeholder in place.
+The backend always requires an explicit database password and, outside explicit local
+development or test runtimes, refuses to start with a known default.
+
 Fresh installs create the bootstrap admin as `admin` with the unique password from
 `ADMIN_DEFAULT_PASSWORD`. Generate it before first startup: the backend refuses to create the
 account when the variable is blank or uses a published legacy default. An upgrade with an

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,7 +9,7 @@ x-backend-db-env: &backend-db-env
   DB_PORT: 5432
   DB_NAME: ${POSTGRES_DB:-praetor}
   DB_USER: ${POSTGRES_USER:-praetor}
-  DB_PASSWORD: ${POSTGRES_PASSWORD:-praetor}
+  DB_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
 
 services:
   # Developer compose (builds images from local source).
@@ -19,7 +19,7 @@ services:
     container_name: praetor-postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER:-praetor}
-      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-praetor}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}
       POSTGRES_DB: ${POSTGRES_DB:-praetor}
       PGDATA: /var/lib/postgresql/18/docker
     volumes:

--- a/docs-site/src/content/docs/en/getting-started.md
+++ b/docs-site/src/content/docs/en/getting-started.md
@@ -9,6 +9,8 @@ sidebar:
 
 Sign in with the credentials provided by your administrator. If your company uses LDAP or single sign-on, you may be redirected to the company identity provider before entering the platform.
 
+Before starting an installation, the operator must generate a unique database password and set it as `POSTGRES_PASSWORD` (or `DB_PASSWORD` when starting the backend directly). Praetor always requires an explicit database password; outside local runtimes configured for development or testing, it also rejects default and published placeholder values.
+
 For a new installation, the operator must generate a unique password and set it as `ADMIN_DEFAULT_PASSWORD` before first startup. Praetor does not create the `admin` account when the value is blank or matches a previously published default credential. Upgrades do not need the variable when the `admin` account already exists.
 
 When enabling the demo dataset with `DEMO_SEEDING=true`, also set a unique `DEMO_USER_PASSWORD`. The refresh stops before cleaning or reseeding demo data if the value is blank or matches the former public password. Every refresh resets demo accounts to this password without changing the dataset's deterministic identities and relationships.

--- a/docs-site/src/content/docs/getting-started.md
+++ b/docs-site/src/content/docs/getting-started.md
@@ -9,6 +9,8 @@ sidebar:
 
 Accedi con le credenziali fornite dall'amministratore. Se l'azienda usa LDAP o single sign-on, potresti essere reindirizzato al provider aziendale prima di entrare nella piattaforma.
 
+Prima di avviare un'installazione, l'operatore deve generare una password database univoca e impostarla in `POSTGRES_PASSWORD` (oppure `DB_PASSWORD` per un avvio diretto del backend). Praetor richiede sempre una password database esplicita; fuori dagli ambienti locali configurati come sviluppo o test, rifiuta anche valori predefiniti o segnaposto pubblicati.
+
 In una nuova installazione, l'operatore deve generare una password univoca e impostarla in `ADMIN_DEFAULT_PASSWORD` prima del primo avvio. Praetor non crea l'account `admin` se il valore è vuoto o corrisponde a una credenziale predefinita pubblicata in precedenza. Negli aggiornamenti, la variabile non è necessaria quando l'account `admin` esiste già.
 
 Se abiliti il dataset dimostrativo con `DEMO_SEEDING=true`, imposta anche una password univoca in `DEMO_USER_PASSWORD`. Il refresh si interrompe prima di pulire o riseminare i dati demo se il valore è vuoto o corrisponde alla vecchia password pubblica. Ogni refresh reimposta gli account demo a questa password senza cambiare le identità e le relazioni deterministiche del dataset.

--- a/docs/frontend/index.html
+++ b/docs/frontend/index.html
@@ -62,6 +62,10 @@ AI Reporting is optional. If you enable it, configure the provider + API key + m
 <pre><code class="bash"><span class="hl-0">cp</span><span class="hl-1"> </span><span class="hl-2">.env.example</span><span class="hl-1"> </span><span class="hl-2">.env</span><br/><span class="hl-0">docker</span><span class="hl-1"> </span><span class="hl-2">compose</span><span class="hl-1"> </span><span class="hl-2">up</span><span class="hl-1"> </span><span class="hl-3">-d</span><span class="hl-1"> </span><span class="hl-3">--build</span>
 </code><button type="button">Copy</button></pre>
 
+<p>Before startup, replace <code>POSTGRES_PASSWORD</code> in <code>.env</code> with a unique generated value.
+Compose refuses an unset value, and the backend always requires an explicit database password.
+Outside explicit local development or test runtimes, it also rejects published defaults and
+placeholders.</p>
 <p>The bundled database now targets fresh PostgreSQL 18 installs and pins <code>PGDATA</code> to the
 official PG18 container layout. Do not point this compose file at an existing PostgreSQL 17
 data volume.</p>

--- a/server/.env.example
+++ b/server/.env.example
@@ -15,9 +15,9 @@ DB_HOST=localhost
 DB_PORT=5432
 DB_NAME=tempo
 DB_USER=tempo
-# Required unless NODE_ENV is explicitly development or test. Production and
-# unspecified runtimes fail closed instead of using a published password.
-DB_PASSWORD=tempo
+# Always required. Outside explicit local development or test runtimes, replace this
+# published placeholder with a unique value. Generate with: openssl rand -base64 24
+DB_PASSWORD=change-me-strong-password
 
 # JWT Secret. Generate a unique high-entropy value before first startup.
 # Generate with: openssl rand -base64 32

--- a/server/bunfig.toml
+++ b/server/bunfig.toml
@@ -2,3 +2,4 @@
 # exists so Bun's bunfig.toml lookup stops here instead of inheriting the
 # project-root preload, which registers happy-dom for the frontend suite.
 [test]
+preload = ["./test/setup.ts"]

--- a/server/db/config.ts
+++ b/server/db/config.ts
@@ -1,6 +1,10 @@
 import { readFileSync } from 'node:fs';
 import type { PoolConfig } from 'pg';
 import { createChildLogger } from '../utils/logger.ts';
+import {
+  INSECURE_DEFAULT_DB_PASSWORDS,
+  readRequiredNonDefaultEnv,
+} from '../utils/runtimeConfig.ts';
 
 const logger = createChildLogger({ module: 'db/config' });
 
@@ -16,18 +20,18 @@ const envInt = (
 };
 
 const DEFAULT_DB_PORT = 5432;
-const LOCAL_DB_PASSWORD = 'praetor';
 
 const getDbPassword = (): string => {
-  const configured = process.env.DB_PASSWORD;
-  if (configured) return configured;
-
   const runtime = process.env.NODE_ENV?.trim().toLowerCase();
-  if (runtime === 'development' || runtime === 'test') return LOCAL_DB_PASSWORD;
+  if (runtime === 'development' || runtime === 'test') {
+    const password = process.env.DB_PASSWORD?.trim();
+    if (!password) throw new Error('DB_PASSWORD is required.');
+    return password;
+  }
 
-  throw new Error(
-    'DB_PASSWORD is required outside explicit development or test runtimes. Set NODE_ENV accordingly only for local use.',
-  );
+  return readRequiredNonDefaultEnv('DB_PASSWORD', INSECURE_DEFAULT_DB_PASSWORDS, {
+    missing: 'DB_PASSWORD is required.',
+  });
 };
 
 export interface DbConnectionConfig {

--- a/server/test/db/config.test.ts
+++ b/server/test/db/config.test.ts
@@ -28,6 +28,7 @@ beforeEach(() => {
     delete process.env[key];
   }
   process.env.NODE_ENV = 'test';
+  process.env.DB_PASSWORD = 'test-database-secret';
 });
 
 afterEach(() => {
@@ -42,18 +43,24 @@ afterEach(() => {
 });
 
 describe('getDbConnectionConfig', () => {
-  test('uses local defaults in the explicit test runtime', () => {
+  test('uses non-secret local connection defaults with an explicit test password', () => {
     expect(getDbConnectionConfig()).toEqual({
       host: 'localhost',
       port: 5432,
       database: 'praetor',
       user: 'praetor',
-      password: 'praetor',
+      password: 'test-database-secret',
     });
+  });
+
+  test('requires DB_PASSWORD in the explicit test runtime', () => {
+    delete process.env.DB_PASSWORD;
+    expect(() => getDbConnectionConfig()).toThrow('DB_PASSWORD is required');
   });
 
   test('requires DB_PASSWORD in production', () => {
     process.env.NODE_ENV = 'production';
+    delete process.env.DB_PASSWORD;
     expect(() => getDbConnectionConfig()).toThrow('DB_PASSWORD is required');
   });
 
@@ -63,13 +70,31 @@ describe('getDbConnectionConfig', () => {
     expect(getDbConnectionConfig().password).toBe('production-secret');
   });
 
-  test('requires DB_PASSWORD when the runtime mode is unspecified', () => {
-    delete process.env.NODE_ENV;
+  test.each([
+    'praetor',
+    'tempo',
+    'change-me-strong-password',
+  ])('rejects the published DB_PASSWORD default %s in production', (password) => {
+    process.env.NODE_ENV = 'production';
+    process.env.DB_PASSWORD = password;
+    expect(() => getDbConnectionConfig()).toThrow('DB_PASSWORD must be set to a non-default value');
+  });
+
+  test('rejects a whitespace-only DB_PASSWORD in production', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.DB_PASSWORD = '   ';
     expect(() => getDbConnectionConfig()).toThrow('DB_PASSWORD is required');
   });
 
-  test('keeps the local fallback in the explicit development runtime', () => {
+  test('requires DB_PASSWORD when the runtime mode is unspecified', () => {
+    delete process.env.NODE_ENV;
+    delete process.env.DB_PASSWORD;
+    expect(() => getDbConnectionConfig()).toThrow('DB_PASSWORD is required');
+  });
+
+  test('allows an explicitly configured local password in development', () => {
     process.env.NODE_ENV = 'development';
+    process.env.DB_PASSWORD = 'praetor';
     expect(getDbConnectionConfig().password).toBe('praetor');
   });
 

--- a/server/test/setup.ts
+++ b/server/test/setup.ts
@@ -1,0 +1,2 @@
+process.env.NODE_ENV ??= 'test';
+process.env.DB_PASSWORD ??= 'praetor-test-database-password';

--- a/server/test/utils/bootstrapAdminDeployment.test.ts
+++ b/server/test/utils/bootstrapAdminDeployment.test.ts
@@ -43,6 +43,9 @@ describe('deployment password configuration', () => {
       expect(source).not.toContain(`DB_PASSWORD: ${knownPassword}`);
       expect(source).not.toContain(`PGPASSWORD: ${knownPassword}`);
     }
+    expect(source).toContain(
+      's/^POSTGRES_PASSWORD=.*/POSTGRES_PASSWORD=ci-docker-stack-postgres-password/',
+    );
   });
 
   test.each([

--- a/server/test/utils/bootstrapAdminDeployment.test.ts
+++ b/server/test/utils/bootstrapAdminDeployment.test.ts
@@ -3,6 +3,7 @@ import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import {
   INSECURE_DEFAULT_ADMIN_PASSWORDS,
+  INSECURE_DEFAULT_DB_PASSWORDS,
   INSECURE_DEFAULT_DEMO_USER_PASSWORDS,
 } from '../../utils/runtimeConfig.ts';
 
@@ -11,6 +12,39 @@ const readRepositoryFile = (path: string): string =>
   readFileSync(join(repositoryRoot, path), 'utf8');
 
 describe('deployment password configuration', () => {
+  test.each([
+    '.env.example',
+    'server/.env.example',
+    'deploy/.env.customer.example',
+  ])('%s uses a database placeholder that runtime validation rejects', (path) => {
+    const source = readRepositoryFile(path);
+    const configuredValue = source.match(/^(?:POSTGRES|DB)_PASSWORD=(.*)$/m)?.[1].trim();
+
+    expect(configuredValue).toBeDefined();
+    expect(INSECURE_DEFAULT_DB_PASSWORDS.some((password) => password === configuredValue)).toBe(
+      true,
+    );
+  });
+
+  test.each([
+    'docker-compose.yml',
+    'deploy/docker-compose.customer.yml',
+  ])('%s requires POSTGRES_PASSWORD instead of using a fallback', (path) => {
+    const source = readRepositoryFile(path);
+
+    expect(source).toContain(`\${POSTGRES_PASSWORD:?POSTGRES_PASSWORD is required}`);
+    expect(source).not.toContain(`\${POSTGRES_PASSWORD:-`);
+  });
+
+  test('CI database services do not use a published database password', () => {
+    const source = readRepositoryFile('.github/workflows/ci.yml');
+
+    for (const knownPassword of INSECURE_DEFAULT_DB_PASSWORDS) {
+      expect(source).not.toContain(`DB_PASSWORD: ${knownPassword}`);
+      expect(source).not.toContain(`PGPASSWORD: ${knownPassword}`);
+    }
+  });
+
   test.each([
     '.env.example',
     'server/.env.example',

--- a/server/test/utils/runtimeConfig.test.ts
+++ b/server/test/utils/runtimeConfig.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, test } from 'bun:test';
 import {
   INSECURE_DEFAULT_ADMIN_PASSWORDS,
+  INSECURE_DEFAULT_DB_PASSWORDS,
   INSECURE_DEFAULT_DEMO_USER_PASSWORDS,
   INSECURE_DEFAULT_JWT_SECRETS,
   readRequiredNonDefaultEnv,
@@ -38,6 +39,14 @@ describe('runtimeConfig', () => {
     expect(INSECURE_DEFAULT_ADMIN_PASSWORDS).toEqual([
       'password',
       'change-me-strong-admin-password',
+    ]);
+  });
+
+  test('maintains the database password denylist with every published default', () => {
+    expect(INSECURE_DEFAULT_DB_PASSWORDS).toEqual([
+      'praetor',
+      'tempo',
+      'change-me-strong-password',
     ]);
   });
 

--- a/server/utils/runtimeConfig.ts
+++ b/server/utils/runtimeConfig.ts
@@ -7,6 +7,11 @@ export const INSECURE_DEFAULT_ENCRYPTION_KEYS = [
   'praetor-encryption-key-change-in-production',
   'change-me-long-random-encryption-key',
 ] as const;
+export const INSECURE_DEFAULT_DB_PASSWORDS = [
+  'praetor',
+  'tempo',
+  'change-me-strong-password',
+] as const;
 export const INSECURE_DEFAULT_ADMIN_PASSWORDS = [
   'password',
   'change-me-strong-admin-password',


### PR DESCRIPTION
## Summary
- Remove the hardcoded database-password fallback from runtime configuration.
- Reject missing passwords in every runtime and published defaults outside explicit development/test modes.
- Require `POSTGRES_PASSWORD` in developer Compose and keep deployment, CI, and bilingual docs aligned.

## Testing
- `bun test ./test/db/config.test.ts ./test/utils/runtimeConfig.test.ts ./test/utils/bootstrapAdminDeployment.test.ts ./test/db/drizzleConfig.test.ts` (50 passed)
- `bun run test:server` (4,676 passed, 29 skipped)
- `bun run typecheck`
- `bun run build`
- `bun run docs:user`
- Changed-file Biome check (6 files)
- React Doctor: 75/100 before and after; command retains the repository's 2 pre-existing errors
- Full frontend suite was attempted twice locally; Bun 1.3.14 crashed with its internal assertion on Windows before completion, so CI remains the authoritative frontend result

## Risks / Rollout
- Deployments still using a missing or published default database password must set a unique `POSTGRES_PASSWORD` before rollout.
- Direct development and test processes must now provide `DB_PASSWORD` explicitly; the server test preload supplies an isolated test value.
- No database migration or data backfill is required.

## Issues
Issue: Not linked