### PR TITLE
reports(security): restrict catalog commercial metrics

### DIFF
--- a/docs-site/src/content/docs/ai-reporting.md
+++ b/docs-site/src/content/docs/ai-reporting.md
@@ -47,7 +47,7 @@ AI Reporting costruisce per ogni richiesta un dataset aggiornato e limitato ai p
 - **Ordini cliente** e **fatture cliente** — valori, stati, incassi, insoluti e scadenzario.
 - **Fornitori** e **preventivi fornitore** — anagrafiche, attività e importi.
 - **Ordini fornitore** e **fatture fornitore** — acquisti, pagamenti, insoluti e scadenzario.
-- **Catalogo** — prodotti, tipologie, categorie, fornitori e utilizzo nei documenti.
+- **Catalogo** — prodotti, tipologie, categorie, fornitori e, quando autorizzato, utilizzo nei documenti.
 - **Rivendite** — costi, ricavi, margini, frequenze di fatturazione, categorie e stato di rilascio delle attività.
 
 Le sezioni non autorizzate non vengono inserite nel contesto AI. Se la domanda riguarda un'area specifica, Praetor carica soltanto le sezioni pertinenti; una richiesta di panoramica usa tutte quelle disponibili. Gli importi dei documenti con righe a durata includono il valore visualizzato come moltiplicatore, senza conversioni tra mesi e anni; i documenti storici conservano invece il contratto di calcolo attivo quando sono stati salvati. Per i preventivi con più candidati viene analizzato il candidato selezionato oppure il primo candidato attivo.
@@ -55,6 +55,8 @@ Le sezioni non autorizzate non vengono inserite nel contesto AI. Se la domanda r
 Nel dataset clienti, nome del contatto, email, telefono e indirizzo sono inclusi solo con `crm.clients.view`. Gli altri permessi che rendono disponibile la sezione clienti, ad esempio quelli per consuntivi, progetti o documenti commerciali, rispettano l'ambito clienti già autorizzato ma non espongono questi dettagli anagrafici.
 
 Nel dataset fornitori, i dettagli dell'anagrafica sono inclusi solo con `crm.suppliers_all.view`. Con un permesso base fornitori o con la sola visualizzazione di documenti fornitore, AI Reporting e lo strumento MCP `praetor_list_suppliers` ricevono soltanto identificativo, nome e stato del fornitore.
+
+Nel dataset catalogo, conteggi e classificazioni dei prodotti dipendono dai permessi catalogo. Le metriche di utilizzo includono invece solo i documenti cliente che il ruolo può visualizzare: preventivi con `sales.client_quotes.view`, ordini e relativi ricavi con `accounting.clients_orders.view`, fatture con `accounting.clients_invoices.view`.
 
 ## Visualizzazioni interattive
 

--- a/docs-site/src/content/docs/en/ai-reporting.md
+++ b/docs-site/src/content/docs/en/ai-reporting.md
@@ -47,7 +47,7 @@ For every request, AI Reporting builds a fresh dataset restricted to the view pe
 - **Client orders** and **client invoices** — values, statuses, payments, outstanding amounts, and aging.
 - **Suppliers** and **supplier quotes** — master data, activity, and amounts.
 - **Supplier orders** and **supplier invoices** — purchasing, payments, outstanding amounts, and aging.
-- **Catalog** — products, types, categories, suppliers, and document usage.
+- **Catalog** — products, types, categories, suppliers, and authorized document usage.
 - **Resales** — costs, revenue, margin, billing frequencies, categories, and activity release state.
 
 Unauthorized sections are never added to the AI context. When a question targets one area, Praetor loads only the relevant sections; an overview request uses every available section. Document totals for duration-based lines use the displayed value as their multiplier without converting months and years; historical documents retain the calculation contract that was active when they were saved. For quotes with multiple candidates, reporting analyzes the selected candidate or the first active candidate.
@@ -55,6 +55,8 @@ Unauthorized sections are never added to the AI context. When a question targets
 Within the client dataset, contact name, email, phone, and address are included only with `crm.clients.view`. Other permissions that make the client section available, such as timesheet, project, or commercial-document permissions, preserve the already authorized client row scope without exposing these master-data details.
 
 Within the supplier dataset, master-data details are included only with `crm.suppliers_all.view`. With a base supplier permission or supplier-document view permission alone, AI Reporting and the `praetor_list_suppliers` MCP tool receive only the supplier identifier, name, and status.
