### PR TITLE
ai(security): block AWS metadata IPv6 SSRF

### DIFF
--- a/server/test/utils/local-ai-endpoint.test.ts
+++ b/server/test/utils/local-ai-endpoint.test.ts
@@ -32,11 +32,13 @@ describe('local AI endpoint utilities', () => {
     }
   });
 
-  test('blocks link-local IPv4 and IPv6 but permits loopback and private LAN addresses', () => {
+  test('blocks metadata and link-local addresses but permits loopback and private LAN addresses', () => {
     expect(isBlockedLocalAiAddress('169.254.169.254')).toBe(true);
     expect(isBlockedLocalAiAddress('100.100.100.200')).toBe(true);
     expect(isBlockedLocalAiAddress('::ffff:a9fe:a9fe')).toBe(true);
     expect(isBlockedLocalAiAddress('fe80::1')).toBe(true);
+    expect(isBlockedLocalAiAddress('fd00:ec2::254')).toBe(true);
+    expect(isBlockedLocalAiAddress('fd00:0ec2:0000:0000:0000:0000:0000:0254')).toBe(true);
     expect(isBlockedLocalAiAddress('fd20:00ce:0000:0000:0000:0000:0000:0254')).toBe(true);
     expect(isBlockedLocalAiAddress('127.0.0.1')).toBe(false);
     expect(isBlockedLocalAiAddress('10.0.0.8')).toBe(false);

--- a/server/utils/local-ai-endpoint.ts
+++ b/server/utils/local-ai-endpoint.ts
@@ -13,7 +13,7 @@ const BLOCKED_METADATA_HOSTNAMES = new Set([
   'metadata.google.internal',
 ]);
 const BLOCKED_METADATA_IPV4 = '100.100.100.200';
-const BLOCKED_METADATA_IPV6 = 'fd20:ce::254';
+const BLOCKED_METADATA_IPV6_ADDRESSES = new Set(['fd00:ec2::254', 'fd20:ce::254']);
 
 const invalidBaseUrl = (message: string) => ({ ok: false as const, message });
 
@@ -66,7 +66,7 @@ export const isBlockedLocalAiAddress = (address: string): boolean => {
   if (isIP(address) !== 6) return false;
   const firstHextet = Number.parseInt(address.split(':')[0] || '0', 16);
   const normalized = new URL(`http://[${address}]/`).hostname.slice(1, -1);
-  return (firstHextet & 0xffc0) === 0xfe80 || normalized === BLOCKED_METADATA_IPV6;
+  return (firstHextet & 0xffc0) === 0xfe80 || BLOCKED_METADATA_IPV6_ADDRESSES.has(normalized);
 };
 
 const localAiHostname = (url: URL): string => url.hostname.replace(/^\[|\]$/g, '');


### PR DESCRIPTION
## Summary
- block AWS IMDS IPv6 (`fd00:ec2::254`) in Local AI endpoint validation
- preserve normalized IPv6 matching for compressed and expanded literals
- add regression coverage for both AWS IMDS IPv6 representations

## Testing
- `bun test server/test/utils/local-ai-endpoint.test.ts`
- `bun run test:server` (4,735 passed; 29 skipped)
- `bun run typecheck`
- `bunx biome check server/utils/local-ai-endpoint.ts server/test/utils/local-ai-endpoint.test.ts`
- `bun run test:react-doctor` (75/100 before and after; exits nonzero for 2 pre-existing findings)

## Risks / Rollout
- Low risk. The change only extends the existing metadata-service denylist; no migration or configuration change is required.

## Issues
- Issue: Not linked