### PR TITLE
quotes(security): mask quote creation database errors

### DIFF
--- a/server/routes/client-quotes.ts
+++ b/server/routes/client-quotes.ts
@@ -37,7 +37,7 @@ import {
   withCalculatedClientLineMol,
 } from '../utils/client-line-pricing.ts';
 import { isPastLocalDate } from '../utils/date.ts';
-import { getUniqueViolation } from '../utils/db-errors.ts';
+import { getForeignKeyViolation, getUniqueViolation } from '../utils/db-errors.ts';
 import { replyDocumentCodeCollision } from '../utils/document-code-replies.ts';
 import {
   DOCUMENT_CODE_MAX_LENGTH,
@@ -1753,6 +1753,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           quoteId: nextIdResult.value ?? 'auto',
         });
         if (autoOfferConflict) return autoOfferConflict;
+        const foreignKeyViolation = getForeignKeyViolation(err);
+        if (foreignKeyViolation?.constraint === 'quotes_client_id_clients_id_fk') {
+          return badRequest(reply, 'Client not found');
+        }
         if (err instanceof ConflictError) {
           return replyError(request, reply, {
             statusCode: err.statusCode,
@@ -1762,8 +1766,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             details: { secondaryLabel: 'supplier_quote_changed' },
           });
         }
-        request.log.error({ err }, 'CRITICAL ERROR creating quote');
-        return reply.code(500).send({ error: `Internal Server Error: ${(err as Error).message}` });
+        throw err;
       }
     },
   );

--- a/server/test/routes/client-quotes.test.ts
+++ b/server/test/routes/client-quotes.test.ts
@@ -1849,28 +1849,32 @@ describe('client quote candidate-family create and update', () => {
     );
     return names;
   };
+  const quotePayload = (
+    items: Array<Record<string, unknown>>,
+    over: Record<string, unknown> = {},
+  ) => ({
+    id: 'q-new',
+    clientId: 'c1',
+    clientName: 'Client',
+    items,
+    candidates: [
+      {
+        name: 'Variante A',
+        items,
+        expirationDate: '2999-12-31',
+        communicationChannelId: 'qcc_email',
+      },
+    ],
+    expirationDate: '2999-12-31',
+    communicationChannelId: 'qcc_email',
+    ...over,
+  });
   const postQuote = (items: Array<Record<string, unknown>>, over: Record<string, unknown> = {}) =>
     testApp.inject({
       method: 'POST',
       url: '/api/sales/client-quotes',
       headers: authHeader(),
-      payload: {
-        id: 'q-new',
-        clientId: 'c1',
-        clientName: 'Client',
-        items,
-        candidates: [
-          {
-            name: 'Variante A',
-            items,
-            expirationDate: '2999-12-31',
-            communicationChannelId: 'qcc_email',
-          },
-        ],
-        expirationDate: '2999-12-31',
-        communicationChannelId: 'qcc_email',
-        ...over,
-      },
+      payload: quotePayload(items, over),
     });
   const putCandidateFamily = (discount: number, itemOverrides: Record<string, unknown> = {}) =>
     testApp.inject({
@@ -1943,6 +1947,48 @@ describe('client quote candidate-family create and update', () => {
       items: [SUPPLIER_ITEM],
     });
   };
+
+  test('400 rejects a quote for a nonexistent client without disclosing database details', async () => {
+    setupCreate();
+    cqCreateMock.mockRejectedValue({
+      code: '23503',
+      constraint: 'quotes_client_id_clients_id_fk',
+      message: 'insert into quotes violated private_constraint_name',
+    });
+
+    const res = await postQuote([freshLine()], { clientId: 'missing-client' });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({ error: 'Client not found' });
+    expect(res.body).not.toContain('private_constraint_name');
+  });
+
+  test('500 delegates unexpected create failures to the application error handler', async () => {
+    setupCreate();
+    cqCreateMock.mockRejectedValue(
+      new Error('insert into quotes violated private_constraint_name'),
+    );
+    const maskingApp = await buildRouteTestApp(routePlugin, '/api/sales/client-quotes', (app) => {
+      app.setErrorHandler((_error, _request, reply) =>
+        reply.code(500).send({ error: 'Internal server error' }),
+      );
+    });
+
+    try {
+      const res = await maskingApp.inject({
+        method: 'POST',
+        url: '/api/sales/client-quotes',
+        headers: authHeader(),
+        payload: quotePayload([freshLine()]),
+      });
+
+      expect(res.statusCode).toBe(500);
+      expect(JSON.parse(res.body)).toEqual({ error: 'Internal server error' });
+      expect(res.body).not.toContain('private_constraint_name');
+    } finally {
+      await maskingApp.close();
+    }
+  });
 
   const setupLegacyCandidateUpdate = (quoteId = 'q-1') => {
     setupCreate();


### PR DESCRIPTION
## Summary
- stop quote creation from returning raw database exception messages
- translate the known missing-client foreign-key failure into a generic 400 response
- delegate unexpected failures to the application error handler for production masking and server-side logging

## Changes
- reuse the shared PostgreSQL foreign-key detector for the quote/client constraint
- add regression coverage for missing-client failures and unexpected internal failures
- user and generated API docs remain unchanged because the route already declares the standard 400 response and no user workflow changed

## Testing
- `DB_PASSWORD=test bun run test:server` (4710 passed, 29 skipped)
- `bun run typecheck`
- `bunx biome check server/routes/client-quotes.ts server/test/routes/client-quotes.test.ts`
- `bun run test:react-doctor` (unchanged 75/100; exits 1 for 94 pre-existing findings)
- three consecutive review/simplify cycles completed cleanly

## Risks / Rollout
- Low risk; scoped to quote-create error translation and fallback handling. No migration, configuration, or dependency changes.

## Issues
- Issue: Not linked (DeepSec finding e50d72200c)