+
+Within the catalog dataset, product counts and classifications follow catalog permissions. Usage metrics include only client documents the role can view: quotes with `sales.client_quotes.view`, orders and their revenue with `accounting.clients_orders.view`, and invoices with `accounting.clients_invoices.view`.
 
 ## Interactive visualizations
 

--- a/server/repositories/reportsCatalogRepo.ts
+++ b/server/repositories/reportsCatalogRepo.ts
@@ -1,4 +1,4 @@
-import { sql } from 'drizzle-orm';
+import { type SQL, sql } from 'drizzle-orm';
 import { type DbExecutor, db, executeRows } from '../db/drizzle.ts';
 import { toDbNumber, toDbText } from '../utils/parse.ts';
 import { supplierQuoteNetValueSql } from './reportsCommercialSql.ts';
@@ -347,6 +347,9 @@ export type CatalogSectionOptions = {
   fromDate: string;
   toDate: string;
   topLimit: number;
+  canViewQuotes: boolean;
+  canViewOrders: boolean;
+  canViewInvoices: boolean;
 };
 
 export type CatalogSection = {
@@ -372,7 +375,85 @@ export const getCatalogSection = async (
   opts: CatalogSectionOptions,
   exec: DbExecutor = db,
 ): Promise<CatalogSection> => {
-  const { fromDate, toDate, topLimit } = opts;
+  const { fromDate, toDate, topLimit, canViewQuotes, canViewOrders, canViewInvoices } = opts;
+
+  const usageQueries: SQL[] = [];
+  if (canViewQuotes) {
+    usageQueries.push(sql`SELECT
+        qi.product_id,
+        qi.product_name,
+        COUNT(*) as use_count,
+        COALESCE(SUM(qi.quantity), 0) as quantity_total
+      FROM quote_items qi
+      JOIN quotes q ON q.id = qi.quote_id
+     WHERE q.created_at::date >= ${fromDate}
+       AND q.created_at::date <= ${toDate}
+       AND qi.product_id IS NOT NULL
+     GROUP BY qi.product_id, qi.product_name`);
+  }
+  if (canViewOrders) {
+    usageQueries.push(sql`SELECT
+        si.product_id,
+        si.product_name,
+        COUNT(*) as use_count,
+        COALESCE(SUM(si.quantity), 0) as quantity_total
+      FROM sale_items si
+      JOIN sales s ON s.id = si.sale_id
+     WHERE s.created_at::date >= ${fromDate}
+       AND s.created_at::date <= ${toDate}
+       AND si.product_id IS NOT NULL
+     GROUP BY si.product_id, si.product_name`);
+  }
+  if (canViewInvoices) {
+    usageQueries.push(sql`SELECT
+        ii.product_id,
+        ii.description as product_name,
+        COUNT(*) as use_count,
+        COALESCE(SUM(ii.quantity), 0) as quantity_total
+      FROM invoice_items ii
+      JOIN invoices i ON i.id = ii.invoice_id
+     WHERE i.issue_date >= ${fromDate}
+       AND i.issue_date <= ${toDate}
+       AND ii.product_id IS NOT NULL
+     GROUP BY ii.product_id, ii.description`);
+  }
+
+  const topProductsByUsageQuery =
+    usageQueries.length > 0
+      ? sql`WITH usage_rows AS (${sql.join(usageQueries, sql` UNION ALL `)})
+          SELECT
+            product_id,
+            product_name,
+            COALESCE(SUM(use_count), 0) as usage_count,
+            COALESCE(SUM(quantity_total), 0) as quantity_total
+            FROM usage_rows
+           GROUP BY product_id, product_name
+           ORDER BY usage_count DESC, quantity_total DESC
+           LIMIT ${topLimit}`
+      : null;
+
+  const topProductsByRevenueQuery = canViewOrders
+    ? sql`SELECT
+            si.product_id,
+            si.product_name,
+            COALESCE(
+              SUM(
+                si.quantity
+                * si.unit_price
+                * (1 - COALESCE(si.discount, 0) / 100.0)
+                * (1 - COALESCE(s.discount, 0) / 100.0)
+              ),
+              0
+            ) as value
+           FROM sale_items si
+           JOIN sales s ON s.id = si.sale_id
+          WHERE s.created_at::date >= ${fromDate}
+            AND s.created_at::date <= ${toDate}
+            AND si.product_id IS NOT NULL
+          GROUP BY si.product_id, si.product_name
+          ORDER BY value DESC
+          LIMIT ${topLimit}`
+    : null;
 
   const [
     counts,
@@ -422,63 +503,20 @@ export const getCatalogSection = async (
         ORDER BY value DESC
         LIMIT ${topLimit}`,
     ),
-    executeRows<{
-      product_id: string;
-      product_name: string;
-      usage_count: string;
-      quantity_total: string;
-    }>(
-      exec,
-      sql`WITH usage_rows AS (
-          SELECT qi.product_id, qi.product_name, COUNT(*) as use_count, COALESCE(SUM(qi.quantity), 0) as quantity_total
-            FROM quote_items qi
-            JOIN quotes q ON q.id = qi.quote_id
-           WHERE q.created_at::date >= ${fromDate} AND q.created_at::date <= ${toDate} AND qi.product_id IS NOT NULL
-           GROUP BY qi.product_id, qi.product_name
-          UNION ALL
-          SELECT si.product_id, si.product_name, COUNT(*) as use_count, COALESCE(SUM(si.quantity), 0) as quantity_total
-            FROM sale_items si
-            JOIN sales s ON s.id = si.sale_id
-           WHERE s.created_at::date >= ${fromDate} AND s.created_at::date <= ${toDate} AND si.product_id IS NOT NULL
-           GROUP BY si.product_id, si.product_name
-          UNION ALL
-          SELECT ii.product_id, ii.description as product_name, COUNT(*) as use_count, COALESCE(SUM(ii.quantity), 0) as quantity_total
-            FROM invoice_items ii
-            JOIN invoices i ON i.id = ii.invoice_id
-           WHERE i.issue_date >= ${fromDate} AND i.issue_date <= ${toDate} AND ii.product_id IS NOT NULL
-           GROUP BY ii.product_id, ii.description
-         )
-        SELECT
-          product_id,
-          product_name,
-          COALESCE(SUM(use_count), 0) as usage_count,
-          COALESCE(SUM(quantity_total), 0) as quantity_total
-          FROM usage_rows
-         GROUP BY product_id, product_name
-         ORDER BY usage_count DESC, quantity_total DESC
-         LIMIT ${topLimit}`,
-    ),
-    executeRows<{ product_id: string; product_name: string; value: string }>(
-      exec,
-      sql`SELECT
-          si.product_id,
-          si.product_name,
-          COALESCE(
-            SUM(
-              si.quantity
-              * si.unit_price
-              * (1 - COALESCE(si.discount, 0) / 100.0)
-              * (1 - COALESCE(s.discount, 0) / 100.0)
-            ),
-            0
-          ) as value
-         FROM sale_items si
-         JOIN sales s ON s.id = si.sale_id
-        WHERE s.created_at::date >= ${fromDate} AND s.created_at::date <= ${toDate} AND si.product_id IS NOT NULL
-        GROUP BY si.product_id, si.product_name
-        ORDER BY value DESC
-        LIMIT ${topLimit}`,
-    ),
+    topProductsByUsageQuery
+      ? executeRows<{
+          product_id: string;
+          product_name: string;
+          usage_count: string;
+          quantity_total: string;
+        }>(exec, topProductsByUsageQuery)
+      : Promise.resolve([]),
+    topProductsByRevenueQuery
+      ? executeRows<{ product_id: string; product_name: string; value: string }>(
+          exec,
+          topProductsByRevenueQuery,
+        )
+      : Promise.resolve([]),
   ]);
 
   return {

--- a/server/routes/reports.ts
+++ b/server/routes/reports.ts
@@ -1958,7 +1958,14 @@ export const buildBusinessDataset = async (
     if (canListProducts && shouldIncludeDatasetSection(requestedSections, 'catalog')) {
       includedSections.add('catalog');
       dataset.catalog = await reportsCatalogRepo.getCatalogSection(
-        { fromDate, toDate, topLimit: listLimits.top },
+        {
+          fromDate,
+          toDate,
+          topLimit: listLimits.top,
+          canViewQuotes,
+          canViewOrders,
+          canViewInvoices,
+        },
         datasetDb,
       );
     }

--- a/server/test/repositories/reportsCatalogRepo.test.ts
+++ b/server/test/repositories/reportsCatalogRepo.test.ts
@@ -12,6 +12,14 @@ beforeEach(() => {
 
 const FROM = '2026-01-01';
 const TO = '2026-01-31';
+const CATALOG_OPTIONS = {
+  fromDate: FROM,
+  toDate: TO,
+  topLimit: 10,
+  canViewQuotes: true,
+  canViewOrders: true,
+  canViewInvoices: true,
+};
 
 describe('getSuppliersSection', () => {
   test('summary + list run in parallel; activity branches skipped when no suppliers', async () => {
@@ -239,9 +247,51 @@ describe('getSupplierQuotesSection', () => {
 });
 
 describe('getCatalogSection', () => {
+  test('omits commercial queries and metrics without client document permissions', async () => {
+    exec.enqueueEmptyN(5);
+
+    const result = await repo.getCatalogSection(
+      {
+        fromDate: FROM,
+        toDate: TO,
+        topLimit: 10,
+        canViewQuotes: false,
+        canViewOrders: false,
+        canViewInvoices: false,
+      },
+      testDb,
+    );
+
+    expect(exec.calls).toHaveLength(5);
+    expect(exec.calls.some((call) => call.sql.includes('quote_items'))).toBe(false);
+    expect(exec.calls.some((call) => call.sql.includes('sale_items'))).toBe(false);
+    expect(exec.calls.some((call) => call.sql.includes('invoice_items'))).toBe(false);
+    expect(result.topProductsByUsage).toEqual([]);
+    expect(result.topProductsByRevenue).toEqual([]);
+  });
+
+  test('queries usage only from authorized client document types', async () => {
+    exec.enqueueEmptyN(6);
+
+    await repo.getCatalogSection(
+      {
+        ...CATALOG_OPTIONS,
+        canViewOrders: false,
+        canViewInvoices: false,
+      },
+      testDb,
+    );
+
+    const usageCall = exec.calls.find((call) => call.sql.includes('WITH usage_rows'));
+    expect(usageCall?.sql).toContain('quote_items');
+    expect(usageCall?.sql).not.toContain('sale_items');
+    expect(usageCall?.sql).not.toContain('invoice_items');
+    expect(usageCall?.params).toEqual([FROM, TO, 10]);
+  });
+
   test('dispatches 7 parallel queries (counts + 4 breakdowns + 2 top lists)', async () => {
     exec.enqueueEmptyN(7);
-    await repo.getCatalogSection({ fromDate: FROM, toDate: TO, topLimit: 10 }, testDb);
+    await repo.getCatalogSection(CATALOG_OPTIONS, testDb);
     expect(exec.calls).toHaveLength(7);
   });
 
@@ -250,16 +300,13 @@ describe('getCatalogSection', () => {
       rows: [{ internal_count: '5', external_count: '3', disabled_count: '1' }],
     });
     exec.enqueueEmptyN(6);
-    const result = await repo.getCatalogSection(
-      { fromDate: FROM, toDate: TO, topLimit: 10 },
-      testDb,
-    );
+    const result = await repo.getCatalogSection(CATALOG_OPTIONS, testDb);
     expect(result.productCounts).toEqual({ internal: 5, external: 3, disabled: 1 });
   });
 
   test('productsBySupplier query has [topLimit] as the only param (LIMIT $1)', async () => {
     exec.enqueueEmptyN(7);
-    await repo.getCatalogSection({ fromDate: FROM, toDate: TO, topLimit: 12 }, testDb);
+    await repo.getCatalogSection({ ...CATALOG_OPTIONS, topLimit: 12 }, testDb);
     const productsBySupplierCall = exec.calls.find((c) => c.sql.includes('LEFT JOIN suppliers'));
     expect(productsBySupplierCall?.params).toEqual([12]);
     expect(productsBySupplierCall?.sql).toContain('LIMIT $1');
@@ -267,7 +314,7 @@ describe('getCatalogSection', () => {
 
   test('top usage query binds [from, to] per UNION ALL leg + topLimit (7 params, LIMIT $7)', async () => {
     exec.enqueueEmptyN(7);
-    await repo.getCatalogSection({ fromDate: FROM, toDate: TO, topLimit: 8 }, testDb);
+    await repo.getCatalogSection({ ...CATALOG_OPTIONS, topLimit: 8 }, testDb);
     const usageCall = exec.calls.find((c) => c.sql.includes('WITH usage_rows'));
     expect(usageCall?.params).toEqual([FROM, TO, FROM, TO, FROM, TO, 8]);
     expect(usageCall?.sql).toContain('LIMIT $7');
@@ -295,10 +342,7 @@ describe('getCatalogSection', () => {
     });
     exec.enqueue({ rows: [{ product_id: 'p2', product_name: 'Gadget', value: '420' }] });
 
-    const result = await repo.getCatalogSection(
-      { fromDate: FROM, toDate: TO, topLimit: 10 },
-      testDb,
-    );
+    const result = await repo.getCatalogSection(CATALOG_OPTIONS, testDb);
     expect(result.byType).toEqual([{ label: 'service', value: 5 }]);
     expect(result.byCategory).toEqual([{ label: 'consulting', value: 4 }]);
     expect(result.bySubcategory).toEqual([{ label: 'training', value: 3 }]);

--- a/server/test/routes/reports.test.ts
+++ b/server/test/routes/reports.test.ts
@@ -450,6 +450,8 @@ describe('determineRequestedSections', () => {
 
 describe('buildBusinessDataset modern sections', () => {
   test('passes client commercial permissions into catalog aggregation', async () => {
+    getCatalogSectionMock.mockResolvedValue({});
+
     await buildBusinessDataset(
       {
         user: {
@@ -467,7 +469,7 @@ describe('buildBusinessDataset modern sections', () => {
       {
         fromDate: '2026-04-01',
         toDate: '2026-07-31',
-        topLimit: 20,
+        topLimit: 50,
         canViewQuotes: false,
         canViewOrders: false,
         canViewInvoices: true,

--- a/server/test/routes/reports.test.ts
+++ b/server/test/routes/reports.test.ts
@@ -449,6 +449,33 @@ describe('determineRequestedSections', () => {
 });
 
 describe('buildBusinessDataset modern sections', () => {
+  test('passes client commercial permissions into catalog aggregation', async () => {
+    await buildBusinessDataset(
+      {
+        user: {
+          id: 'u1',
+          permissions: ['catalog.internal_listing.view', 'accounting.clients_invoices.view'],
+        },
+      } as never,
+      AI_ENABLED_SETTINGS as never,
+      '2026-04-01',
+      '2026-07-31',
+      new Set(['catalog']),
+    );
+
+    expect(getCatalogSectionMock).toHaveBeenCalledWith(
+      {
+        fromDate: '2026-04-01',
+        toDate: '2026-07-31',
+        topLimit: 20,
+        canViewQuotes: false,
+        canViewOrders: false,
+        canViewInvoices: true,
+      },
+      expect.anything(),
+    );
+  });
+
   test('marks client details unavailable for non-CRM workflow viewers', async () => {
     await buildBusinessDataset(
       { user: { id: 'u1', permissions: ['timesheets.tracker.view'] } } as never,


### PR DESCRIPTION
## Summary
- prevent AI catalog reports from querying client quote, order, or invoice items without the matching view permission
- keep product metadata available while returning empty unauthorized commercial metric arrays
- document catalog metric permission behavior in Italian and English

## Changes
- pass client commercial permission flags into the catalog report repository
- build catalog usage SQL only from authorized document sources and gate revenue on client-order access
- add repository and route regression coverage for denied and selective access

## Testing
- `bun test server/test/repositories/reportsCatalogRepo.test.ts` (16 passed)
- `bun run typecheck` (passed)
- `bun run build` (passed)
- `bun x biome check --write server/repositories/reportsCatalogRepo.ts server/routes/reports.ts server/test/repositories/reportsCatalogRepo.test.ts server/test/routes/reports.test.ts` (passed)
- `bun run test` (incomplete: Bun 1.3.14 exhausted memory after reaching `server/test/routes/reports.test.ts`)
- `bun run lint` (workspace-wide Biome check reports 1,220 diagnostics outside the scoped files; changed TypeScript files pass targeted Biome)
- `bun run test:react-doctor` (75/100; two existing frontend findings are outside this backend/docs change)

## Review
- completed three consecutive clean code-reuse, efficiency, and quality/security review passes

## Risks / Rollout
- low risk; no schema, migration, configuration, or dependency changes

## Issues
- DeepSec finding `praetor-acl-check-d1e74ab6db`