### PR TITLE
reports(security): protect commercial project details

### DIFF
--- a/docs-site/src/content/docs/ai-reporting.md
+++ b/docs-site/src/content/docs/ai-reporting.md
@@ -82,6 +82,10 @@ Usa i risultati come supporto all'analisi, non come sostituto dei dati ufficiali
 - Controlla sempre importi, date e riferimenti citati nella risposta.
 - Riformula la domanda se la risposta è troppo generica.
 
+## Dati avanzati delle commesse
+
+I dataset di AI reporting includono ordine collegato, offerta e ricavo di una commessa solo se il ruolo dispone del permesso `projects.details.view`. Senza questo permesso, restano disponibili i dati operativi della commessa consentiti dagli altri permessi, ma i riferimenti commerciali e il ricavo vengono omessi.
+
 ## Costi nei report
 
 Praetor calcola il costo di ogni voce di consuntivo come `durata * costo orario` con la stessa precisione decimale usata per le fatture. Il costo orario salvato sulla voce deriva dal calendario del dipendente alla data della registrazione; quando il calendario cambia, Praetor aggiorna retroattivamente le entry interessate e i relativi aggregati.

--- a/docs-site/src/content/docs/en/ai-reporting.md
+++ b/docs-site/src/content/docs/en/ai-reporting.md
@@ -82,6 +82,10 @@ Use results as analytical support, not as a replacement for official data. Befor
 - Always verify amounts, dates, and references mentioned in the answer.
 - Rephrase the question if the answer is too generic.
 
+## Advanced project data
+
+AI reporting datasets include a project's linked order, offer, and revenue only when the role has the `projects.details.view` permission. Without this permission, project operational data allowed by other permissions remains available, but commercial references and revenue are omitted.
+
 ## Cost in reports
 
 Praetor computes each time entry cost as `duration * hourly cost`, using the same currency precision as invoices. The stored hourly cost comes from the employee calendar on the entry date; changing that calendar retroactively updates affected entries and their aggregates.

