### PR TITLE
docker(security): pin base images by digest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,11 @@
 # STAGE 1: Install dependencies
-FROM oven/bun:1.3.14 AS install
+FROM oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS install
 WORKDIR /temp
 COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile
 
 # STAGE 2: Build
-FROM oven/bun:1.3.14 AS builder
+FROM oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS builder
 WORKDIR /app
 COPY --from=install /temp/node_modules node_modules
 COPY . .
@@ -20,7 +20,7 @@ ENV NODE_ENV=production
 RUN bun run build
 
 # STAGE 3: Production with Caddy
-FROM caddy:alpine
+FROM caddy:alpine@sha256:5f5c8640aae01df9654968d946d8f1a56c497f1dd5c5cda4cf95ab7c14d58648
 
 COPY Caddyfile /etc/caddy/Caddyfile
 COPY --from=builder /app/dist /srv

--- a/test/dockerfile-security.test.ts
+++ b/test/dockerfile-security.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, test } from 'bun:test';
+
+const dockerfile = await Bun.file(new URL('../Dockerfile', import.meta.url)).text();
+const baseImages = dockerfile
+  .split(/\r?\n/)
+  .map((line) => line.match(/^\s*FROM(?:\s+--\S+)*\s+(\S+)/i)?.[1])
+  .filter((image): image is string => image !== undefined);
+
+describe('Dockerfile base images', () => {
+  test('pins every image tag to an immutable SHA-256 digest', () => {
+    expect(baseImages).not.toHaveLength(0);
+
+    for (const image of baseImages) {
+      expect(image).toMatch(/^[^@\s]+:[^@\s]+@sha256:[a-f0-9]{64}$/);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Pin the Bun build image and Caddy runtime image to verified Docker Hub OCI index digests.
- Add a regression test that rejects mutable or digest-only Dockerfile base references.

## Testing
- un test ./test/dockerfile-security.test.ts (pass)
- un run test:server via un run test (4,677 pass, 29 skip, 0 fail)
- un run build (pass)
- unx biome check test/dockerfile-security.test.ts (pass)
- un run test:react-doctor (75/100 before and after; existing diagnostics keep the command nonzero)
- Full frontend suite progressed without assertion failures but Bun 1.3.14 crashed with an internal assertion after peaking at 10 GB on Windows; Linux CI remains authoritative.
- Repository-wide Biome check is affected by CRLF conversion across the Windows worktree; the changed TypeScript test passes a focused Biome check.

## Risks / Rollout
- Low risk: build inputs are unchanged by tag but now immutable. Future base-image updates must refresh the corresponding digest intentionally.
- No API, database, or user documentation changes.

## Issues
- Issue: Not linked