### PR TITLE
tasks(security): validate task assignees server-side

### DIFF
--- a/docs-site/src/content/docs/crm-projects.md
+++ b/docs-site/src/content/docs/crm-projects.md
@@ -95,7 +95,7 @@ La sezione **Regole della commessa** nella pagina di dettaglio permette di crear
 
 ### Assegnazione utenti
 
-Dal comando **Assegna Utenti** gestisci chi è assegnato a una commessa o a una sua attività. L'accesso a questa finestra è governato dal permesso **Assegnazioni Progetto**: l'azione **View** consente di aprire le assegnazioni di qualsiasi commessa o attività indipendentemente dalla propria appartenenza, mentre **Update** consente di modificarle. I permessi di modifica delle attività non autorizzano la gestione delle assegnazioni. Manager e Top Manager dispongono di entrambi i permessi di assegnazione per impostazione predefinita, quindi possono gestire le assegnazioni anche quando non sono membri della commessa o dell'attività.
+Dal comando **Assegna Utenti** gestisci chi è assegnato a una commessa o a una sua attività. L'accesso a questa finestra è governato dal permesso **Assegnazioni Progetto**: l'azione **View** consente di aprire le assegnazioni di qualsiasi commessa o attività indipendentemente dalla propria appartenenza, mentre **Update** consente di modificarle. I permessi di modifica delle attività non autorizzano la gestione delle assegnazioni. Manager e Top Manager dispongono di entrambi i permessi di assegnazione per impostazione predefinita, quindi possono gestire le assegnazioni anche quando non sono membri della commessa o dell'attività. Per le attività, il server accetta soltanto utenti abilitati, visibili a chi esegue la modifica e idonei all'assegnazione; utenti disabilitati, Top Manager e utenti con il solo ruolo Admin vengono rifiutati anche nelle richieste API dirette.
 
 ## Competence Center
 

--- a/docs-site/src/content/docs/en/crm-projects.md
+++ b/docs-site/src/content/docs/en/crm-projects.md
@@ -95,7 +95,7 @@ The **Job rules** section on the detail page lets you create automatic controls 
 
 ### Assigning users
 
-The **Assign Users** command manages who is assigned to a job or one of its activities. Access to this dialog is governed by the **Project Assignments** permission: the **View** action lets a role open the assignments of any job or activity regardless of its own membership, while **Update** lets it edit them. Task-edit permissions do not grant assignment-management access. Managers and Top Managers hold both assignment permissions by default, so they can manage assignments even when they are not members of the job or activity.
+The **Assign Users** command manages who is assigned to a job or one of its activities. Access to this dialog is governed by the **Project Assignments** permission: the **View** action lets a role open the assignments of any job or activity regardless of its own membership, while **Update** lets it edit them. Task-edit permissions do not grant assignment-management access. Managers and Top Managers hold both assignment permissions by default, so they can manage assignments even when they are not members of the job or activity. For tasks, the server accepts only enabled users who are visible to the editor and eligible for assignment; disabled users, Top Managers, and admin-only users are rejected even in direct API requests.
 
 ## Competence centers
 

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -19789,7 +19789,7 @@
         "tags": [
           "tasks"
         ],
