### PR TITLE
reports(security): rate limit AI generation requests

### DIFF
--- a/docs-site/src/content/docs/ai-reporting.md
+++ b/docs-site/src/content/docs/ai-reporting.md
@@ -33,6 +33,8 @@ Il toggle **Info tecniche** in alto a destra mostra il provider e il modello usa
 
 Il composer fluttua sopra la conversazione: resta compatto su una riga e cresce automaticamente quando il testo va su più righe. Premi **Invio** per inviare oppure **Shift+Invio** per andare a capo.
 
+L'invio e la rigenerazione delle risposte AI condividono un limite di 10 richieste al minuto per utente autenticato e indirizzo IP. Se il limite viene superato, Praetor restituisce una risposta 429: attendi la fine della finestra indicata prima di riprovare.
+
 Il pulsante con la graffetta allega fino a 5 file di testo, inclusi TXT, Markdown, CSV, JSON, XML, YAML, log, SQL e comuni file sorgente. Ogni file può pesare fino a 64 KB; il contenuto testuale complessivo degli allegati può raggiungere 12.000 caratteri. I file vengono letti nel browser e inclusi nella richiesta inviata ad AI Reporting. Il loro contenuto diventa una fonte dati esplicita per analisi, calcoli e visualizzazioni, ma viene sempre trattato come dato e mai come istruzione per l'AI.
 
 ## Dataset aziendali disponibili

--- a/docs-site/src/content/docs/en/ai-reporting.md
+++ b/docs-site/src/content/docs/en/ai-reporting.md
@@ -33,6 +33,8 @@ The **Technical info** toggle in the top-right corner shows the provider and mod
 
 The composer floats over the conversation: it stays compact on one line and grows automatically when the text wraps onto additional lines. Press **Enter** to send or **Shift+Enter** to insert a new line.
 
+Sending and regenerating AI answers share a limit of 10 requests per minute for each authenticated user and IP address. If the limit is exceeded, Praetor returns a 429 response; wait for the indicated window to end before retrying.
+
 Use the paperclip button to attach up to 5 text files, including TXT, Markdown, CSV, JSON, XML, YAML, logs, SQL, and common source-code files. Each file can be up to 64 KB, while the combined text content can contain up to 12,000 characters. Files are read in the browser and included in the request sent to AI Reporting. Their contents become an explicit data source for analysis, calculations, and visualizations, while remaining data rather than instructions for the AI.
 
 ## Available business datasets

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -59329,6 +59329,27 @@
               }
             }
           },
