### PR TITLE
server(security): mask internal errors by default

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -57,6 +57,9 @@ UPLOAD_PATH=./uploads
 LOG_LEVEL=info
 # Pretty logs are enabled by default outside production; force with true/false if needed.
 # LOG_PRETTY=true
+# 5xx response details are masked by default. For local debugging only, detailed messages
+# require both NODE_ENV=development and this explicit opt-in. Never enable it in deployment.
+# EXPOSE_INTERNAL_ERRORS=true
 
 # LDAP Configuration (for Docker/Self-Signed Certs)
 # LDAP_TLS_CA_FILE=/app/certs/ca.crt

--- a/server/app.ts
+++ b/server/app.ts
@@ -72,17 +72,18 @@ const parseTrustProxyEnv = (value: string | undefined): boolean | string | numbe
   return value.trim();
 };
 
-// Exported for testing. In production, sanitize 5xx response bodies so internal error details
-// (stack traces, DB column names, etc.) never reach API clients. The full error is still
-// recorded server-side via request.log.error. 4xx responses pass through unchanged so
-// validation/auth/etc. messages remain useful to API clients in every environment.
+// Exported for testing. Sanitize 5xx response bodies by default so a missing or incorrect
+// NODE_ENV cannot expose internal details. Local development can opt in explicitly, while
+// production always stays masked. The full error is still recorded via request.log.error.
+// 4xx responses pass through so validation/auth messages remain useful to API clients.
 export const buildErrorResponseMessage = (
   error: Error & { statusCode?: number },
   env: NodeJS.ProcessEnv = process.env,
 ): { statusCode: number; message: string } => {
   const statusCode = error.statusCode || 500;
-  const isProduction = env.NODE_ENV === 'production';
-  const shouldMaskMessage = isProduction && statusCode >= 500;
+  const exposeInternalErrors =
+    env.NODE_ENV === 'development' && env.EXPOSE_INTERNAL_ERRORS?.trim().toLowerCase() === 'true';
+  const shouldMaskMessage = statusCode >= 500 && !exposeInternalErrors;
   const message = shouldMaskMessage
     ? 'Internal server error'
     : error.message || 'Internal server error';

--- a/server/test/app.test.ts
+++ b/server/test/app.test.ts
@@ -48,16 +48,22 @@ const buildTestApp = () => {
   return { fastify, logLines };
 };
 
-// Capture both the value and presence: assigning `undefined` back to `process.env.NODE_ENV`
-// would stringify to the literal `'undefined'` and break later reads, so delete it instead
-// when the var wasn't set at module load.
+// Capture both values and presence: assigning `undefined` back to `process.env` stringifies
+// it to the literal `'undefined'`, so delete variables that were absent at module load.
 const hadOriginalNodeEnv = 'NODE_ENV' in process.env;
 const originalNodeEnv = process.env.NODE_ENV;
+const hadOriginalExposeInternalErrors = 'EXPOSE_INTERNAL_ERRORS' in process.env;
+const originalExposeInternalErrors = process.env.EXPOSE_INTERNAL_ERRORS;
 afterEach(() => {
   if (hadOriginalNodeEnv) {
     process.env.NODE_ENV = originalNodeEnv;
   } else {
     delete process.env.NODE_ENV;
+  }
+  if (hadOriginalExposeInternalErrors) {
+    process.env.EXPOSE_INTERNAL_ERRORS = originalExposeInternalErrors;
+  } else {
+    delete process.env.EXPOSE_INTERNAL_ERRORS;
   }
 });
 
@@ -87,11 +93,35 @@ describe('buildErrorResponseMessage', () => {
     expect(result).toEqual({ statusCode: 400, message: 'Invalid email' });
   });
 
-  test('non-production + 500: original message passes through (developer ergonomics)', () => {
+  test('development + 500: masks sensitive details by default', () => {
     const result = buildErrorResponseMessage(new Error('SQL near "FROM" failed'), {
       NODE_ENV: 'development',
     } as NodeJS.ProcessEnv);
+    expect(result).toEqual({ statusCode: 500, message: 'Internal server error' });
+  });
+
+  test('missing NODE_ENV + 500: masks sensitive details by default', () => {
+    const result = buildErrorResponseMessage(
+      new Error('SQL near "FROM" failed'),
+      {} as NodeJS.ProcessEnv,
+    );
+    expect(result).toEqual({ statusCode: 500, message: 'Internal server error' });
+  });
+
+  test('development + explicit opt-in: exposes detailed 500 messages', () => {
+    const result = buildErrorResponseMessage(new Error('SQL near "FROM" failed'), {
+      NODE_ENV: 'development',
+      EXPOSE_INTERNAL_ERRORS: 'true',
+    } as NodeJS.ProcessEnv);
     expect(result).toEqual({ statusCode: 500, message: 'SQL near "FROM" failed' });
+  });
+
+  test('production ignores the detailed-error opt-in', () => {
+    const result = buildErrorResponseMessage(new Error('SQL near "FROM" failed'), {
+      NODE_ENV: 'production',
+      EXPOSE_INTERNAL_ERRORS: 'true',
+    } as NodeJS.ProcessEnv);
+    expect(result).toEqual({ statusCode: 500, message: 'Internal server error' });
   });
 
   test('falls back to "Internal server error" when the Error has no message', () => {
@@ -163,8 +193,22 @@ describe('Fastify error handler integration', () => {
     await fastify.close();
   });
 
-  test('non-production: 5xx error messages still pass through to the client', async () => {
+  test('development masks 5xx error messages unless explicitly enabled', async () => {
     process.env.NODE_ENV = 'development';
+    delete process.env.EXPOSE_INTERNAL_ERRORS;
+    const { fastify } = buildTestApp();
+
+    const response = await fastify.inject({ method: 'GET', url: '/boom-500' });
+
+    expect(response.statusCode).toBe(500);
+    expect(JSON.parse(response.body)).toEqual({ error: 'Internal server error' });
+
+    await fastify.close();
+  });
+
+  test('development can explicitly enable detailed 5xx error messages', async () => {
+    process.env.NODE_ENV = 'development';
+    process.env.EXPOSE_INTERNAL_ERRORS = 'true';
     const { fastify } = buildTestApp();
 
     const response = await fastify.inject({ method: 'GET', url: '/boom-500' });


### PR DESCRIPTION
## Summary
- Mask all 5xx exception messages by default, including when `NODE_ENV` is unset or misconfigured.
- Allow detailed 5xx responses only with the explicit local-development combination `NODE_ENV=development` and `EXPOSE_INTERNAL_ERRORS=true`.

## Changes
- Tightened the shared Fastify error response builder while preserving server-side error logging and 4xx messages.
- Added unit and handler-level regression coverage for fail-closed defaults, development opt-in, and production enforcement.
- Documented the local-only opt-in in `server/.env.example`.

## Testing
- `cd server && bun test ./test/app.test.ts` (15 passed)
- `bun run test:server` via `bun run test` (4,709 passed, 0 failed)
- `bun run lint` reached and passed i18n and TypeScript checks; repository-wide Biome formatting is blocked locally by pre-existing Windows CRLF checkout diagnostics.
- `bunx biome check --formatter-enabled=false server/app.ts server/test/app.test.ts` (passed)
- `bun run test:react-doctor` (75/100 before and after; unchanged, exits 1 on pre-existing diagnostics)
- Full frontend test run was attempted but Bun 1.3.14 crashed with an internal assertion after reaching 10.24 GB peak memory; no frontend code changed.

## Risks / Rollout
- Low risk and backend-only. Existing local development that intentionally relied on raw 5xx messages must set the documented explicit opt-in.
- No database, dependency, API success-path, or user-documentation changes.

## Issues
- Issue: Not linked (DeepSec finding `praetor-other-info-disclosure-265e90582f`)