### PR TITLE
frontend(security): run Caddy as non-root

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -5,7 +5,7 @@
 # Caddyfile for Praetor
 # Serves static frontend files and proxies API requests to backend over HTTP
 
-:80 {
+:8080 {
     # Serve static files from the SPA build
     root * /srv
     

--- a/Dockerfile
+++ b/Dockerfile
@@ -22,12 +22,20 @@ RUN bun run build
 # STAGE 3: Production with Caddy
 FROM caddy:alpine
 
+RUN addgroup -S -g 10001 praetor \
+    && adduser -S -D -H -u 10001 -G praetor praetor
+
 COPY Caddyfile /etc/caddy/Caddyfile
 COPY --from=builder /app/dist /srv
 COPY docker-entrypoint.sh /docker-entrypoint.sh
-RUN chmod +x /docker-entrypoint.sh
+RUN chmod 0555 /docker-entrypoint.sh \
+    && chown -R praetor:praetor /data /config \
+    && chmod -R u=rwX,go= /data /config \
+    && setcap -r /usr/bin/caddy
 
-EXPOSE 80
+USER praetor:praetor
+
+EXPOSE 8080
 
 ENTRYPOINT ["/docker-entrypoint.sh"]
 CMD ["caddy", "run", "--config", "/etc/caddy/Caddyfile"]

--- a/deploy/docker-compose.customer.yml
+++ b/deploy/docker-compose.customer.yml
@@ -49,7 +49,7 @@ services:
     image: ${PRAETOR_IMAGE_PREFIX:-ghcr.io/xbounceit}/praetor-frontend:${PRAETOR_VERSION:?PRAETOR_VERSION is required}
     container_name: praetor-frontend
     ports:
-      - '${FRONTEND_PORT:-3000}:80'
+      - '${FRONTEND_PORT:-3000}:8080'
     depends_on:
       - backend
     restart: unless-stopped

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -68,7 +68,7 @@ services:
         VITE_API_URL: /api
     container_name: praetor-frontend
     ports:
-      - '3000:80'
+      - '3000:8080'
     depends_on:
       - backend
     restart: unless-stopped

--- a/test/security/frontendContainer.test.ts
+++ b/test/security/frontendContainer.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, test } from 'bun:test';
+
+const dockerfile = await Bun.file(new URL('../../Dockerfile', import.meta.url)).text();
+const caddyfile = await Bun.file(new URL('../../Caddyfile', import.meta.url)).text();
+const compose = await Bun.file(new URL('../../docker-compose.yml', import.meta.url)).text();
+const customerCompose = await Bun.file(
+  new URL('../../deploy/docker-compose.customer.yml', import.meta.url),
+).text();
+const runtimeStage = dockerfile.slice(dockerfile.lastIndexOf('\nFROM '));
+
+describe('frontend container hardening', () => {
+  test('runs Caddy as the dedicated Praetor user without inherited bind capability', () => {
+    expect(runtimeStage).toContain('addgroup -S -g 10001 praetor');
+    expect(runtimeStage).toContain('adduser -S -D -H -u 10001 -G praetor praetor');
+    expect(runtimeStage).toContain('setcap -r /usr/bin/caddy');
+    const userDirectives = runtimeStage.match(/^USER\s+.+$/gm);
+    expect(userDirectives?.at(-1)?.trim()).toBe('USER praetor:praetor');
+  });
+
+  test('limits runtime write access to Caddy state directories', () => {
+    expect(runtimeStage).toContain('chown -R praetor:praetor /data /config');
+    expect(runtimeStage).toContain('chmod -R u=rwX,go= /data /config');
+  });
+
+  test('serves through an unprivileged container port', () => {
+    expect(caddyfile).toMatch(/(?:^|\n):8080 \{/);
+    expect(runtimeStage).toContain('EXPOSE 8080');
+    expect(compose).toContain(`- '3000:8080'`);
+    expect(customerCompose).toContain(`- '\${FRONTEND_PORT:-3000}:8080'`);
+  });
+});


### PR DESCRIPTION
## Summary
- run the frontend Caddy process as a dedicated non-root user
- remove the inherited low-port bind capability and move the container listener to port 8080
- keep public host ports unchanged in development and customer compose deployments

## Changes
- restrict writable ownership to Caddy's `/data` and `/config` state directories
- update Caddy, Docker, and compose port configuration consistently
- add regression tests for the runtime user, capabilities, permissions, and both compose mappings

## Testing
- `bun test ./test/security/frontendContainer.test.ts` (pass: 3 tests)
- `bun run build` (pass)
- `bun run test` (backend pass: 4,689 tests; frontend process later crashed inside Bun 1.3.14 with an internal assertion after reaching 11.3 GB peak RSS)
- `bun run test:react-doctor` (75/100 before and after; existing 94 findings unchanged)
- three consecutive clean review/simplify cycles completed

## Risks / Rollout
- External frontend ports remain unchanged; only the container-internal listener changes from 80 to 8080.
- Docker execution was not run locally per repository policy; CI validates the container build.
- User documentation was reviewed and needs no update because externally visible URLs and ports are unchanged.

## Issues
Issue: Not linked