### PR TITLE
db(security): verify PostgreSQL TLS certificates

### DIFF
--- a/deploy/.env.customer.example
+++ b/deploy/.env.customer.example
@@ -43,11 +43,10 @@ DEMO_USER_PASSWORD=
 
 # Optional: PostgreSQL TLS
 # `node-postgres` does not honor PGSSLMODE, so SSL is configured here.
-# Accepted values mirror libpq:
 # - `disable` (or unset): no TLS. Use for the bundled Postgres container.
-# - `require`:     encrypted; server certificate is NOT validated.
+# - `true` / `require`: encrypted; CA and hostname validated.
 # - `verify-ca`:   encrypted; CA validated; hostname NOT checked.
-# - `verify-full`: encrypted; CA validated; hostname must match (recommended).
-# verify-ca/verify-full use DB_SSL_CA (inline PEM) or DB_SSL_CA_FILE (path).
+# - `verify-full`: encrypted; CA validated; hostname must match.
+# Enabled modes use DB_SSL_CA (inline PEM) or DB_SSL_CA_FILE (path).
 # DB_SSL=verify-full
 # DB_SSL_CA_FILE=/run/secrets/pg-ca.pem

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -33,17 +33,17 @@ and rotate it after the first login.
 ### PostgreSQL TLS (optional)
 
 The backend uses `node-postgres`, which does **not** honor `PGSSLMODE` — TLS must be opted
-in via the app-level `DB_SSL` env var. Accepted values mirror libpq:
+in via the app-level `DB_SSL` env var:
 
 - `disable` / unset: no TLS. Use for the bundled compose stack (Postgres image has no TLS).
-- `require`: encrypted connection, server certificate is **not** validated.
+- `true` / `require`: encrypted connection with CA and hostname validation.
 - `verify-ca`: encrypted connection, server certificate is validated against the CA, but
   the hostname is **not** checked. Useful when connecting through a tunnel or by IP.
 - `verify-full`: encrypted connection, server certificate is validated against the CA, and
-  the hostname must match. Recommended for production.
+  the hostname must match.
 
-For `verify-ca` and `verify-full`, provide the CA either inline via `DB_SSL_CA` (PEM
-string) or as a path via `DB_SSL_CA_FILE`. Without a CA, the system trust store is used.
+For every enabled mode, provide the CA either inline via `DB_SSL_CA` (PEM string) or as a path
+via `DB_SSL_CA_FILE`. Without a CA, the system trust store is used.
 
 `DB_SSL` is read by both the runtime pool and `drizzle-kit` migrations, so the same value
 applies to both paths.

--- a/server/db/config.ts
+++ b/server/db/config.ts
@@ -71,12 +71,11 @@ const readSslCa = (): string | undefined => {
 // `node-postgres` does not honor PGSSLMODE — only libpq does — so SSL must be
 // configured here in code. Defaults to off to preserve the bundled docker-compose
 // stack (Postgres image has no TLS). Enable via DB_SSL=require|verify-ca|verify-full.
-// verify-ca skips the hostname check (matching libpq), verify-full keeps it.
+// Every enabled mode validates the certificate; verify-ca alone skips the hostname check.
 export const getDbSslConfig = (): PoolConfig['ssl'] => {
   const raw = process.env.DB_SSL?.trim().toLowerCase();
   if (!raw || raw === 'false' || raw === 'disable') return false;
-  if (raw === 'true' || raw === 'require') return { rejectUnauthorized: false };
-  if (raw === 'verify-full' || raw === 'verify-ca') {
+  if (raw === 'true' || raw === 'require' || raw === 'verify-full' || raw === 'verify-ca') {
     const ca = readSslCa();
     return {
       rejectUnauthorized: true,

--- a/server/test/db/config.test.ts
+++ b/server/test/db/config.test.ts
@@ -135,11 +135,10 @@ describe('getDbSslConfig', () => {
     expect(getDbSslConfig()).toBe(false);
   });
 
-  test('DB_SSL=true / require yields { rejectUnauthorized: false } (encrypt without CA validation)', () => {
-    process.env.DB_SSL = 'true';
-    expect(getDbSslConfig()).toEqual({ rejectUnauthorized: false });
-    process.env.DB_SSL = 'require';
-    expect(getDbSslConfig()).toEqual({ rejectUnauthorized: false });
+  test.each(['true', 'require'])('DB_SSL=%s enforces CA and hostname validation', (mode) => {
+    process.env.DB_SSL = mode;
+    process.env.DB_SSL_CA = 'TRUSTED_CA';
+    expect(getDbSslConfig()).toEqual({ rejectUnauthorized: true, ca: 'TRUSTED_CA' });
   });
 
   test('DB_SSL=verify-full enforces CA and hostname validation', () => {
@@ -213,7 +212,7 @@ describe('createDbPoolConfig', () => {
   test('propagates DB_SSL through to pool.ssl', () => {
     process.env.DB_SSL = 'require';
     const pool = createDbPoolConfig();
-    expect(pool.ssl).toEqual({ rejectUnauthorized: false });
+    expect(pool.ssl).toEqual({ rejectUnauthorized: true });
   });
 
   test('overrides win over both env vars and computed ssl', () => {


### PR DESCRIPTION
## Summary
- make `DB_SSL=true` and `DB_SSL=require` validate PostgreSQL server certificates and hostnames
- reuse configured CA material for all enabled TLS modes
- update deployment guidance and add regression coverage for runtime and migration pool configuration

## Testing
- `bun test ./test/db/config.test.ts ./test/db/drizzleConfig.test.ts` (28 passed)
- `bun run typecheck` (passed)
- `bunx biome check server/db/config.ts server/test/db/config.test.ts` (passed)
- backend suite from `bun run test` (4,698 passed, 0 failed; frontend run later stalled in an unrelated accounting test)
- `bun run test:react-doctor` (75/100 before and after; existing diagnostics unchanged)

## Risks / Rollout
- Deployments that relied on `true` or `require` with an untrusted/self-signed certificate must configure `DB_SSL_CA` or `DB_SSL_CA_FILE`; the connection now fails closed instead of skipping verification.
- No schema or data migration is required.

## Issues
Issue: Not linked