### PR TITLE
backend(security): set production runtime in image

### DIFF
--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -8,6 +8,8 @@ RUN bun install --frozen-lockfile
 FROM oven/bun:1.3.14-slim AS release
 WORKDIR /app
 
+ENV NODE_ENV=production
+
 COPY --from=install --chown=bun:bun /temp/node_modules node_modules
 COPY --chown=bun:bun . .
 

--- a/server/test/dockerfile.test.ts
+++ b/server/test/dockerfile.test.ts
@@ -1,0 +1,12 @@
+import { describe, expect, test } from 'bun:test';
+
+const dockerfile = await Bun.file(new URL('../Dockerfile', import.meta.url)).text();
+
+describe('backend production image', () => {
+  test('sets NODE_ENV=production in the release stage', () => {
+    const releaseStage = dockerfile.split(/^FROM .+ AS release$/m)[1];
+
+    expect(releaseStage).toBeDefined();
+    expect(releaseStage).toMatch(/^ENV NODE_ENV=production$/m);
+  });
+});


### PR DESCRIPTION
## Summary
- set `NODE_ENV=production` in the backend release image so production 5xx responses remain sanitized by default
- add a regression test that pins the release-stage runtime environment

## Testing
- `bun test ./test/dockerfile.test.ts`
- `bun run test:server` (4713 passed, 29 skipped)
- `bun run typecheck`
- `bun run test:react-doctor` (75/100 before and after; exits 1 for pre-existing findings)
- `bunx biome check server/test/dockerfile.test.ts`

## Risks / Rollout
- Low risk and limited to the backend container release stage. Explicit runtime overrides remain possible.
- No database, API, dependency, or user-documentation changes.

## Issues
Issue: Not linked