### PR TITLE
backend(security): pin Bun base image digests

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: /
     schedule:
       interval: weekly
+  - package-ecosystem: docker
+    directory: /server
+    schedule:
+      interval: weekly

--- a/server/Dockerfile
+++ b/server/Dockerfile
@@ -1,11 +1,11 @@
 # STAGE 1: Install dependencies
-FROM oven/bun:1.3.14 AS install
+FROM oven/bun:1.3.14@sha256:e10577f0db68676a7024391c6e5cb4b879ebd17188ab750cf10024a6d700e5c4 AS install
 WORKDIR /temp
 COPY package.json bun.lock ./
 RUN bun install --frozen-lockfile
 
 # STAGE 2: Production
-FROM oven/bun:1.3.14-slim AS release
+FROM oven/bun:1.3.14-slim@sha256:d56a2534ffd262e92c12fd3249d3924d296d97086da773f821d7d0477435ea04 AS release
 WORKDIR /app
 
 ENV NODE_ENV=production

--- a/test/security/backendContainer.test.ts
+++ b/test/security/backendContainer.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, test } from 'bun:test';
+
+const dockerfile = await Bun.file(new URL('../../server/Dockerfile', import.meta.url)).text();
+const dependabot = await Bun.file(new URL('../../.github/dependabot.yml', import.meta.url)).text();
+
+const baseImages = [...dockerfile.matchAll(/^FROM\s+(\S+)/gm)].map((match) => match[1]);
+const dockerDependabotUpdate = dependabot
+  .split(/\r?\n(?= {2}- package-ecosystem:)/)
+  .find((update) => /package-ecosystem:\s*docker/.test(update));
+
+describe('backend container supply-chain safety', () => {
+  test('pins every Bun base image to an immutable digest', () => {
+    expect(baseImages.length).toBeGreaterThan(0);
+
+    for (const image of baseImages) {
+      expect(image).toMatch(/^oven\/bun:[^@\s]+@sha256:[0-9a-f]{64}$/);
+    }
+  });
+
+  test('keeps pinned Docker image digests current through Dependabot', () => {
+    expect(dockerDependabotUpdate).toBeDefined();
+    expect(dockerDependabotUpdate).toMatch(/directory:\s*\/server/);
+    expect(dockerDependabotUpdate).toMatch(/interval:\s*weekly/);
+  });
+});


### PR DESCRIPTION
## Summary
- Pin both backend Bun base images to immutable Docker Hub digests.
- Add weekly Dependabot updates for Docker images under `/server`.
- Add regression coverage for digest pins and automated update configuration.

## Testing
- `bun test test/security/backendContainer.test.ts` (passes)
- `bun run typecheck` (passes)
- `bun run build` (passes)
- `bun run test:react-doctor` (unchanged at 75/100; exits nonzero for 94 pre-existing diagnostics)
- `bun run test:frontend` (Bun 1.3.14 crashed on Windows after reaching accounting component tests; the focused security suite and separately rerun Login suite pass)
- `bun run lint` (typecheck passes; repository-wide Biome check reports existing CRLF formatting diagnostics in the Windows checkout)

## Risks / Rollout
- Low risk. Runtime behavior is unchanged; builds now resolve exact base-image manifests and Dependabot can propose controlled digest refreshes.
- User and API documentation are unchanged because this only affects build provenance.

## Issues
Issue: Not linked