### PR TITLE
reports(security): limit AI reporting generation abuse

### DIFF
--- a/docs-site/src/content/docs/ai-reporting.md
+++ b/docs-site/src/content/docs/ai-reporting.md
@@ -35,6 +35,12 @@ Il composer fluttua sopra la conversazione: resta compatto su una riga e cresce 
 
 Il pulsante con la graffetta allega fino a 5 file di testo, inclusi TXT, Markdown, CSV, JSON, XML, YAML, log, SQL e comuni file sorgente. Ogni file può pesare fino a 64 KB; il contenuto testuale complessivo degli allegati può raggiungere 12.000 caratteri. I file vengono letti nel browser e inclusi nella richiesta inviata ad AI Reporting. Il loro contenuto diventa una fonte dati esplicita per analisi, calcoli e visualizzazioni, ma viene sempre trattato come dato e mai come istruzione per l'AI.
 
+## Limiti di utilizzo
+
+Per proteggere i costi del provider e la capacità del server, ogni utente può avviare fino a 10 generazioni AI al minuto e mantenere al massimo 2 generazioni contemporanee. Il budget è condiviso tra nuovi messaggi, messaggi in streaming e rigenerazioni dopo una modifica. Ogni risposta è limitata a 4.096 token di output.
+
+Quando viene raggiunto un limite, Praetor restituisce una risposta `429`. Attendi la conclusione di una generazione attiva o il rinnovo del budget di un minuto prima di riprovare.
+
 ## Dataset aziendali disponibili
 
 AI Reporting costruisce per ogni richiesta un dataset aggiornato e limitato ai permessi di visualizzazione del tuo ruolo. La risposta può usare queste sezioni:

--- a/docs-site/src/content/docs/en/ai-reporting.md
+++ b/docs-site/src/content/docs/en/ai-reporting.md
@@ -35,6 +35,12 @@ The composer floats over the conversation: it stays compact on one line and grow
 
 Use the paperclip button to attach up to 5 text files, including TXT, Markdown, CSV, JSON, XML, YAML, logs, SQL, and common source-code files. Each file can be up to 64 KB, while the combined text content can contain up to 12,000 characters. Files are read in the browser and included in the request sent to AI Reporting. Their contents become an explicit data source for analysis, calculations, and visualizations, while remaining data rather than instructions for the AI.
 
+## Usage limits
+
+To protect provider costs and server capacity, each user can start up to 10 AI generations per minute and run at most 2 generations at the same time. This shared budget covers new messages, streamed messages, and edited-message regeneration. A response is limited to 4,096 output tokens.
+
+When a limit is reached, Praetor returns a `429` response. Wait for an active generation to finish or for the one-minute budget to reset before retrying.
+
 ## Available business datasets
 
 For every request, AI Reporting builds a fresh dataset restricted to the view permissions granted to your role. Answers can use these sections:

--- a/server/routes/reports.ts
+++ b/server/routes/reports.ts
@@ -15,6 +15,10 @@ import * as suppliersRepo from '../repositories/suppliersRepo.ts';
 import * as workUnitsRepo from '../repositories/workUnitsRepo.ts';
 import { standardErrorResponses, standardRateLimitedErrorResponses } from '../schemas/common.ts';
 import { normalizeGeminiModelPath } from '../utils/ai-models.ts';
+import {
+  AI_REPORTING_MAX_OUTPUT_TOKENS,
+  createAiReportingAbuseControls,
+} from '../utils/ai-reporting-abuse-controls.ts';
 import { assertAuthenticated } from '../utils/auth-assert.ts';
 import { fetchLocalAi, localAiEndpointUrl, localAiHeaders } from '../utils/local-ai-endpoint.ts';
 import { generatePrefixedId } from '../utils/order-ids.ts';
@@ -613,7 +617,10 @@ const buildGeminiRequestBody = (prompt: string, systemPrompt?: string) => ({
       }
     : {}),
   contents: [{ role: 'user', parts: [{ text: prompt }] }],