-        "description": "Requires projects.assignments.update. Task update permissions do not authorize assignment changes.",
+        "description": "Requires projects.assignments.update. Task update permissions do not authorize assignment changes. Assignees must be active, eligible users visible to the caller.",
         "requestBody": {
           "required": true,
           "content": {

--- a/server/repositories/taskAssignmentEligibilityRepo.ts
+++ b/server/repositories/taskAssignmentEligibilityRepo.ts
@@ -1,0 +1,68 @@
+import { sql } from 'drizzle-orm';
+import { type DbExecutor, db, executeRows } from '../db/drizzle.ts';
+import { ADMIN_ROLE_ID, TOP_MANAGER_ROLE_ID } from '../utils/permissions.ts';
+
+export type TaskAssigneeVisibility = {
+  viewerId: string;
+  canViewAllUsers: boolean;
+  canViewManagedUsers: boolean;
+  canViewInternal: boolean;
+  canViewExternal: boolean;
+};
+
+export const findIneligibleAssigneeIds = async (
+  userIds: string[],
+  visibility: TaskAssigneeVisibility,
+  exec: DbExecutor = db,
+): Promise<string[]> => {
+  if (userIds.length === 0) return [];
+
+  const scopedVisibility = visibility.canViewAllUsers
+    ? sql`TRUE`
+    : sql`(
+        u.id = ${visibility.viewerId}
+        OR (
+          ${visibility.canViewManagedUsers}
+          AND EXISTS (
+            SELECT 1
+            FROM user_work_units assignee_uw
+            INNER JOIN work_unit_managers viewer_wum
+              ON viewer_wum.work_unit_id = assignee_uw.work_unit_id
+            WHERE assignee_uw.user_id = u.id
+              AND viewer_wum.user_id = ${visibility.viewerId}
+          )
+        )
+        OR (${visibility.canViewInternal} AND u.employee_type IN ('app_user', 'internal'))
+        OR (${visibility.canViewExternal} AND u.employee_type = 'external')
+      )`;
+
+  const eligibleRows = await executeRows<{ id: string }>(
+    exec,
+    sql`
+      SELECT u.id
+      FROM users u
+      WHERE u.id = ANY(${sql.param(userIds)}::text[])
+        AND COALESCE(u.is_disabled, false) = false
+        AND u.role <> ${TOP_MANAGER_ROLE_ID}
+        AND NOT EXISTS (
+          SELECT 1
+          FROM user_roles top_manager_role
+          WHERE top_manager_role.user_id = u.id
+            AND top_manager_role.role_id = ${TOP_MANAGER_ROLE_ID}
+        )
+        AND NOT (
+          u.role = ${ADMIN_ROLE_ID}
+          AND NOT EXISTS (
+            SELECT 1
+            FROM user_roles non_admin_role
+            WHERE non_admin_role.user_id = u.id
+              AND non_admin_role.role_id <> ${ADMIN_ROLE_ID}
+          )
+        )
+        AND ${scopedVisibility}
+    `,
+  );
+
+  const eligibleIds = new Set(eligibleRows.map(({ id }) => id));
+  return userIds.filter((id) => !eligibleIds.has(id));
+};

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -14,6 +14,7 @@ import {
   standardErrorResponses,
   standardRateLimitedErrorResponses,
 } from '../schemas/common.ts';
+import { findIneligibleTaskAssigneeIds } from '../services/taskAssignmentEligibility.ts';
 import { MAX_DURATION_HOURS } from '../services/timeEntries.ts';
 import { deriveToggleAction, getAuditChangedFields, logAudit } from '../utils/audit.ts';
 import { assertAuthenticated } from '../utils/auth-assert.ts';
@@ -766,7 +767,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         tags: ['tasks'],
         summary: 'Update task user assignments',
         description:
-          'Requires projects.assignments.update. Task update permissions do not authorize assignment changes.',
+          'Requires projects.assignments.update. Task update permissions do not authorize assignment changes. Assignees must be active, eligible users visible to the caller.',
         params: idParamSchema,
         body: userIdsSchema,
         response: {
@@ -811,10 +812,17 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         });
       }
 
