### PR TITLE
sso(security): reject expired SAML request IDs

### DIFF
--- a/server/repositories/ssoStatesRepo.ts
+++ b/server/repositories/ssoStatesRepo.ts
@@ -95,6 +95,7 @@ export const removeForProvider = async (
         eq(ssoStates.state, state),
         eq(ssoStates.providerId, providerId),
         eq(ssoStates.protocol, protocol),
+        gt(ssoStates.expiresAt, new Date()),
       ),
     )
     .returning({ relayState: ssoStates.relayState });

--- a/server/test/repositories/ssoStatesRepo.test.ts
+++ b/server/test/repositories/ssoStatesRepo.test.ts
@@ -1,0 +1,36 @@
+import { beforeEach, describe, expect, test } from 'bun:test';
+import type { DbExecutor } from '../../db/drizzle.ts';
+import * as ssoStatesRepo from '../../repositories/ssoStatesRepo.ts';
+import { type FakeExecutor, setupTestDb } from '../helpers/fakeExecutor.ts';
+
+let exec: FakeExecutor;
+let testDb: DbExecutor;
+
+beforeEach(() => {
+  ({ exec, testDb } = setupTestDb());
+});
+
+describe('removeForProvider', () => {
+  test('atomically consumes only an unexpired provider-scoped state', async () => {
+    exec.enqueue({ rows: [['relay-state']] });
+
+    await expect(
+      ssoStatesRepo.removeForProvider('request-id', 'provider-1', 'saml', testDb),
+    ).resolves.toBe('relay-state');
+
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('delete from "sso_states"');
+    expect(sql).toContain('"state" =');
+    expect(sql).toContain('"provider_id" =');
+    expect(sql).toContain('"protocol" =');
+    expect(sql).toContain('"expires_at" >');
+  });
+
+  test('returns null when no unexpired state is consumed', async () => {
+    exec.enqueue({ rows: [] });
+
+    await expect(
+      ssoStatesRepo.removeForProvider('expired-request-id', 'provider-1', 'saml', testDb),
+    ).resolves.toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Reject expired SAML request IDs during atomic cache consumption.
- Add repository regression coverage for the expiry predicate and empty consumption result.

## Changes
- Require `sso_states.expires_at` to be in the future in the provider-scoped delete used by SAML `InResponseTo` validation.
- Keep provider, protocol, and one-time deletion checks in the same database operation.

## Testing
- `bun test test/repositories/ssoStatesRepo.test.ts test/services/sso.test.ts`
- `bun run build` (from `server/`)
- `bun run test:server` (4,727 passed, 29 skipped)
- `bunx biome check server/repositories/ssoStatesRepo.ts server/test/repositories/ssoStatesRepo.test.ts`
- `bun run test:react-doctor` (75/100, unchanged baseline; exits non-zero for pre-existing findings)

## Risks / Rollout
- Low risk and no migration required. The change only narrows SAML request-ID consumption to the existing ten-minute validity window.
- Documentation reviewed; no user-facing or API documentation changes are needed because this restores the configured expiry contract.

## Issues
- Issue: Not linked