+          "429": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
           "503": {
             "description": "Default Response",
             "content": {
@@ -59474,6 +59495,27 @@
             }
           },
           "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
             "description": "Default Response",
             "content": {
               "application/json": {
@@ -59688,6 +59730,27 @@
             }
           },
           "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
             "description": "Default Response",
             "content": {
               "application/json": {

--- a/server/routes/reports.ts
+++ b/server/routes/reports.ts
@@ -22,7 +22,7 @@ import {
   requestHasPermission as hasPermission,
   canViewProjectDetails as hasProjectDetailsAccess,
 } from '../utils/permissions.ts';
-import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
+import { AI_REPORTING_CHAT_RATE_LIMIT, STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import { replyError } from '../utils/replyError.ts';
 import { badRequest, optionalNonEmptyString, requireNonEmptyString } from '../utils/validation.ts';
 
@@ -2375,6 +2375,7 @@ const createSseStreamHandlers = (
 
 export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.addHook('onRequest', authenticateToken);
+  const aiReportingChatRateLimit = fastify.rateLimit(AI_REPORTING_CHAT_RATE_LIMIT);
 
   const sessionSummarySchema = {
     type: 'object',
@@ -2677,7 +2678,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/ai-reporting/chat/stream',
     {
-      onRequest: [requirePermission('reports.ai_reporting.create')],
+      onRequest: [aiReportingChatRateLimit, requirePermission('reports.ai_reporting.create')],
       schema: {
         tags: ['reports'],
         summary: 'Send a message to AI Reporting and stream progress',
@@ -2691,7 +2692,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           required: ['message'],
         },
         response: {
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },
@@ -2922,7 +2923,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/ai-reporting/chat/edit-stream',
     {
-      onRequest: [requirePermission('reports.ai_reporting.create')],
+      onRequest: [aiReportingChatRateLimit, requirePermission('reports.ai_reporting.create')],
       schema: {
         tags: ['reports'],
         summary: 'Edit a user message and regenerate the assistant response via streaming',
@@ -2937,7 +2938,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           required: ['sessionId', 'messageId', 'content'],
         },
         response: {
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },
@@ -3164,7 +3165,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/ai-reporting/chat',
     {
-      onRequest: [requirePermission('reports.ai_reporting.create')],
+      onRequest: [aiReportingChatRateLimit, requirePermission('reports.ai_reporting.create')],
       schema: {
         tags: ['reports'],
         summary: 'Send a message to AI Reporting and store history',
@@ -3188,7 +3189,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             },
             required: ['sessionId', 'text'],
           },
-          ...standardErrorResponses,
+          ...standardRateLimitedErrorResponses,
         },
       },
     },

--- a/server/test/routes/reports.test.ts
+++ b/server/test/routes/reports.test.ts
@@ -44,6 +44,8 @@ const findAuthUserByIdMock = mock();
 const userHasRoleMock = mock();
 const getRolePermissionsMock = mock();
 const getGeneralSettingsMock = mock();
+const aiReportingRateLimitHookMock = mock(async () => {});
+const rateLimitMock = mock((_options: unknown) => aiReportingRateLimitHookMock);
 
 const listSessionsForUserMock = mock();
 const createSessionMock = mock();
@@ -242,6 +244,8 @@ const allMocks = [
   userHasRoleMock,
   getRolePermissionsMock,
   getGeneralSettingsMock,
+  aiReportingRateLimitHookMock,
+  rateLimitMock,
   listSessionsForUserMock,
   createSessionMock,
   archiveSessionMock,
@@ -284,6 +288,8 @@ let testApp: FastifyInstance;
 
 beforeEach(async () => {
   for (const m of allMocks) m.mockReset();
+  aiReportingRateLimitHookMock.mockImplementation(async () => {});
+  rateLimitMock.mockImplementation((_options: unknown) => aiReportingRateLimitHookMock);
   localAiFetchMock.mockClear();
   resetWithDbTransactionMock();
   findAuthUserByIdMock.mockResolvedValue(HAPPY_USER);
@@ -293,7 +299,9 @@ beforeEach(async () => {
   listManagedUserIdsMock.mockResolvedValue([]);
   listSupplierOptionsMock.mockResolvedValue([]);
 
-  testApp = await buildRouteTestApp(routePlugin, '/api/reports');
+  testApp = await buildRouteTestApp(routePlugin, '/api/reports', (app) => {
+    app.rateLimit = rateLimitMock as typeof app.rateLimit;
+  });
 });
 
 afterEach(async () => {
@@ -349,6 +357,44 @@ const openAiStreamResponse = (events: Array<Record<string, unknown>>) =>
       },
     }),
   }) as unknown as Response;
+
+describe('AI reporting chat rate limiting', () => {
+  test('shares a strict user-and-IP limit across all paid generation routes', async () => {
+    type RateLimitOptions = {
+      keyGenerator?: (request: { ip: string; user?: { id?: string } }) => string;
+      max?: number;
+      timeWindow?: string;
+    };
+    const matchingCalls = rateLimitMock.mock.calls.filter(([options]) => {
+      const config = options as RateLimitOptions;
+      return config.max === 10 && config.timeWindow === '1 minute';
+    });
+
+    expect(matchingCalls).toHaveLength(1);
+    const config = matchingCalls[0]?.[0] as RateLimitOptions;
+    expect(config.keyGenerator?.({ ip: '203.0.113.5', user: { id: 'user-1' } })).toBe(
+      'user:user-1:ip:203.0.113.5',
+    );
+
+    aiReportingRateLimitHookMock.mockClear();
+    for (const request of [
+      { url: '/api/reports/ai-reporting/chat', payload: { message: '' } },
+      { url: '/api/reports/ai-reporting/chat/stream', payload: { message: '' } },
+      {
+        url: '/api/reports/ai-reporting/chat/edit-stream',
+        payload: { sessionId: 's', messageId: 'm', content: '' },
+      },
+    ]) {
+      await testApp.inject({
+        method: 'POST',
+        url: request.url,
+        headers: authHeader(),
+        payload: request.payload,
+      });
+    }
+    expect(aiReportingRateLimitHookMock).toHaveBeenCalledTimes(3);
+  });
+});
 
 describe('determineRequestedSections', () => {
   test('does not select business datasets from attachment contents', () => {

--- a/server/test/utils/rate-limit.test.ts
+++ b/server/test/utils/rate-limit.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from 'bun:test';
+import Fastify from 'fastify';
+import rateLimit from 'fastify-rate-limit';
 import {
+  AI_REPORTING_CHAT_RATE_LIMIT,
   GLOBAL_RATE_LIMIT,
   LOGIN_RATE_LIMIT,
   STANDARD_ROUTE_RATE_LIMIT,
@@ -23,6 +26,41 @@ describe('LOGIN_RATE_LIMIT', () => {
   test('has the documented max and timeWindow', () => {
     expect(LOGIN_RATE_LIMIT.max).toBe(30);
     expect(LOGIN_RATE_LIMIT.timeWindow).toBe('15 minutes');
+  });
+});
+
+describe('AI_REPORTING_CHAT_RATE_LIMIT', () => {
+  test('blocks the eleventh request across routes sharing one limiter', async () => {
+    const app = Fastify({ logger: false });
+    await app.register(rateLimit, { global: false });
+    app.addHook('onRequest', async (request) => {
+      request.user = {
+        id: 'user-1',
+        name: 'Alice',
+        username: 'alice',
+        role: 'manager',
+        avatarInitials: 'AL',
+        permissions: ['reports.ai_reporting.create'],
+      };
+    });
+    const chatRateLimit = app.rateLimit(AI_REPORTING_CHAT_RATE_LIMIT);
+    app.post('/send', { onRequest: [chatRateLimit] }, async () => ({ ok: true }));
+    app.post('/regenerate', { onRequest: [chatRateLimit] }, async () => ({ ok: true }));
+
+    try {
+      for (let requestNumber = 0; requestNumber < 10; requestNumber++) {
+        const response = await app.inject({
+          method: 'POST',
+          url: requestNumber % 2 === 0 ? '/send' : '/regenerate',
+        });
+        expect(response.statusCode).toBe(200);
+      }
+
+      const blocked = await app.inject({ method: 'POST', url: '/regenerate' });
+      expect(blocked.statusCode).toBe(429);
+    } finally {
+      await app.close();
+    }
   });
 });
 

--- a/server/utils/rate-limit.ts
+++ b/server/utils/rate-limit.ts
@@ -1,3 +1,5 @@
+import type { FastifyRequest } from 'fastify';
+
 export const GLOBAL_RATE_LIMIT = {
   max: 3000,
   timeWindow: '1 minute',
@@ -11,4 +13,13 @@ export const STANDARD_ROUTE_RATE_LIMIT = {
 export const LOGIN_RATE_LIMIT = {
   max: 30,
   timeWindow: '15 minutes',
+} as const;
+
+export const AI_REPORTING_CHAT_RATE_LIMIT = {
+  max: 10,
+  timeWindow: '1 minute',
+  keyGenerator: (request: FastifyRequest) => {
+    const userId = request.user?.id;
+    return userId ? `user:${userId}:ip:${request.ip}` : `ip:${request.ip}`;
+  },
 } as const;


### PR DESCRIPTION
## Summary
- add a shared 10 requests/minute limiter for AI Reporting send and regenerate operations
- key the cost-control bucket by authenticated user and client IP across all three generation endpoints
- document 429 responses in OpenAPI and the Italian/English user guides

## Changes
- reuse one route limiter instance so streaming, edit-streaming, and non-streaming requests consume the same bucket
- add route-wiring and real Fastify enforcement regression coverage
- expose the 429 response schema for every limited endpoint

## Testing
- `bun test ./test/routes/reports.test.ts ./test/utils/rate-limit.test.ts` (97 passed)
- `bun run typecheck`
- `bun run i18n:check`
- `bunx biome check server/routes/reports.ts server/test/routes/reports.test.ts server/test/utils/rate-limit.test.ts server/utils/rate-limit.ts`
- full backend suite via `bun run test`: 4,698 passed; the subsequent frontend run stalled in the pre-existing `ClientsOrdersView` suite and was stopped
- `bun run test:react-doctor`: unchanged at 75/100 (exits non-zero for 94 pre-existing findings)

## Risks / Rollout
- Low risk and no migration required. The limiter uses the application's existing in-memory rate-limit store, so the effective ceiling remains per server process in horizontally scaled deployments.

## Issues
- DeepSec finding `0f897cd4f8`; no GitHub issue linked.