### PR TITLE
auth(security): rate limit SAML callbacks

### DIFF
--- a/server/routes/sso-auth.ts
+++ b/server/routes/sso-auth.ts
@@ -137,11 +137,15 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
   fastify.post(
     '/saml/:slug/callback',
     {
+      onRequest: fastify.rateLimit(LOGIN_RATE_LIMIT),
       schema: {
         tags: ['sso'],
         summary: 'Complete SAML login',
         params: slugParamsSchema,
         security: [],
+        response: {
+          ...standardRateLimitedErrorResponses,
+        },
       },
     },
     async (request: FastifyRequest, reply: FastifyReply) => {

--- a/server/test/routes/sso-auth.test.ts
+++ b/server/test/routes/sso-auth.test.ts
@@ -1,10 +1,12 @@
 import { afterAll, afterEach, beforeAll, beforeEach, describe, expect, mock, test } from 'bun:test';
-import type { FastifyInstance, FastifyPluginAsync } from 'fastify';
+import Fastify, { type FastifyInstance, type FastifyPluginAsync } from 'fastify';
+import rateLimit from 'fastify-rate-limit';
 import * as realAuth from '../../middleware/auth.ts';
 import * as realSsoProvidersRepo from '../../repositories/ssoProvidersRepo.ts';
 import * as realFirstLogin from '../../services/firstLogin.ts';
 import * as realSsoService from '../../services/sso.ts';
 import * as realAudit from '../../utils/audit.ts';
+import * as realRateLimit from '../../utils/rate-limit.ts';
 import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
 
 // Mix of two concerns sharing the same route plugin:
@@ -17,6 +19,7 @@ const ssoServiceSnap = { ...realSsoService };
 const authSnap = { ...realAuth };
 const firstLoginSnap = { ...realFirstLogin };
 const auditSnap = { ...realAudit };
+const rateLimitSnap = { ...realRateLimit };
 
 const findBySlugMock = mock();
 const completeOidcLoginMock = mock();
@@ -66,6 +69,10 @@ beforeAll(async () => {
     ...auditSnap,
     logAudit: logAuditMock,
   }));
+  mock.module('../../utils/rate-limit.ts', () => ({
+    ...rateLimitSnap,
+    LOGIN_RATE_LIMIT: { max: 2, timeWindow: '1 minute' },
+  }));
 
   routePlugin = (await import('../../routes/sso-auth.ts')).default as FastifyPluginAsync;
 });
@@ -76,6 +83,7 @@ afterAll(() => {
   mock.module('../../middleware/auth.ts', () => authSnap);
   mock.module('../../services/firstLogin.ts', () => firstLoginSnap);
   mock.module('../../utils/audit.ts', () => auditSnap);
+  mock.module('../../utils/rate-limit.ts', () => rateLimitSnap);
 });
 
 const samlProvider: realSsoProvidersRepo.SsoProvider = {
@@ -244,6 +252,40 @@ describe('POST /api/auth/sso/consume', () => {
 
 const ssoErrorParam = (location: string): string =>
   new URL(location).searchParams.get('sso_error') ?? '';
+
+describe('POST /api/auth/sso/saml/:slug/callback rate limiting', () => {
+  test('applies LOGIN_RATE_LIMIT before SAML response processing', async () => {
+    completeSamlLoginMock.mockResolvedValue('https://app.example.com');
+    const app = Fastify({ logger: false });
+
+    await app.register(rateLimit, {
+      ...rateLimitSnap.GLOBAL_RATE_LIMIT,
+      global: true,
+      hook: 'onRequest',
+    });
+    await app.register(routePlugin, { prefix: '/api/auth/sso' });
+    await app.ready();
+
+    try {
+      const request = {
+        method: 'POST' as const,
+        url: '/api/auth/sso/saml/okta/callback',
+        headers: { 'content-type': 'application/x-www-form-urlencoded' },
+        payload: 'SAMLResponse=fake',
+      };
+      const first = await app.inject(request);
+      const second = await app.inject(request);
+      const third = await app.inject(request);
+
+      expect(first.statusCode).toBe(302);
+      expect(second.statusCode).toBe(302);
+      expect(third.statusCode).toBe(429);
+      expect(completeSamlLoginMock).toHaveBeenCalledTimes(2);
+    } finally {
+      await app.close();
+    }
+  });
+});
 
 describe('SSO callbacks — sso_error carries a stable code (issue #604)', () => {
   test('SAML callback redirects with the SsoLoginError.code, not err.message', async () => {


### PR DESCRIPTION
## Summary
- Protect the public SAML callback from anonymous request floods with the existing login-rate-limit budget.
- Document the callback's rate-limit error response and add regression coverage proving rejected requests never reach SAML processing.

## Testing
- `bun test ./test/routes/sso-auth.test.ts` (from `server/`)
- `bun run test:server`
- `bun run typecheck`
- `bun x biome check server/routes/sso-auth.ts server/test/routes/sso-auth.test.ts`
- `bun run test:react-doctor` (75/100 before and after; existing unrelated diagnostics remain)
- Three consecutive clean iterative review/simplify passes

## Risks / Rollout
- Low risk. The change uses the existing 30 requests per 15 minutes per-client-IP login limit and requires no migration or configuration change.

## Issues
- DeepSec finding `2524934a67`; no GitHub issue linked.