### PR TITLE
mcp(security): prevent HR detail disclosure

### DIFF
--- a/docs-site/src/content/docs/ai-reporting.md
+++ b/docs-site/src/content/docs/ai-reporting.md
@@ -168,6 +168,7 @@ Gli strumenti di aggiornamento dei consuntivi richiedono il campo `version` rest
 Note di sicurezza:
 
 - I token MCP ereditano i permessi del tuo ruolo corrente al momento della chiamata, filtrati dall'ambito del token (completo o sola lettura).
+- `praetor_get_users_hierarchy` restituisce i dettagli HR solo per i tipi di dipendente autorizzati da `hr.internal.view` o `hr.external.view`. La visibilità di email e costi orari resta regolata separatamente dai relativi permessi.
 - I token scadono automaticamente dopo 30 giorni di inattività. Gli operatori possono modificare la finestra tramite la variabile d'ambiente `MCP_IDLE_TIMEOUT_MS` (millisecondi).
 - Il cambio password del tuo account invalida anche tutti i token MCP precedentemente emessi. Dopo una rotazione della password devi ricreare i token e reimpostare gli agenti.
 - L'endpoint MCP è limitato alla soglia standard delle route autenticate (600 richieste/minuto per IP client); le richieste in eccesso ricevono una risposta 429.

