### PR TITLE
accounting(security): prevent supplier invoice route confusion

### DIFF
--- a/docs-site/src/content/docs/en/sales-accounting.md
+++ b/docs-site/src/content/docs/en/sales-accounting.md
@@ -109,6 +109,8 @@ When you create an order from a supplier quote (with the dedicated button or thr
 
 Customer and supplier invoices should match actual orders and deliveries. Check taxable amounts, VAT, totals, and references to the linked document.
 
+When assigning or changing a supplier-invoice code manually, use only letters, numbers, hyphens, and underscores, up to 100 characters. Historical invoices with other codes remain accessible and can be edited without renaming them.
+
 After an invoice leaves draft status it becomes read-only: it cannot be moved back to draft or deleted. Delete only draft invoices that were created by mistake, before issuing them.
 
 The amount paid cannot exceed the invoice total. When an invoice is set to **paid**, the amount paid must cover at least the full total; otherwise Praetor rejects the save so aging, balances, and reports stay consistent.

--- a/docs-site/src/content/docs/sales-accounting.md
+++ b/docs-site/src/content/docs/sales-accounting.md
@@ -109,6 +109,8 @@ Creando un ordine da un preventivo fornitore (con il pulsante dedicato o nella c
 
 Le fatture clienti e fornitori devono riflettere ordini e consegne effettive. Controlla imponibili, IVA, totale e riferimenti al documento collegato.
 
+Quando assegni o modifichi manualmente il codice di una fattura fornitore, usa solo lettere, numeri, trattini e trattini bassi, per un massimo di 100 caratteri. Le fatture storiche con codici diversi restano consultabili e modificabili senza rinominarle.
+
 Quando una fattura esce dallo stato bozza diventa in sola lettura: non può essere riportata in bozza o eliminata. Elimina solo le bozze create per errore, prima dell'emissione.
 
 L'importo pagato non può superare il totale della fattura. Quando una fattura viene impostata su **pagata**, l'importo pagato deve coprire almeno l'intero totale; in caso contrario Praetor respinge il salvataggio per mantenere coerenti scadenziari, saldi e report.

--- a/server/routes/supplier-invoices.ts
+++ b/server/routes/supplier-invoices.ts
@@ -12,9 +12,15 @@ import {
 import { logAudit } from '../utils/audit.ts';
 import { type DatabaseError, getUniqueViolation } from '../utils/db-errors.ts';
 import { replyDocumentCodeCollision } from '../utils/document-code-replies.ts';
+import {
+  DOCUMENT_CODE_MAX_LENGTH,
+  OPTIONAL_DOCUMENT_CODE_VALUE_PATTERN,
+  validateOptionalDocumentCode,
+} from '../utils/document-codes.ts';
 import { defaultDurationMonthsForUnit } from '../utils/duration-unit.ts';
 import { roundCurrency } from '../utils/invoice-math.ts';
 import { generatePrefixedId, ITEM_ID_PREFIXES } from '../utils/order-ids.ts';
+import { requirePathSegment } from '../utils/path-segments.ts';
 import { inheritPricingSemanticsVersions } from '../utils/pricing-semantics.ts';
 import { STANDARD_ROUTE_RATE_LIMIT } from '../utils/rate-limit.ts';
 import { replyError } from '../utils/replyError.ts';
@@ -37,6 +43,20 @@ import {
 
 const AMOUNT_PAID_EXCEEDS_TOTAL_ERROR = 'amountPaid cannot exceed total';
 const PAID_INVOICE_UNDERPAID_ERROR = 'amountPaid must be at least total when status is paid';
+
+const manualInvoiceCodeCreateSchema = {
+  type: 'string',
+  maxLength: DOCUMENT_CODE_MAX_LENGTH,
+  pattern: OPTIONAL_DOCUMENT_CODE_VALUE_PATTERN,
+  description:
+    'Optional manual invoice code. Letters, numbers, underscores, and hyphens only; blank allocates the configured automatic code.',
+} as const;
+
+const manualInvoiceCodeUpdateSchema = {
+  type: 'string',
+  description:
+    'Invoice code. A renamed code must use at most 100 letters, numbers, underscores, or hyphens; an unchanged legacy code remains accepted.',
+} as const;
 
 const duplicateInvoiceError = (databaseError: DatabaseError) => {
   if (databaseError.constraint === 'idx_supplier_invoices_linked_sale_id_unique') {
@@ -155,7 +175,7 @@ const invoiceItemBodySchema = {
 const createBodySchema = {
   type: 'object',
   properties: {
-    id: { type: 'string' },
+    id: manualInvoiceCodeCreateSchema,
     linkedSaleId: { type: 'string' },
     supplierId: { type: 'string' },
     supplierName: { type: 'string' },
@@ -174,7 +194,7 @@ const createBodySchema = {
 const updateBodySchema = {
   type: 'object',
   properties: {
-    id: { type: 'string' },
+    id: manualInvoiceCodeUpdateSchema,
     supplierId: { type: 'string' },
     supplierName: { type: 'string' },
     issueDate: { type: 'string', format: 'date' },
@@ -350,7 +370,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       const supplierNameResult = requireNonEmptyString(supplierName, 'supplierName');
       if (!supplierNameResult.ok) return badRequest(reply, supplierNameResult.message);
-      const nextIdResult = optionalNonEmptyString(nextId, 'id');
+      const nextIdResult = validateOptionalDocumentCode(nextId, 'id');
       if (!nextIdResult.ok) return badRequest(reply, nextIdResult.message);
 
       const issueDateResult = parseDateString(issueDate, 'issueDate');
@@ -615,7 +635,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         items: SupplierInvoiceItemInput[] | unknown;
       };
 
-      const idResult = requireNonEmptyString(id, 'id');
+      const idResult = requirePathSegment(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
       const patch: supplierInvoicesRepo.SupplierInvoiceUpdate = {};
@@ -634,7 +654,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       let nextIdValue: string | null = null;
       if (nextId !== undefined) {
-        const nextIdResult = optionalNonEmptyString(nextId, 'id');
+        const nextIdResult =
+          typeof nextId === 'string' && nextId.trim() === idResult.value
+            ? ({ ok: true, value: idResult.value } as const)
+            : validateOptionalDocumentCode(nextId, 'id');
         if (!nextIdResult.ok) return badRequest(reply, nextIdResult.message);
         nextIdValue = nextIdResult.value;
       }
@@ -912,7 +935,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
     },
     async (request: FastifyRequest, reply: FastifyReply) => {
       const { id } = request.params as { id: string };
-      const idResult = requireNonEmptyString(id, 'id');
+      const idResult = requirePathSegment(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
       const existing = await supplierInvoicesRepo.findStatusAndSupplierName(idResult.value);

--- a/server/test/routes/supplier-invoices.test.ts
+++ b/server/test/routes/supplier-invoices.test.ts
@@ -576,6 +576,23 @@ describe('POST /api/supplier-invoices', () => {
     expect(body.id).toBe('CUSTOM-1');
   });
 
+  test('400 rejects a manual invoice id that is unsafe in a URL path segment', async () => {
+    const unsafeId = '../supplier-orders/SORD-1?force=true';
+    createMock.mockResolvedValue({ ...SAMPLE_INVOICE, id: unsafeId });
+    insertItemsMock.mockResolvedValue([{ ...SAMPLE_ITEM, invoiceId: unsafeId }]);
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/supplier-invoices',
+      headers: authHeader(),
+      payload: { ...validBody, id: unsafeId },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(createMock).not.toHaveBeenCalled();
+    expect(insertItemsMock).not.toHaveBeenCalled();
+  });
+
   test('400 missing supplierId', async () => {
     const res = await testApp.inject({
       method: 'POST',
@@ -772,6 +789,50 @@ describe('POST /api/supplier-invoices', () => {
 });
 
 describe('PUT /api/supplier-invoices/:id', () => {
+  test('200 lets an existing unsafe invoice id be resubmitted unchanged', async () => {
+    const legacyId = '../supplier-orders/SORD-1?force=true';
+    findExistingMock.mockResolvedValue(existingInvoiceForUpdate({ id: legacyId }));
+    lockExistingByIdMock.mockResolvedValue({
+      ...existingInvoiceForUpdate({ id: legacyId }),
+      supplierName: 'Acme Supply',
+    });
+    updateMock.mockResolvedValue({ ...SAMPLE_INVOICE, id: legacyId, notes: 'updated' });
+    findItemsForInvoiceMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/supplier-invoices/..%2Fsupplier-orders%2FSORD-1%3Fforce%3Dtrue',
+      headers: authHeader(),
+      payload: { id: legacyId, notes: 'updated' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(findExistingMock).toHaveBeenCalledWith(legacyId);
+    expect(renameMock).not.toHaveBeenCalled();
+  });
+
+  test('200 decodes the transport escape for an existing dot-only invoice id', async () => {
+    const legacyId = '..';
+    findExistingMock.mockResolvedValue(existingInvoiceForUpdate({ id: legacyId }));
+    lockExistingByIdMock.mockResolvedValue({
+      ...existingInvoiceForUpdate({ id: legacyId }),
+      supplierName: 'Acme Supply',
+    });
+    updateMock.mockResolvedValue({ ...SAMPLE_INVOICE, id: legacyId, notes: 'updated' });
+    findItemsForInvoiceMock.mockResolvedValue([SAMPLE_ITEM]);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: `/api/supplier-invoices/${'~'.repeat(101)}..`,
+      headers: authHeader(),
+      payload: { id: legacyId, notes: 'updated' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(findExistingMock).toHaveBeenCalledWith(legacyId);
+    expect(renameMock).not.toHaveBeenCalled();
+  });
+
   test('200 partial update on draft invoice', async () => {
     findExistingMock.mockResolvedValue(existingInvoiceForUpdate());
     updateMock.mockResolvedValue({ ...SAMPLE_INVOICE, status: 'sent' });
@@ -1070,6 +1131,22 @@ describe('PUT /api/supplier-invoices/:id', () => {
 
     expect(res.statusCode).toBe(409);
     expect(JSON.parse(res.body)).toEqual({ error: 'Invoice ID already exists' });
+  });
+
+  test('400 rejects renaming an invoice to an id that is unsafe in a URL path segment', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+      headers: authHeader(),
+      payload: { id: '../supplier-orders/SORD-1?force=true' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'id can only contain letters, numbers, underscores, and hyphens',
+    });
+    expect(findExistingMock).not.toHaveBeenCalled();
+    expect(renameMock).not.toHaveBeenCalled();
   });
 
   test('400 dueDate before issueDate using effective dates', async () => {

--- a/services/api/supplierInvoices.ts
+++ b/services/api/supplierInvoices.ts
@@ -1,6 +1,10 @@
 import type { SupplierInvoice } from '../../types';
 import { fetchApi } from './client';
 import { normalizeSupplierInvoice } from './normalizers';
+import { encodePathSegment } from './path';
+
+const supplierInvoicePath = (id: string): string =>
+  `/accounting/supplier-invoices/${encodePathSegment(id)}`;
 
 export const supplierInvoicesApi = {
   list: (): Promise<SupplierInvoice[]> =>
@@ -15,11 +19,10 @@ export const supplierInvoicesApi = {
     }).then(normalizeSupplierInvoice),
 
   update: (id: string, updates: Partial<SupplierInvoice>): Promise<SupplierInvoice> =>
-    fetchApi<SupplierInvoice>(`/accounting/supplier-invoices/${id}`, {
+    fetchApi<SupplierInvoice>(supplierInvoicePath(id), {
       method: 'PUT',
       body: JSON.stringify(updates),
     }).then(normalizeSupplierInvoice),
 
-  delete: (id: string): Promise<void> =>
-    fetchApi(`/accounting/supplier-invoices/${id}`, { method: 'DELETE' }),
+  delete: (id: string): Promise<void> => fetchApi(supplierInvoicePath(id), { method: 'DELETE' }),
 };

--- a/test/services/supplierInvoices.test.ts
+++ b/test/services/supplierInvoices.test.ts
@@ -1,0 +1,49 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { buildResponse } from '../helpers/fetchMock';
+
+const invoicePayload = {
+  id: 'sinv-1',
+  supplierId: 'supplier-1',
+  supplierName: 'Supplier',
+  issueDate: '2026-07-24',
+  dueDate: '2026-08-24',
+  status: 'draft',
+  subtotal: 100,
+  total: 100,
+  amountPaid: 0,
+  createdAt: 1,
+  updatedAt: 1,
+  items: [],
+};
+
+const originalFetch = globalThis.fetch;
+const fetchMock = mock(async (_input: unknown, _init?: unknown) =>
+  buildResponse({ json: () => invoicePayload }),
+);
+globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+const { supplierInvoicesApi } = await import('../../services/api/supplierInvoices');
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockImplementation(async () => buildResponse({ json: () => invoicePayload }));
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+describe('supplierInvoicesApi path segments', () => {
+  test('keeps a legacy traversal-shaped invoice id inside its route segment', async () => {
+    const invoiceId = '../supplier-orders/SORD-1?force=true#details';
+    const encodedId = '..%2Fsupplier-orders%2FSORD-1%3Fforce%3Dtrue%23details';
+
+    await supplierInvoicesApi.update(invoiceId, { notes: 'updated' });
+    await supplierInvoicesApi.delete(invoiceId);
+
+    expect(fetchMock.mock.calls.map(([input]) => String(input))).toEqual([
+      `/api/accounting/supplier-invoices/${encodedId}`,
+      `/api/accounting/supplier-invoices/${encodedId}`,
+    ]);
+  });
+});


### PR DESCRIPTION
## Summary
- Prevent stored supplier-invoice IDs from changing the target accounting route.
- Keep historical traversal-shaped IDs operable through opaque path-segment encoding.

## Changes
- Encode supplier-invoice update and delete path segments with the shared route helper.
- Reject unsafe IDs on create or rename while allowing an unchanged legacy ID.
- Add frontend and backend regression coverage plus Italian and English user documentation.

## Testing
- `bun test ./test/services/supplierInvoices.test.ts`
- `cd server && bun test ./test/routes/supplier-invoices.test.ts`
- `bun run typecheck`
- `bunx @biomejs/biome check services/api/supplierInvoices.ts server/routes/supplier-invoices.ts server/test/routes/supplier-invoices.test.ts test/services/supplierInvoices.test.ts`
- `bun run build`
- Full backend suite: 4,748 tests passed; full frontend suite was interrupted by a Bun 1.3.14 internal assertion after reaching 8.77 GB peak memory, so CI remains the authoritative full-suite run.
- React Doctor: 75/100 before and after (no regression; pre-existing findings unchanged).

## Risks / Rollout
- Low risk. No schema or data migration; existing nonconforming invoice IDs remain accessible and editable without renaming.

## Issues
Issue: Not linked