### PR TITLE
ci(security): pin workflow actions to commits

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,10 +16,10 @@ jobs:
     env:
       DB_PASSWORD: ci-schema-check-not-used
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
 
@@ -62,10 +62,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
 
@@ -98,10 +98,10 @@ jobs:
           --health-timeout 3s
           --health-retries 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.13
 
@@ -184,10 +184,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
 
@@ -288,7 +288,7 @@ jobs:
 
       - name: Upload integration test logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: ldap-integration-logs
           path: |
@@ -304,10 +304,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
 
@@ -358,7 +358,7 @@ jobs:
 
       - name: Upload SSO integration test logs
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: sso-integration-logs
           path: |
@@ -374,15 +374,15 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 22.12.0
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v2
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
         with:
           bun-version: 1.3.14
 
@@ -397,10 +397,10 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
       - name: Prepare environment file
         run: |
@@ -514,7 +514,7 @@ jobs:
 
       - name: Upload stack logs as artifact
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: docker-stack-logs
           path: logs/

--- a/test/workflows/ci.test.ts
+++ b/test/workflows/ci.test.ts
@@ -1,11 +1,32 @@
 import { describe, expect, test } from 'bun:test';
 
 const workflow = await Bun.file(new URL('../../.github/workflows/ci.yml', import.meta.url)).text();
+const dependabot = await Bun.file(new URL('../../.github/dependabot.yml', import.meta.url)).text();
 const scanStepMarker = '      - name: Scan postgres logs for FATAL/PANIC';
 const scanStepIndex = workflow.indexOf(scanStepMarker);
 if (scanStepIndex < 0) throw new Error('Postgres log scan step not found');
 const nextStepIndex = workflow.indexOf('\n      - name:', scanStepIndex + scanStepMarker.length);
 const scanStep = workflow.slice(scanStepIndex, nextStepIndex < 0 ? undefined : nextStepIndex);
+const remoteActionReferences = [
+  ...workflow.matchAll(/^[ \t]*(?:-[ \t]+)?uses:[ \t]+([^ \t#\r\n]+)/gm),
+]
+  .map((match) => match[1])
+  .filter((reference) => !reference.startsWith('./'));
+
+describe('CI action supply-chain safety', () => {
+  test('pins every remote action to a full commit SHA', () => {
+    expect(remoteActionReferences.length).toBeGreaterThan(0);
+
+    for (const reference of remoteActionReferences) {
+      expect(reference).toMatch(/^[^@\s]+@[0-9a-f]{40}$/);
+    }
+  });
+
+  test('keeps pinned actions current through Dependabot', () => {
+    expect(dependabot).toMatch(/package-ecosystem:\s*github-actions/);
+    expect(dependabot).toMatch(/interval:\s*weekly/);
+  });
+});
 
 describe('CI Postgres log scan', () => {
   test('ignores expected startup and shutdown FATAL messages', () => {


### PR DESCRIPTION
## Summary
- Pin every third-party action in the CI workflow to an immutable commit SHA.
- Add weekly Dependabot updates and regression coverage so mutable references cannot return unnoticed.

## Changes
- Replaced 18 mutable action tags across all CI jobs with the current immutable commits while retaining major-version comments.
- Added GitHub Actions dependency updates in `.github/dependabot.yml`.
- Added workflow tests for full-SHA pins and Dependabot configuration.

## Testing
- `bun test ./test/workflows/ci.test.ts` (passes: 4 tests)
- `bunx biome check test/workflows/ci.test.ts` (passes)
- `bun run test:react-doctor` (score unchanged at 75/100; command exits non-zero for existing findings)
- `bun run test:frontend` (Bun 1.3.14 crashed on Windows after ~494 seconds; no test assertion failed before the runtime crash)
- `bun run lint` (local Windows checkout reports repository-wide CRLF formatting drift; the changed TypeScript test passes Biome directly)

## Risks / Rollout
- Low risk: action versions are unchanged, only their references are made immutable. Dependabot will propose reviewed SHA refreshes weekly.
- No application behavior, API, database, or user documentation changes.

## Issues
Issue: Not linked