--- a/docs-site/src/content/docs/en/ai-reporting.md
+++ b/docs-site/src/content/docs/en/ai-reporting.md
@@ -168,6 +168,7 @@ Time-entry update tools require the `version` field returned by `praetor_list_ti
 Security notes:
 
 - MCP tokens inherit your current role permissions at call time, filtered by the token's scope (full or read-only).
+- `praetor_get_users_hierarchy` returns HR details only for employee types authorized by `hr.internal.view` or `hr.external.view`. Email and hourly-cost visibility remain controlled independently by their respective permissions.
 - Tokens expire automatically after 30 days of inactivity. Operators can override the window with the `MCP_IDLE_TIMEOUT_MS` environment variable (milliseconds).
 - Changing your account password also invalidates every MCP token you previously issued. Re-issue and re-key your agents after a password rotation.
 - The MCP endpoint is rate-limited at the standard authenticated-route limit (600 requests/minute per client IP); excess requests get a 429 response.

--- a/server/routes/mcp.ts
+++ b/server/routes/mcp.ts
@@ -27,6 +27,10 @@ import {
   TimeEntryServiceError,
   updateTimeEntry,
 } from '../services/timeEntries.ts';
+import {
+  HR_VIEW_PERMISSION_BY_EMPLOYEE_TYPE,
+  maskUserResponse,
+} from '../services/userVisibility.ts';
 import { APP_VERSION } from '../utils/app-version.ts';
 import { todayLocalDateOnly } from '../utils/date.ts';
 import { canViewProjectDetails, equivalentPermissionsFor } from '../utils/permissions.ts';
@@ -193,15 +197,6 @@ const canViewCostFor = (user: McpAuthenticatedUser, targetUserId: string | null 
   if (targetUserId === user.id) return hasPermission(user, 'hr.costs.view');
   return hasPermission(user, 'hr.costs_all.view');
 };
-
-const maskUser = (
-  user: usersRepo.UserListRow,
-  options: { canViewCosts: boolean; canViewEmails: boolean },
-) => ({
-  ...user,
-  email: options.canViewEmails ? user.email : '',
-  costPerHour: options.canViewCosts ? user.costPerHour : 0,
-});
 
 const runTimeEntryTool = async (
   operation: () => Promise<Record<string, unknown>>,
@@ -564,17 +559,21 @@ const buildServer = () => {
 
       return jsonResult({
         users: users.map((entry) =>
-          maskUser(
+          maskUserResponse(
             { ...entry, costPerHour: currentCosts.get(entry.id) ?? entry.costPerHour },
             {
               canViewCosts: canViewCostFor(user, entry.id),
               canViewEmails: hasEmailView,
+              canViewHrDetails: hasPermission(
+                user,
+                HR_VIEW_PERMISSION_BY_EMPLOYEE_TYPE[entry.employeeType],
+              ),
             },
           ),
         ),
         // Expose only member user IDs, derived from the members the repo already returns
         // (no second user_work_units query). The member display names are deliberately
-        // dropped here — they would bypass the per-user `maskUser` scoping applied to
+        // dropped here — they would bypass the per-user `maskUserResponse` scoping applied to
         // `users` above.
         workUnits: visibleWorkUnits.map(({ members, ...unit }) => ({
           ...unit,

--- a/server/routes/users.ts
+++ b/server/routes/users.ts
@@ -28,7 +28,12 @@ import {
   externalGroupsYieldNoKnownRole,
 } from '../services/external-auth.ts';
 import { requiresTotpEnrollment } from '../services/totpEnforcement.ts';
-import { getUserVisibilityScope } from '../services/userVisibility.ts';
+import {
+  getUserVisibilityScope,
+  HR_DETAIL_FIELDS,
+  HR_VIEW_PERMISSION_BY_EMPLOYEE_TYPE,
+  maskUserResponse,
+} from '../services/userVisibility.ts';
 import { getAuditChangedFields, getAuditCounts, logAudit } from '../utils/audit.ts';
 import { assertAuthenticated } from '../utils/auth-assert.ts';
 import { todayLocalDateOnly } from '../utils/date.ts';
@@ -403,35 +408,8 @@ const HR_UPDATE_PERM_BY_EMPLOYEE_TYPE: Record<usersRepo.EmployeeType, string> = 
   external: 'hr.external.update',
 };
 
-const HR_VIEW_PERM_BY_EMPLOYEE_TYPE: Record<usersRepo.EmployeeType, string> = {
-  app_user: 'hr.internal.view',
-  internal: 'hr.internal.view',
-  external: 'hr.external.view',
-};
-
-const HR_DETAIL_FIELDS = [
-  'firstName',
-  'lastName',
-  'phone',
-  'jobTitle',
-  'department',
-  'responsibleUserId',
-  'employeeCode',
-  'hireDate',
-  'terminationDate',
-  'contractType',
-  'employmentStatus',
-  'workLocation',
-  'emergencyContactName',
-  'emergencyContactPhone',
-  'address',
-  'notes',
-] as const;
-
-const HR_RESPONSE_DETAIL_FIELDS = [...HR_DETAIL_FIELDS, 'responsibleUserName'] as const;
-
 const canViewHrDetailsFor = (request: FastifyRequest, employeeType: usersRepo.EmployeeType) =>
-  hasPermission(request, HR_VIEW_PERM_BY_EMPLOYEE_TYPE[employeeType]);
+  hasPermission(request, HR_VIEW_PERMISSION_BY_EMPLOYEE_TYPE[employeeType]);
 
 const canUpdateHrDetailsFor = (request: FastifyRequest, employeeType: usersRepo.EmployeeType) =>
   hasPermission(request, HR_UPDATE_PERM_BY_EMPLOYEE_TYPE[employeeType]);
@@ -439,34 +417,12 @@ const canUpdateHrDetailsFor = (request: FastifyRequest, employeeType: usersRepo.
 const canViewEmailFor = (request: FastifyRequest, user: usersRepo.UserListRow) =>
   canViewUserEmails(request) || canViewHrDetailsFor(request, user.employeeType);
 
-const maskUserResponse = (
-  user: usersRepo.UserListRow,
-  canViewCosts: boolean,
-  canRevealUserEmails: boolean,
-  canRevealHrDetails: boolean,
-) => {
-  const response: Partial<usersRepo.UserListRow> = {
-    ...user,
-    email: canRevealUserEmails ? user.email : '',
-    costPerHour: canViewCosts ? user.costPerHour : 0,
-  };
-
-  if (!canRevealHrDetails) {
-    for (const field of HR_RESPONSE_DETAIL_FIELDS) {
-      delete response[field];
-    }
-  }
-
-  return response;
-};
-
 const maskUserForRequest = (request: FastifyRequest, user: usersRepo.UserListRow) =>
-  maskUserResponse(
-    user,
-    canViewCostFor(request, user.id),
-    canViewEmailFor(request, user),
-    canViewHrDetailsFor(request, user.employeeType),
-  );
+  maskUserResponse(user, {
+    canViewCosts: canViewCostFor(request, user.id),
+    canViewEmails: canViewEmailFor(request, user),
+    canViewHrDetails: canViewHrDetailsFor(request, user.employeeType),
+  });
 
 // Cost visibility per row — the two scopes are strictly independent:
 //   - own row    → hr.costs.view       (personal-scope, read-only counterpart of hr.costs.update)

--- a/server/services/userVisibility.ts
+++ b/server/services/userVisibility.ts
@@ -1,10 +1,37 @@
 import type { FastifyRequest } from 'fastify';
-import type { ManagerScopeOptions } from '../repositories/usersRepo.ts';
+import type { EmployeeType, ManagerScopeOptions, UserListRow } from '../repositories/usersRepo.ts';
 import { requestHasPermission as hasPermission } from '../utils/permissions.ts';
 
 export type UserVisibilityScope = ManagerScopeOptions & {
   canViewAllUsers: boolean;
 };
+
+export const HR_VIEW_PERMISSION_BY_EMPLOYEE_TYPE: Record<EmployeeType, string> = {
+  app_user: 'hr.internal.view',
+  internal: 'hr.internal.view',
+  external: 'hr.external.view',
+};
+
+export const HR_DETAIL_FIELDS = [
+  'firstName',
+  'lastName',
+  'phone',
+  'jobTitle',
+  'department',
+  'responsibleUserId',
+  'employeeCode',
+  'hireDate',
+  'terminationDate',
+  'contractType',
+  'employmentStatus',
+  'workLocation',
+  'emergencyContactName',
+  'emergencyContactPhone',
+  'address',
+  'notes',
+] as const;
+
+const HR_RESPONSE_DETAIL_FIELDS = [...HR_DETAIL_FIELDS, 'responsibleUserName'] as const;
 
 export const getUserVisibilityScope = (request: FastifyRequest): UserVisibilityScope => ({
   canViewAllUsers:
@@ -20,3 +47,26 @@ export const getUserVisibilityScope = (request: FastifyRequest): UserVisibilityS
   canViewInternal: hasPermission(request, 'hr.internal.view'),
   canViewExternal: hasPermission(request, 'hr.external.view'),
 });
+
+export const maskUserResponse = (
+  user: UserListRow,
+  options: {
+    canViewCosts: boolean;
+    canViewEmails: boolean;
+    canViewHrDetails: boolean;
+  },
+): Partial<UserListRow> => {
+  const response: Partial<UserListRow> = {
+    ...user,
+    email: options.canViewEmails ? user.email : '',
+    costPerHour: options.canViewCosts ? user.costPerHour : 0,
+  };
+
+  if (!options.canViewHrDetails) {
+    for (const field of HR_RESPONSE_DETAIL_FIELDS) {
+      delete response[field];
+    }
+  }
+
+  return response;
+};

--- a/server/test/routes/mcp.test.ts
+++ b/server/test/routes/mcp.test.ts
@@ -357,6 +357,36 @@ const makeCreateTimeEntryArgs = (task: string) => ({
   task,
   duration: 1,
 });
+const FULL_HR_USER = {
+  id: 'u2',
+  name: 'Bob',
+  username: 'bob',
+  email: 'bob@example.com',
+  role: 'user',
+  avatarInitials: 'BO',
+  costPerHour: 84,
+  isDisabled: false,
+  employeeType: 'internal' as const,
+  hasTopManagerRole: false,
+  isAdminOnly: false,
+  firstName: 'Robert',
+  lastName: 'Example',
+  phone: '+39 555 0100',
+  jobTitle: 'Engineer',
+  department: 'Research',
+  responsibleUserId: 'u3',
+  responsibleUserName: 'Manager',
+  employeeCode: 'EMP-002',
+  hireDate: '2024-01-15',
+  terminationDate: null,
+  contractType: 'permanent' as const,
+  employmentStatus: 'active' as const,
+  workLocation: 'hybrid' as const,
+  emergencyContactName: 'Emergency Contact',
+  emergencyContactPhone: '+39 555 0199',
+  address: 'Private address',
+  notes: 'Private HR notes',
+};
 const FULL_PROJECT = {
   id: 'p1',
   name: 'Project One',
@@ -733,6 +763,82 @@ describe('/api/mcp', () => {
     expect(workUnitsListUserIdsByUnitIdsMock).not.toHaveBeenCalled();
     expect(usersListAllForAdminMock).not.toHaveBeenCalled();
     expect(workUnitsListAllMock).not.toHaveBeenCalled();
+  });
+
+  test('does not disclose HR details through hierarchy-only permissions', async () => {
+    currentPermissions = ['timesheets.tracker.view', 'hr.work_units.view'];
+    usersListScopedForManagerMock.mockResolvedValue([FULL_HR_USER]);
+
+    const res = await rpc({
+      jsonrpc: '2.0',
+      id: 17,
+      method: 'tools/call',
+      params: { name: 'praetor_get_users_hierarchy', arguments: {} },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = parseMcpBody(res.body);
+    expect(body.result.structuredContent.users).toEqual([
+      {
+        id: 'u2',
+        name: 'Bob',
+        username: 'bob',
+        email: '',
+        role: 'user',
+        avatarInitials: 'BO',
+        costPerHour: 0,
+        isDisabled: false,
+        employeeType: 'internal',
+        hasTopManagerRole: false,
+        isAdminOnly: false,
+      },
+    ]);
+  });
+
+  test('reveals MCP hierarchy HR details only for the matching employee type', async () => {
+    currentPermissions = ['timesheets.tracker.view', 'hr.internal.view'];
+    usersListScopedForManagerMock.mockResolvedValue([
+      FULL_HR_USER,
+      {
+        ...FULL_HR_USER,
+        id: 'u3',
+        name: 'Eve',
+        username: 'eve',
+        employeeType: 'external',
+      },
+    ]);
+
+    const res = await rpc({
+      jsonrpc: '2.0',
+      id: 18,
+      method: 'tools/call',
+      params: { name: 'praetor_get_users_hierarchy', arguments: {} },
+    });
+
+    expect(res.statusCode).toBe(200);
+    const body = parseMcpBody(res.body);
+    const [internalUser, externalUser] = body.result.structuredContent.users;
+    expect(internalUser).toMatchObject({
+      id: 'u2',
+      firstName: 'Robert',
+      emergencyContactName: 'Emergency Contact',
+      notes: 'Private HR notes',
+      email: '',
+      costPerHour: 0,
+    });
+    expect(externalUser).toEqual({
+      id: 'u3',
+      name: 'Eve',
+      username: 'eve',
+      email: '',
+      role: 'user',
+      avatarInitials: 'BO',
+      costPerHour: 0,
+      isDisabled: false,
+      employeeType: 'external',
+      hasTopManagerRole: false,
+      isAdminOnly: false,
+    });
   });
 
   test('hr.costs.view → caller sees own costPerHour, other rows masked', async () => {


### PR DESCRIPTION
## Summary
- Prevents `praetor_get_users_hierarchy` from exposing HR and PII fields to MCP callers without employee-type HR view permissions.
- Keeps email and hourly-cost masking independent and documents the permission behavior in Italian and English.

## Changes
- Centralizes HR field masking and employee-type permission mapping in the existing user visibility service, shared by REST and MCP routes.
- Adds MCP regression coverage for hierarchy-only callers and mixed internal/external visibility.

## Testing
- `DB_PASSWORD=test bun test server/test/routes/mcp.test.ts server/test/routes/users.test.ts` (184 passed)
- `bun run typecheck` (passed)
- `bunx biome check server/routes/mcp.ts server/routes/users.ts server/services/userVisibility.ts server/test/routes/mcp.test.ts` (passed)
- `bun run docs:user` (passed)
- Full backend suite: 4,707 passed, 29 skipped, 0 failed
- React Doctor: 75/100 before and after
- Full frontend suite was attempted twice but Bun 1.3.14 crashed on Windows with an internal assertion at 11.17 GB peak memory; no test assertion failed before the runner crash.
- Repository-wide Biome formatting is blocked locally by pre-existing CRLF checkout normalization; all changed TypeScript files pass Biome.

## Risks / Rollout
- Low risk. This only removes unauthorized response fields and reuses the established REST masking policy; no database or configuration changes.

## Issues
Issue: Not linked