-      await withDbTransaction(async (tx) => {
+      const ineligibleUserIds = await withDbTransaction(async (tx) => {
+        const invalidIds = await findIneligibleTaskAssigneeIds(request, validUserIds, tx);
+        if (invalidIds.length > 0) return invalidIds;
+
         await tasksRepo.clearNonTopManagerAssignments(idResult.value, tx);
         await tasksRepo.addManualAssignments(idResult.value, validUserIds, tx);
+        return [];
       });
+      if (ineligibleUserIds.length > 0) {
+        return badRequest(reply, 'userIds contains users who are not eligible for task assignment');
+      }
 
       await logAudit({
         request,

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -28,6 +28,7 @@ import {
   externalGroupsYieldNoKnownRole,
 } from '../services/external-auth.ts';
 import { requiresTotpEnrollment } from '../services/totpEnforcement.ts';
+import { getUserVisibilityScope } from '../services/userVisibility.ts';
 import { getAuditChangedFields, getAuditCounts, logAudit } from '../utils/audit.ts';
 import { assertAuthenticated } from '../utils/auth-assert.ts';
 import { todayLocalDateOnly } from '../utils/date.ts';
@@ -341,8 +342,7 @@ const canViewUserEmails = (request: FastifyRequest) =>
   hasPermission(request, 'administration.user_management.view');
 
 const canViewAllUsers = (request: FastifyRequest) =>
-  hasPermission(request, 'administration.user_management_all.view') ||
-  hasPermission(request, 'hr.work_units_all.view');
+  getUserVisibilityScope(request).canViewAllUsers;
 
 const canViewTargetUserAssignments = async (request: FastifyRequest, targetUserId: string) => {
   if (request.user?.id === targetUserId) return true;
@@ -757,24 +757,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     async (request: FastifyRequest, reply: FastifyReply) => {
       if (!assertAuthenticated(request, reply)) return;
 
-      const canViewUserManagement = hasPermission(request, 'administration.user_management.view');
-      const canViewManagedUsers =
-        hasPermission(request, 'timesheets.tracker.view') ||
-        hasPermission(request, 'timesheets.tracker_all.view') ||
-        hasPermission(request, 'timesheets.ril.view') ||
-        hasPermission(request, 'hr.work_units.view') ||
-        hasPermission(request, 'hr.work_units_all.view') ||
-        canViewUserManagement;
-      const canViewInternal = hasPermission(request, 'hr.internal.view');
-      const canViewExternal = hasPermission(request, 'hr.external.view');
-
-      const users = canViewAllUsers(request)
+      const { canViewAllUsers: canViewAll, ...managerScope } = getUserVisibilityScope(request);
+      const users = canViewAll
         ? await usersRepo.listAllForAdmin()
-        : await usersRepo.listScopedForManager(request.user.id, {
-            canViewManagedUsers,
-            canViewInternal,
-            canViewExternal,
-          });
+        : await usersRepo.listScopedForManager(request.user.id, managerScope);
 
       const currentCosts = await userHourlyCostPeriodsRepo.listCostsForDate(
         users.filter((user) => canViewCostFor(request, user.id)).map((user) => user.id),

--- a/server/services/taskAssignmentEligibility.ts
+++ b/server/services/taskAssignmentEligibility.ts
@@ -1,0 +1,18 @@
+import type { FastifyRequest } from 'fastify';
+import type { DbExecutor } from '../db/drizzle.ts';
+import * as taskAssignmentEligibilityRepo from '../repositories/taskAssignmentEligibilityRepo.ts';
+import { getUserVisibilityScope } from './userVisibility.ts';
+
+export const findIneligibleTaskAssigneeIds = (
+  request: FastifyRequest,
+  userIds: string[],
+  exec: DbExecutor,
+): Promise<string[]> =>
+  taskAssignmentEligibilityRepo.findIneligibleAssigneeIds(
+    userIds,
+    {
+      viewerId: request.user?.id ?? '',
+      ...getUserVisibilityScope(request),
+    },
+    exec,
+  );

--- a/server/services/userVisibility.ts
+++ b/server/services/userVisibility.ts
@@ -1,0 +1,22 @@
+import type { FastifyRequest } from 'fastify';
+import type { ManagerScopeOptions } from '../repositories/usersRepo.ts';
+import { requestHasPermission as hasPermission } from '../utils/permissions.ts';
+
+export type UserVisibilityScope = ManagerScopeOptions & {
+  canViewAllUsers: boolean;
+};
+
+export const getUserVisibilityScope = (request: FastifyRequest): UserVisibilityScope => ({
+  canViewAllUsers:
+    hasPermission(request, 'administration.user_management_all.view') ||
+    hasPermission(request, 'hr.work_units_all.view'),
+  canViewManagedUsers:
+    hasPermission(request, 'timesheets.tracker.view') ||
+    hasPermission(request, 'timesheets.tracker_all.view') ||
+    hasPermission(request, 'timesheets.ril.view') ||
+    hasPermission(request, 'hr.work_units.view') ||
+    hasPermission(request, 'hr.work_units_all.view') ||
+    hasPermission(request, 'administration.user_management.view'),
+  canViewInternal: hasPermission(request, 'hr.internal.view'),
+  canViewExternal: hasPermission(request, 'hr.external.view'),
+});

--- a/server/test/repositories/taskAssignmentEligibilityRepo.test.ts
+++ b/server/test/repositories/taskAssignmentEligibilityRepo.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import type { DbExecutor } from '../../db/drizzle.ts';
+import * as taskAssignmentEligibilityRepo from '../../repositories/taskAssignmentEligibilityRepo.ts';
+import { type FakeExecutor, setupTestDb } from '../helpers/fakeExecutor.ts';
+
+let exec: FakeExecutor;
+let testDb: DbExecutor;
+
+beforeEach(() => {
+  ({ exec, testDb } = setupTestDb());
+});
+
+describe('findIneligibleAssigneeIds', () => {
+  test('skips the database for an empty request', async () => {
+    const result = await taskAssignmentEligibilityRepo.findIneligibleAssigneeIds(
+      [],
+      {
+        viewerId: 'viewer-1',
+        canViewAllUsers: false,
+        canViewManagedUsers: false,
+        canViewInternal: false,
+        canViewExternal: false,
+      },
+      testDb,
+    );
+
+    expect(result).toEqual([]);
+    expect(exec.calls).toHaveLength(0);
+  });
+
+  test('rejects requested IDs not returned by every eligibility and visibility guard', async () => {
+    exec.enqueue({ rows: [{ id: 'eligible-user' }] });
+
+    const result = await taskAssignmentEligibilityRepo.findIneligibleAssigneeIds(
+      [
+        'eligible-user',
+        'missing-user',
+        'disabled-user',
+        'admin-only-user',
+        'top-manager-user',
+        'invisible-user',
+      ],
+      {
+        viewerId: 'viewer-1',
+        canViewAllUsers: false,
+        canViewManagedUsers: true,
+        canViewInternal: true,
+        canViewExternal: false,
+      },
+      testDb,
+    );
+
+    expect(result).toEqual([
+      'missing-user',
+      'disabled-user',
+      'admin-only-user',
+      'top-manager-user',
+      'invisible-user',
+    ]);
+
+    const query = exec.calls[0];
+    expect(query.params).toContainEqual([
+      'eligible-user',
+      'missing-user',
+      'disabled-user',
+      'admin-only-user',
+      'top-manager-user',
+      'invisible-user',
+    ]);
+    expect(query.params).toContain('viewer-1');
+    expect(query.sql).toContain('u.is_disabled');
+    expect(query.sql).toContain('u.role <>');
+    expect(query.sql).toContain('top_manager_role.role_id');
+    expect(query.sql).toContain('non_admin_role.role_id <>');
+    expect(query.sql).toContain('user_work_units assignee_uw');
+    expect(query.sql).toContain("u.employee_type IN ('app_user', 'internal')");
+    expect(query.sql).toContain("u.employee_type = 'external'");
+  });
+
+  test('does not apply caller scope joins to all-user viewers', async () => {
+    exec.enqueue({ rows: [{ id: 'eligible-user' }] });
+
+    const result = await taskAssignmentEligibilityRepo.findIneligibleAssigneeIds(
+      ['eligible-user'],
+      {
+        viewerId: 'viewer-1',
+        canViewAllUsers: true,
+        canViewManagedUsers: false,
+        canViewInternal: false,
+        canViewExternal: false,
+      },
+      testDb,
+    );
+
+    expect(result).toEqual([]);
+    expect(exec.calls[0].sql).not.toContain('user_work_units assignee_uw');
+  });
+});

--- a/server/test/routes/tasks.test.ts
+++ b/server/test/routes/tasks.test.ts
@@ -3,6 +3,7 @@ import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
 import * as realDrizzle from '../../db/drizzle.ts';
 import * as realProjectsRepo from '../../repositories/projectsRepo.ts';
 import * as realRolesRepo from '../../repositories/rolesRepo.ts';
+import * as realTaskAssignmentEligibilityRepo from '../../repositories/taskAssignmentEligibilityRepo.ts';
 import * as realTasksRepo from '../../repositories/tasksRepo.ts';
 import * as realUserAssignmentsRepo from '../../repositories/userAssignmentsRepo.ts';
 import * as realUsersRepo from '../../repositories/usersRepo.ts';
@@ -22,6 +23,7 @@ import { makeWithDbTransactionMock } from '../helpers/withDbTransactionMock.ts';
 const usersRepoSnap = { ...realUsersRepo };
 const rolesRepoSnap = { ...realRolesRepo };
 const permissionsSnap = { ...realPermissions };
+const taskAssignmentEligibilityRepoSnap = { ...realTaskAssignmentEligibilityRepo };
 const tasksRepoSnap = { ...realTasksRepo };
 const projectsRepoSnap = { ...realProjectsRepo };
 const userAssignmentsRepoSnap = { ...realUserAssignmentsRepo };
@@ -44,6 +46,9 @@ const findNameAndProjectIdMock = mock();
 const clearNonTopManagerAssignmentsMock = mock();
 const addManualAssignmentsMock = mock();
 const sumHoursByProjectsMock = mock();
+
+// taskAssignmentEligibilityRepo mocks
+const findIneligibleAssigneeIdsMock = mock();
 
 // projectsRepo
 const findClientIdMock = mock();
@@ -93,6 +98,10 @@ beforeAll(async () => {
     addManualAssignments: addManualAssignmentsMock,
     sumHoursByProjects: sumHoursByProjectsMock,
   }));
+  mock.module('../../repositories/taskAssignmentEligibilityRepo.ts', () => ({
+    ...taskAssignmentEligibilityRepoSnap,
+    findIneligibleAssigneeIds: findIneligibleAssigneeIdsMock,
+  }));
   mock.module('../../repositories/projectsRepo.ts', () => ({
     ...projectsRepoSnap,
     findClientId: findClientIdMock,
@@ -126,6 +135,10 @@ afterAll(() => {
   mock.module('../../repositories/usersRepo.ts', () => usersRepoSnap);
   mock.module('../../repositories/rolesRepo.ts', () => rolesRepoSnap);
   mock.module('../../utils/permissions.ts', () => permissionsSnap);
+  mock.module(
+    '../../repositories/taskAssignmentEligibilityRepo.ts',
+    () => taskAssignmentEligibilityRepoSnap,
+  );
   mock.module('../../repositories/tasksRepo.ts', () => tasksRepoSnap);
   mock.module('../../repositories/projectsRepo.ts', () => projectsRepoSnap);
   mock.module('../../repositories/userAssignmentsRepo.ts', () => userAssignmentsRepoSnap);
@@ -191,6 +204,7 @@ const allMocks = [
   clearNonTopManagerAssignmentsMock,
   addManualAssignmentsMock,
   sumHoursByProjectsMock,
+  findIneligibleAssigneeIdsMock,
   findClientIdMock,
   findBillingByIdMock,
   assignClientToUserMock,
@@ -212,6 +226,7 @@ beforeEach(async () => {
   findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
   userHasRoleMock.mockResolvedValue(true);
   getRolePermissionsMock.mockResolvedValue(TASKS_PERMS);
+  findIneligibleAssigneeIdsMock.mockResolvedValue([]);
   resetWithDbTransactionMock();
   logAuditMock.mockImplementation(async () => undefined);
   assignClientToUserMock.mockImplementation(async () => undefined);
@@ -1155,6 +1170,37 @@ describe('POST /api/tasks/:id/users', () => {
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'task.users_assigned', entityId: 't-1' }),
     );
+  });
+
+  test('400: rejects users outside the caller-visible eligible assignee set', async () => {
+    findNameAndProjectIdMock.mockResolvedValue({ name: 'Implement feature', projectId: 'p-1' });
+    findIneligibleAssigneeIdsMock.mockResolvedValue(['disabled-user']);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/tasks/t-1/users',
+      headers: authHeader(),
+      payload: { userIds: ['u2', 'disabled-user'] },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'userIds contains users who are not eligible for task assignment',
+    });
+    expect(findIneligibleAssigneeIdsMock).toHaveBeenCalledWith(
+      ['u2', 'disabled-user'],
+      {
+        viewerId: 'u1',
+        canViewAllUsers: false,
+        canViewManagedUsers: false,
+        canViewInternal: false,
+        canViewExternal: false,
+      },
+      TX_SENTINEL,
+    );
+    expect(clearNonTopManagerAssignmentsMock).not.toHaveBeenCalled();
+    expect(addManualAssignmentsMock).not.toHaveBeenCalled();
+    expect(logAuditMock).not.toHaveBeenCalled();
   });
 
   test('400: empty userIds array', async () => {


### PR DESCRIPTION
## Summary
- Enforce task-assignee eligibility in the backend instead of trusting the browser filter.
- Reject unknown, disabled, top-manager, admin-only, and caller-invisible user IDs before assignment rows change.
- Share user-visibility scope calculation with the users API and document the API contract in English and Italian.

## Testing
- [x] `bun test server/test/routes/tasks.test.ts server/test/routes/users.test.ts server/test/repositories/taskAssignmentEligibilityRepo.test.ts` (232 passed)
- [x] `bun run typecheck`
- [x] `bun run build`
- [x] Focused Biome check on all changed backend files
- [x] React Doctor remained 75/100 before and after
- [ ] `bun run test` completed all 4,677 server tests, then Bun 1.3.14 crashed with an internal assertion during the unrelated frontend suite
- [ ] Full `bun run lint` reaches Biome after i18n and typecheck pass, then fails on repository-wide CRLF formatting in this Windows checkout; focused changed-file checks pass

## Risks / Rollout
- Low-to-medium authorization risk: task assignment requests now return 400 for users outside the same visibility and eligibility set exposed by the UI.
- No migration, configuration, or dependency changes.

## Issues
- Issue: Not linked (DeepSec finding `praetor-acl-check-c81f2f94c1`)