--- a/server/repositories/reportsHoursRepo.ts
+++ b/server/repositories/reportsHoursRepo.ts
@@ -17,11 +17,11 @@ type ProjectRow = {
   client_id: string | null;
   client_name: string | null;
   description: string | null;
-  order_id: string | null;
-  offer_id: string | null;
+  order_id?: string | null;
+  offer_id?: string | null;
   start_date: string | null;
   end_date: string | null;
-  revenue: string | number | null;
+  revenue?: string | number | null;
   billing_type: string | null;
   billing_frequency: string | null;
   status: string | null;
@@ -208,6 +208,7 @@ export type ProjectsSectionOptions = {
   fromDate: string;
   toDate: string;
   canViewAllProjects: boolean;
+  canViewProjectDetails: boolean;
   canViewTimesheets: boolean;
   canViewAllTimesheets: boolean;
   allowedTimesheetUserIds: string[] | null;
@@ -221,11 +222,11 @@ export type ProjectInfo = {
   clientId: string;
   clientName: string;
   description: string;
-  orderId: string;
-  offerId: string;
+  orderId?: string;
+  offerId?: string;
   startDate: string;
   endDate: string;
-  revenue: number;
+  revenue?: number;
   billingType: string;
   billingFrequency: string;
   status: string;
@@ -251,12 +252,16 @@ export const getProjectsSection = async (
     fromDate,
     toDate,
     canViewAllProjects,
+    canViewProjectDetails,
     canViewTimesheets,
     canViewAllTimesheets,
     allowedTimesheetUserIds,
     itemsLimit,
     topLimit,
   } = opts;
+  const commercialProjectFieldsSql = canViewProjectDetails
+    ? sql`p.order_id, p.offer_id, p.revenue,`
+    : sql``;
 
   const summaryQuery = canViewAllProjects
     ? executeRows<{ count: string; disabled_count: string }>(
@@ -285,11 +290,9 @@ export const getProjectsSection = async (
             p.client_id,
             c.name as client_name,
             p.description,
-            p.order_id,
-            p.offer_id,
+            ${commercialProjectFieldsSql}
             p.start_date,
             p.end_date,
-            p.revenue,
             ${derivedBillingTypeSql} AS billing_type,
             p.billing_frequency,
             p.status,
@@ -308,11 +311,9 @@ export const getProjectsSection = async (
             p.client_id,
             c.name as client_name,
             p.description,
-            p.order_id,
-            p.offer_id,
+            ${commercialProjectFieldsSql}
             p.start_date,
             p.end_date,
-            p.revenue,
             ${derivedBillingTypeSql} AS billing_type,
             p.billing_frequency,
             p.status,
@@ -388,11 +389,15 @@ export const getProjectsSection = async (
       clientId: toDbText(r.client_id),
       clientName: toDbText(r.client_name),
       description: toDbText(r.description),
-      orderId: toDbText(r.order_id),
-      offerId: toDbText(r.offer_id),
+      ...(canViewProjectDetails
+        ? {
+            orderId: toDbText(r.order_id),
+            offerId: toDbText(r.offer_id),
+            revenue: parseDbNumber(r.revenue, 0),
+          }
+        : {}),
       startDate: toDbText(r.start_date),
       endDate: toDbText(r.end_date),
-      revenue: parseDbNumber(r.revenue, 0),
       billingType: toDbText(r.billing_type),
       billingFrequency: toDbText(r.billing_frequency),
       status: toDbText(r.status),

--- a/server/routes/reports.ts
+++ b/server/routes/reports.ts
@@ -18,7 +18,10 @@ import { normalizeGeminiModelPath } from '../utils/ai-models.ts';
 import { assertAuthenticated } from '../utils/auth-assert.ts';
 import { fetchLocalAi, localAiEndpointUrl, localAiHeaders } from '../utils/local-ai-endpoint.ts';
 import { generatePrefixedId } from '../utils/order-ids.ts';
-import { requestHasPermission as hasPermission } from '../utils/permissions.ts';
+import {
+  requestHasPermission as hasPermission,
+  canViewProjectDetails as hasProjectDetailsAccess,
+} from '../utils/permissions.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import { replyError } from '../utils/replyError.ts';
 import { badRequest, optionalNonEmptyString, requireNonEmptyString } from '../utils/validation.ts';
@@ -1817,12 +1820,15 @@ export const buildBusinessDataset = async (
       );
 
       const canViewAllProjects = hasPermission(request, 'projects.manage_all.view');
+      const canViewProjectDetails = hasProjectDetailsAccess(request.user?.permissions);
+      if (canViewProjectDetails) permissionsApplied.add('projects.details.view');
       const projects = await reportsHoursRepo.getProjectsSection(
         {
           viewerId,
           fromDate,
           toDate,
           canViewAllProjects,
+          canViewProjectDetails,
           canViewTimesheets,
           canViewAllTimesheets,
           allowedTimesheetUserIds,

--- a/server/test/repositories/reportsHoursRepo.test.ts
+++ b/server/test/repositories/reportsHoursRepo.test.ts
@@ -131,6 +131,7 @@ describe('getProjectsSection', () => {
         fromDate: FROM,
         toDate: TO,
         canViewAllProjects: true,
+        canViewProjectDetails: false,
         canViewTimesheets: true,
         canViewAllTimesheets: true,
         allowedTimesheetUserIds: null,
@@ -150,6 +151,7 @@ describe('getProjectsSection', () => {
         fromDate: FROM,
         toDate: TO,
         canViewAllProjects: true,
+        canViewProjectDetails: false,
         canViewTimesheets: false,
         canViewAllTimesheets: true,
         allowedTimesheetUserIds: null,
@@ -171,6 +173,7 @@ describe('getProjectsSection', () => {
         fromDate: FROM,
         toDate: TO,
         canViewAllProjects: true,
+        canViewProjectDetails: false,
         canViewTimesheets: true,
         canViewAllTimesheets: true,
         allowedTimesheetUserIds: null,
@@ -198,6 +201,7 @@ describe('getProjectsSection', () => {
         fromDate: FROM,
         toDate: TO,
         canViewAllProjects: true,
+        canViewProjectDetails: false,
         canViewTimesheets: true,
         canViewAllTimesheets: true,
         allowedTimesheetUserIds: null,
@@ -226,6 +230,7 @@ describe('getProjectsSection', () => {
         fromDate: FROM,
         toDate: TO,
         canViewAllProjects: true,
+        canViewProjectDetails: false,
         canViewTimesheets: true,
         canViewAllTimesheets: true,
         allowedTimesheetUserIds: null,
@@ -246,6 +251,7 @@ describe('getProjectsSection', () => {
         fromDate: FROM,
         toDate: TO,
         canViewAllProjects: false,
+        canViewProjectDetails: false,
         canViewTimesheets: false,
         canViewAllTimesheets: false,
         allowedTimesheetUserIds: ['u1'],
@@ -290,6 +296,7 @@ describe('getProjectsSection', () => {
         fromDate: FROM,
         toDate: TO,
         canViewAllProjects: true,
+        canViewProjectDetails: true,
         canViewTimesheets: true,
         canViewAllTimesheets: true,
         allowedTimesheetUserIds: null,
@@ -318,6 +325,55 @@ describe('getProjectsSection', () => {
         isDisabled: false,
       },
     ]);
+  });
+
+  test('omits commercial project fields without project-detail permission', async () => {
+    exec.enqueue({ rows: [{ count: '1', disabled_count: '0' }] });
+    exec.enqueue({
+      rows: [
+        {
+          id: 'p1',
+          name: 'Phoenix',
+          client_id: 'c1',
+          client_name: 'Acme',
+          description: 'desc',
+          order_id: 'o1',
+          offer_id: 'of1',
+          start_date: '2026-01-01',
+          end_date: '2026-12-31',
+          revenue: '50000',
+          billing_type: 'fixed',
+          billing_frequency: 'monthly',
+          status: 'active',
+          tipo: 'attivo',
+          is_disabled: false,
+        },
+      ],
+    });
+    exec.enqueue({ rows: [] });
+
+    const result = await repo.getProjectsSection(
+      {
+        viewerId: 'u1',
+        fromDate: FROM,
+        toDate: TO,
+        canViewAllProjects: false,
+        canViewProjectDetails: false,
+        canViewTimesheets: false,
+        canViewAllTimesheets: false,
+        allowedTimesheetUserIds: ['u1'],
+        itemsLimit: 50,
+        topLimit: 10,
+      },
+      testDb,
+    );
+
+    expect(exec.calls[1].sql).not.toContain('p.order_id');
+    expect(exec.calls[1].sql).not.toContain('p.offer_id');
+    expect(exec.calls[1].sql).not.toContain('p.revenue');
+    expect(result.items[0]).not.toHaveProperty('orderId');
+    expect(result.items[0]).not.toHaveProperty('offerId');
+    expect(result.items[0]).not.toHaveProperty('revenue');
   });
 });
 

--- a/server/test/routes/reports.test.ts
+++ b/server/test/routes/reports.test.ts
@@ -487,6 +487,26 @@ describe('buildBusinessDataset modern sections', () => {
     );
   });
 
+  test('passes project-detail visibility into the projects dataset query', async () => {
+    getProjectsSectionMock.mockResolvedValue({ topByHours: [], topByCost: [] });
+
+    await buildBusinessDataset(
+      { user: { id: 'u1', permissions: ['projects.manage.view'] } } as never,
+      AI_ENABLED_SETTINGS as never,
+      '2026-04-01',
+      '2026-07-31',
+      new Set(['projects']),
+    );
+
+    expect(getProjectsSectionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        viewerId: 'u1',
+        canViewProjectDetails: false,
+      }),
+      expect.anything(),
+    );
+  });
+
   test('loads newly available sections only when their view permissions are granted', async () => {
     getClientOffersSectionMock.mockResolvedValue({ source: 'client-offers' });
     getSupplierOrdersSectionMock.mockResolvedValue({ source: 'supplier-orders' });


### PR DESCRIPTION
## Summary
- require the shared project-detail authorization check before AI reporting can include project revenue or linked order/offer IDs
- avoid selecting commercial project columns when details access is absent and omit those fields from the dataset response
- add route/repository regression coverage and document the permission behavior in Italian and English

## Testing
- `bun test ./test/repositories/reportsHoursRepo.test.ts` (21 passed)
- `bun test ./test/routes/reports.test.ts` (88 passed)
- `bun run typecheck`
- `bunx biome check server/repositories/reportsHoursRepo.ts server/routes/reports.ts server/test/repositories/reportsHoursRepo.test.ts server/test/routes/reports.test.ts`
- `bun run docs:user`
- `bun run test:react-doctor` (75/100, unchanged from baseline; exits non-zero for existing findings)
- `bun run test` (backend: 4,666 passed; frontend aborted when Bun 1.3.14 crashed with an internal assertion under local memory pressure)

## Risks / Rollout
- Low risk and no migration required. Users without `projects.details.view` lose only the commercial fields they were not authorized to receive.

## Issues
Issue: Not linked