-  generationConfig: { temperature: 0.2 },
+  generationConfig: {
+    temperature: 0.2,
+    maxOutputTokens: AI_REPORTING_MAX_OUTPUT_TOKENS,
+  },
 });
 
 const geminiGenerateText = async (
@@ -653,7 +660,12 @@ const chatCompletionsGenerateText = async (
   const res = await fetcher(endpoint, {
     method: 'POST',
     headers,
-    body: JSON.stringify({ model: modelId, temperature: 0.2, messages }),
+    body: JSON.stringify({
+      model: modelId,
+      temperature: 0.2,
+      max_tokens: AI_REPORTING_MAX_OUTPUT_TOKENS,
+      messages,
+    }),
     redirect,
   });
   if (!res.ok) throw new Error(`${providerLabel} request failed: HTTP ${res.status}`);
@@ -700,7 +712,7 @@ const anthropicGenerateText = async (
     },
     body: JSON.stringify({
       model: modelId,
-      max_tokens: 4096,
+      max_tokens: AI_REPORTING_MAX_OUTPUT_TOKENS,
       temperature: 0.2,
       system: anthropicMessages.system || undefined,
       messages: anthropicMessages.messages,
@@ -718,7 +730,12 @@ const openaiGenerateText = async (apiKey: string, modelId: string, messages: AiC
       Authorization: `Bearer ${apiKey}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ model: modelId, input: messages, store: false }),
+    body: JSON.stringify({
+      model: modelId,
+      input: messages,
+      max_output_tokens: AI_REPORTING_MAX_OUTPUT_TOKENS,
+      store: false,
+    }),
   });
   if (!res.ok) throw new Error(`OpenAI request failed: HTTP ${res.status}`);
   return openaiTextFromResponse(await res.json());
@@ -840,6 +857,7 @@ const chatCompletionsGenerateTextStream = async (
     body: JSON.stringify({
       model: modelId,
       temperature: 0.2,
+      max_tokens: AI_REPORTING_MAX_OUTPUT_TOKENS,
       stream: true,
       messages,
     }),
@@ -996,7 +1014,7 @@ const anthropicGenerateTextStream = async (
     },
     body: JSON.stringify({
       model: modelId,
-      max_tokens: 4096,
+      max_tokens: AI_REPORTING_MAX_OUTPUT_TOKENS,
       temperature: 0.2,
       stream: true,
       system: anthropicMessages.system || undefined,
@@ -1100,7 +1118,13 @@ const openaiGenerateTextStream = async (
       Authorization: `Bearer ${apiKey}`,
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ model: modelId, input: messages, stream: true, store: false }),
+    body: JSON.stringify({
+      model: modelId,
+      input: messages,
+      max_output_tokens: AI_REPORTING_MAX_OUTPUT_TOKENS,
+      stream: true,
+      store: false,
+    }),
     signal,
   });
   if (!res.ok) throw new Error(`OpenAI request failed: HTTP ${res.status}`);
@@ -2375,6 +2399,7 @@ const createSseStreamHandlers = (
 
 export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.addHook('onRequest', authenticateToken);
+  const aiReportingAbuseControls = createAiReportingAbuseControls(fastify);
 
   const sessionSummarySchema = {
     type: 'object',
@@ -2677,7 +2702,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/ai-reporting/chat/stream',
     {
-      onRequest: [requirePermission('reports.ai_reporting.create')],
+      onRequest: [
+        requirePermission('reports.ai_reporting.create'),
+        aiReportingAbuseControls.rateLimit,
+        aiReportingAbuseControls.concurrencyLimit,
+      ],
       schema: {
         tags: ['reports'],
         summary: 'Send a message to AI Reporting and stream progress',
@@ -2691,7 +2720,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           required: ['message'],
         },
         response: {
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },
@@ -2922,7 +2951,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/ai-reporting/chat/edit-stream',
     {
-      onRequest: [requirePermission('reports.ai_reporting.create')],
+      onRequest: [
+        requirePermission('reports.ai_reporting.create'),
+        aiReportingAbuseControls.rateLimit,
+        aiReportingAbuseControls.concurrencyLimit,
+      ],
       schema: {
         tags: ['reports'],
         summary: 'Edit a user message and regenerate the assistant response via streaming',
@@ -2937,7 +2970,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           required: ['sessionId', 'messageId', 'content'],
         },
         response: {
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },
@@ -3164,7 +3197,11 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/ai-reporting/chat',
     {
-      onRequest: [requirePermission('reports.ai_reporting.create')],
+      onRequest: [
+        requirePermission('reports.ai_reporting.create'),
+        aiReportingAbuseControls.rateLimit,
+        aiReportingAbuseControls.concurrencyLimit,
+      ],
       schema: {
         tags: ['reports'],
         summary: 'Send a message to AI Reporting and store history',
@@ -3188,7 +3225,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             },
             required: ['sessionId', 'text'],
           },
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/test/routes/reports.test.ts
+++ b/server/test/routes/reports.test.ts
@@ -1,5 +1,6 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
-import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import Fastify, { type FastifyInstance, type FastifyPluginAsync } from 'fastify';
+import rateLimit from 'fastify-rate-limit';
 import * as realDrizzle from '../../db/drizzle.ts';
 import * as realGeneralSettingsRepo from '../../repositories/generalSettingsRepo.ts';
 import * as realReportsAiChatRepo from '../../repositories/reportsAiChatRepo.ts';
@@ -12,6 +13,10 @@ import * as realRolesRepo from '../../repositories/rolesRepo.ts';
 import * as realSuppliersRepo from '../../repositories/suppliersRepo.ts';
 import * as realUsersRepo from '../../repositories/usersRepo.ts';
 import * as realWorkUnitsRepo from '../../repositories/workUnitsRepo.ts';
+import {
+  AI_REPORTING_GENERATION_RATE_LIMIT,
+  AI_REPORTING_MAX_OUTPUT_TOKENS,
+} from '../../utils/ai-reporting-abuse-controls.ts';
 import * as realLocalAiEndpoint from '../../utils/local-ai-endpoint.ts';
 import * as realPermissions from '../../utils/permissions.ts';
 import {
@@ -300,7 +305,9 @@ afterEach(async () => {
   await testApp.close();
 });
 
-const authHeader = () => ({ authorization: `Bearer ${signToken({ userId: 'u1' })}` });
+const authHeader = (userId = 'u1') => ({
+  authorization: `Bearer ${signToken({ userId })}`,
+});
 const attachmentMessage = (visibleText: string, content: string) =>
   `${visibleText}\n\n\u001ePRAETOR_AI_ATTACHMENTS_V1\n${JSON.stringify({
     files: [{ name: 'data.csv', content }],
@@ -319,6 +326,13 @@ const createDeferredResponse = () => {
     resolveResponse = resolve;
   });
   return { promise, resolve: resolveResponse };
+};
+
+const waitForFetchCalls = async (expected: number) => {
+  for (let attempt = 0; attempt < 100 && fetchMock.mock.calls.length < expected; attempt++) {
+    await Bun.sleep(1);
+  }
+  expect(fetchMock).toHaveBeenCalledTimes(expected);
 };
 
 const expectAssistantPersistedBeforeMetadata = async () => {
@@ -1061,6 +1075,7 @@ describe('POST /api/reports/ai-reporting/chat (non-streaming)', () => {
     ) as {
       systemInstruction: { parts: Array<{ text: string }> };
       contents: Array<{ parts: Array<{ text: string }> }>;
+      generationConfig: { maxOutputTokens: number };
     };
     const systemPrompt = providerRequest.systemInstruction.parts[0]?.text ?? '';
     const prompt = providerRequest.contents[0]?.parts[0]?.text ?? '';
@@ -1095,6 +1110,7 @@ describe('POST /api/reports/ai-reporting/chat (non-streaming)', () => {
     expect(prompt).toContain('at most 10 points');
     expect(prompt).toContain('at most 7 visualization blocks');
     expect(prompt).toContain('Never include HTML, JavaScript, CSS, color values, URLs');
+    expect(providerRequest.generationConfig.maxOutputTokens).toBe(AI_REPORTING_MAX_OUTPUT_TOKENS);
     expect(prompt).toContain(
       'Place each interpretation immediately before its matching visualization block',
     );
@@ -1298,6 +1314,10 @@ describe('POST /api/reports/ai-reporting/chat (non-streaming)', () => {
     });
 
     expect(res.statusCode).toBe(200);
+    const providerRequest = JSON.parse(
+      String((fetchMock.mock.calls[0]?.[1] as RequestInit | undefined)?.body),
+    ) as { max_tokens?: number };
+    expect(providerRequest.max_tokens).toBe(AI_REPORTING_MAX_OUTPUT_TOKENS);
     expect(fetchMock.mock.calls[1]?.[0]).toBe(
       'https://openrouter.ai/api/v1/model/openai/gpt-4o-mini-test',
     );
@@ -1349,7 +1369,11 @@ describe('POST /api/reports/ai-reporting/chat (non-streaming)', () => {
       expect.objectContaining({ Authorization: 'Bearer test-openai-key' }),
     );
     expect(JSON.parse(String(init.body))).toEqual(
-      expect.objectContaining({ model: 'gpt-5', store: false }),
+      expect.objectContaining({
+        model: 'gpt-5',
+        max_output_tokens: AI_REPORTING_MAX_OUTPUT_TOKENS,
+        store: false,
+      }),
     );
     expect(JSON.parse(res.body).technicalInfo).toEqual({
       provider: 'openai',
@@ -1722,7 +1746,11 @@ describe('POST /api/reports/ai-reporting/chat (non-streaming)', () => {
     expect(options.headers).toEqual({ 'Content-Type': 'application/json' });
     expect(options.redirect).toBe('error');
     expect(JSON.parse(String(options.body))).toEqual(
-      expect.objectContaining({ model: 'llama3.2', messages: expect.any(Array) }),
+      expect.objectContaining({
+        model: 'llama3.2',
+        max_tokens: AI_REPORTING_MAX_OUTPUT_TOKENS,
+        messages: expect.any(Array),
+      }),
     );
     expect(insertAssistantMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({ content: 'Local answer', thoughtContent: 'Local reasoning' }),
@@ -1804,6 +1832,119 @@ describe('POST /api/reports/ai-reporting/chat (non-streaming)', () => {
     );
   });
 
+  test('rejects a third concurrent generation and releases capacity after completion', async () => {
+    findAuthUserByIdMock.mockImplementation(async (userId: string) => ({
+      ...HAPPY_USER,
+      id: userId,
+    }));
+    getActiveSessionForUserMock.mockResolvedValue({ id: 'rpt-chat-1', title: 'Existing' });
+    listRecentMessagesMock.mockResolvedValue([]);
+    insertUserMessageMock.mockResolvedValue(undefined);
+    insertAssistantMessageMock.mockResolvedValue(undefined);
+    updateSessionTitleAndTouchMock.mockResolvedValue(undefined);
+
+    const providerResponse = createDeferredResponse();
+    fetchMock.mockImplementation(() => providerResponse.promise);
+    const request = (userId = 'u1') =>
+      testApp.inject({
+        method: 'POST',
+        url: '/api/reports/ai-reporting/chat',
+        headers: authHeader(userId),
+        payload: { sessionId: 'rpt-chat-1', message: 'Summarize revenue' },
+      });
+
+    const first = request();
+    const second = request();
+    await waitForFetchCalls(2);
+
+    const rejected = await request();
+    expect(rejected.statusCode).toBe(429);
+    expect(JSON.parse(rejected.body)).toEqual({
+      error: 'Too many concurrent AI reporting requests',
+    });
+    expect(rejected.headers['retry-after']).toBe('1');
+
+    const otherUser = request('u2');
+    await waitForFetchCalls(3);
+
+    providerResponse.resolve(
+      okFetchResponse({
+        candidates: [{ content: { parts: [{ text: 'Revenue summary' }] } }],
+      }),
+    );
+    expect((await first).statusCode).toBe(200);
+    expect((await second).statusCode).toBe(200);
+    expect((await otherUser).statusCode).toBe(200);
+
+    fetchMock.mockResolvedValue(
+      okFetchResponse({
+        candidates: [{ content: { parts: [{ text: 'Capacity restored' }] } }],
+      }),
+    );
+    expect((await request()).statusCode).toBe(200);
+  });
+
+  test('shares a per-user generation budget across all generation endpoints', async () => {
+    await testApp.close();
+    testApp = Fastify({ logger: false });
+    await testApp.register(rateLimit, { global: false });
+    await testApp.register(routePlugin, { prefix: '/api/reports' });
+    await testApp.ready();
+
+    findAuthUserByIdMock.mockImplementation(async (userId: string) => ({
+      ...HAPPY_USER,
+      id: userId,
+    }));
+    getActiveSessionForUserMock.mockResolvedValue({ id: 'rpt-chat-1', title: 'Existing' });
+    listRecentMessagesMock.mockResolvedValue([]);
+    insertUserMessageMock.mockResolvedValue(undefined);
+    insertAssistantMessageMock.mockResolvedValue(undefined);
+    updateSessionTitleAndTouchMock.mockResolvedValue(undefined);
+    fetchMock.mockResolvedValue(
+      okFetchResponse({
+        candidates: [{ content: { parts: [{ text: 'Revenue summary' }] } }],
+      }),
+    );
+
+    for (
+      let requestNumber = 0;
+      requestNumber < AI_REPORTING_GENERATION_RATE_LIMIT.max;
+      requestNumber++
+    ) {
+      const response = await testApp.inject({
+        method: 'POST',
+        url: '/api/reports/ai-reporting/chat',
+        headers: authHeader(),
+        payload: { sessionId: 'rpt-chat-1', message: `Request ${requestNumber}` },
+      });
+      expect(response.statusCode).toBe(200);
+    }
+
+    for (const [url, payload] of [
+      ['/api/reports/ai-reporting/chat/stream', { message: 'Stream request' }],
+      [
+        '/api/reports/ai-reporting/chat/edit-stream',
+        { sessionId: 'rpt-chat-1', messageId: 'm-user', content: 'Edit request' },
+      ],
+    ] as const) {
+      const response = await testApp.inject({
+        method: 'POST',
+        url,
+        headers: authHeader(),
+        payload,
+      });
+      expect(response.statusCode).toBe(429);
+    }
+
+    const otherUserResponse = await testApp.inject({
+      method: 'POST',
+      url: '/api/reports/ai-reporting/chat',
+      headers: authHeader('u2'),
+      payload: { sessionId: 'rpt-chat-1', message: 'Independent user request' },
+    });
+    expect(otherUserResponse.statusCode).toBe(200);
+  });
+
   test('401 missing token', async () => {
     const res = await testApp.inject({
       method: 'POST',
@@ -1871,7 +2012,12 @@ describe('POST /api/reports/ai-reporting/chat/stream (streaming)', () => {
     expect(res.body).toContain('stream');
     const [, init] = fetchMock.mock.calls[0] as unknown as [string, RequestInit];
     expect(JSON.parse(String(init.body))).toEqual(
-      expect.objectContaining({ model: 'gpt-5', stream: true, store: false }),
+      expect.objectContaining({
+        model: 'gpt-5',
+        max_output_tokens: AI_REPORTING_MAX_OUTPUT_TOKENS,
+        stream: true,
+        store: false,
+      }),
     );
     expect(insertAssistantMessageMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -2068,7 +2214,12 @@ describe('POST /api/reports/ai-reporting/chat/stream (streaming)', () => {
     );
     expect(res.body).toContain('"contextTokensUsed":162000');
     const options = (fetchMock.mock.calls[0] as unknown as [string, RequestInit])[1];
-    expect(JSON.parse(String(options.body)).stream).toBe(true);
+    expect(JSON.parse(String(options.body))).toEqual(
+      expect.objectContaining({
+        max_tokens: AI_REPORTING_MAX_OUTPUT_TOKENS,
+        stream: true,
+      }),
+    );
   });
 
   test('streams local Chat Completions deltas and persists reasoning', async () => {
@@ -2123,7 +2274,12 @@ describe('POST /api/reports/ai-reporting/chat/stream (streaming)', () => {
     expect(options.headers).toEqual(
       expect.objectContaining({ Authorization: 'Bearer local-token' }),
     );
-    expect(JSON.parse(String(options.body)).stream).toBe(true);
+    expect(JSON.parse(String(options.body))).toEqual(
+      expect.objectContaining({
+        max_tokens: AI_REPORTING_MAX_OUTPUT_TOKENS,
+        stream: true,
+      }),
+    );
   });
 });
 

--- a/server/utils/ai-reporting-abuse-controls.ts
+++ b/server/utils/ai-reporting-abuse-controls.ts
@@ -1,0 +1,65 @@
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+
+export const AI_REPORTING_GENERATION_RATE_LIMIT = {
+  max: 10,
+  timeWindow: '1 minute',
+} as const;
+
+export const AI_REPORTING_MAX_CONCURRENT_GENERATIONS_PER_USER = 2;
+export const AI_REPORTING_MAX_OUTPUT_TOKENS = 4096;
+
+const generationKey = (request: FastifyRequest): string =>
+  request.user?.id ? `user:${request.user.id}` : `ip:${request.ip}`;
+
+const logThrottle = (request: FastifyRequest, reason: 'concurrency_limit' | 'rate_limit'): void => {
+  request.log.warn(
+    {
+      action: 'reports_ai_generation.throttled',
+      reason,
+      userId: request.user?.id,
+      authSource: request.auth?.source,
+      route: request.routeOptions.url,
+    },
+    'AI reporting generation request throttled',
+  );
+};
+
+export const createAiReportingAbuseControls = (fastify: FastifyInstance) => {
+  const activeGenerations = new Map<string, number>();
+  const rateLimit = fastify.rateLimit({
+    ...AI_REPORTING_GENERATION_RATE_LIMIT,
+    keyGenerator: generationKey,
+    onExceeded: (request) => logThrottle(request, 'rate_limit'),
+  });
+
+  const concurrencyLimit = async (request: FastifyRequest, reply: FastifyReply) => {
+    const key = generationKey(request);
+    const active = activeGenerations.get(key) ?? 0;
+    if (active >= AI_REPORTING_MAX_CONCURRENT_GENERATIONS_PER_USER) {
+      logThrottle(request, 'concurrency_limit');
+      const response = reply
+        .code(429)
+        .header('retry-after', '1')
+        .send({ error: 'Too many concurrent AI reporting requests' });
+      if (reply.raw.headersSent && !reply.sent) reply.hijack();
+      return response;
+    }
+
+    activeGenerations.set(key, active + 1);
+    let released = false;
+    const release = () => {
+      if (released) return;
+      released = true;
+      reply.raw.off('finish', release);
+      reply.raw.off('close', release);
+      const remaining = (activeGenerations.get(key) ?? 1) - 1;
+      if (remaining > 0) activeGenerations.set(key, remaining);
+      else activeGenerations.delete(key);
+    };
+
+    reply.raw.once('finish', release);
+    reply.raw.once('close', release);
+  };
+
+  return { concurrencyLimit, rateLimit };
+};


### PR DESCRIPTION
## Summary
- protect all AI Reporting generation endpoints with a shared per-user request budget and concurrency ceiling
- cap provider output tokens and emit warning telemetry whenever generation is throttled
- document the limits in Italian and English

## Changes
- limit each user to 10 generations per minute across chat, stream, and edit-stream routes
- allow at most 2 simultaneous generations per user and release capacity on response finish or disconnect
- cap Gemini, OpenAI, OpenRouter, Anthropic, and local provider output at 4,096 tokens
- add regression coverage for shared route budgets, concurrent requests, capacity release, and independent user buckets

## Testing
- `bun test ./test/routes/reports.test.ts` (91 passed)
- `bun run typecheck`
- `bun run docs:user`
- `bunx biome check server/utils/ai-reporting-abuse-controls.ts server/routes/reports.ts server/test/routes/reports.test.ts`
- `bun run test:react-doctor` (75/100, unchanged from baseline)
- full backend suite via `bun run test` (4,698 passed); the subsequent frontend suite stopped on a Bun 1.3.14 internal assertion crash

## Risks / Rollout
- Low migration risk: no database or configuration changes.
- Limits are process-local, matching the existing Fastify rate-limit store; multi-instance deployments enforce the limits independently per instance.

## Issues
Issue: Not linked