### PR TITLE
clients(security): serialize profile option mutations

### DIFF
--- a/server/repositories/clientProfileOptionsRepo.ts
+++ b/server/repositories/clientProfileOptionsRepo.ts
@@ -1,5 +1,5 @@
 import { and, eq, ne, sql } from 'drizzle-orm';
-import { type DbExecutor, db, executeRows } from '../db/drizzle.ts';
+import { type DbExecutor, db, executeRows, runAtomically } from '../db/drizzle.ts';
 import { clientProfileOptions } from '../db/schema/clientProfileOptions.ts';
 
 export const PROFILE_OPTION_CATEGORIES = [
@@ -105,6 +105,23 @@ export const findByCategoryAndId = async (
   return rows[0] ?? null;
 };
 
+const lockClientsForProfileOptionMutation = async (exec: DbExecutor): Promise<void> => {
+  await executeRows(exec, sql`LOCK TABLE clients IN SHARE ROW EXCLUSIVE MODE`);
+};
+
+const lockByCategoryAndId = async (
+  category: ProfileOptionCategory,
+  id: string,
+  exec: DbExecutor,
+): Promise<{ id: string; value: string } | null> => {
+  const rows = await exec
+    .select({ id: clientProfileOptions.id, value: clientProfileOptions.value })
+    .from(clientProfileOptions)
+    .where(and(eq(clientProfileOptions.id, id), eq(clientProfileOptions.category, category)))
+    .for('update');
+  return rows[0] ?? null;
+};
+
 export const findByCategoryAndValue = async (
   category: ProfileOptionCategory,
   value: string,
@@ -170,52 +187,58 @@ export const create = async (
 /**
  * Updates the option row and, when the value changed, cascades the new value to all clients
  * whose corresponding column held the old value. The cascade column is selected internally from
- * the category allowlist - no caller-supplied column names ever reach the SQL.
+ * the category allowlist - no caller-supplied column names ever reach the SQL. The clients table
+ * lock prevents a concurrent client write from restoring the old value between the option update
+ * and cascade. The option row is then locked and read in the same transaction so concurrent option
+ * updates always cascade from the latest committed value.
  */
 export const update = async (
   category: ProfileOptionCategory,
   id: string,
-  patch: { value: string; sortOrder: number | null; previousValue: string },
+  patch: { value: string; sortOrder: number | null },
   exec: DbExecutor = db,
-): Promise<ProfileOption | null> => {
-  const updateResult = await exec
-    .update(clientProfileOptions)
-    .set({
-      value: patch.value,
-      sortOrder: sql`COALESCE(${patch.sortOrder}, ${clientProfileOptions.sortOrder})`,
-      updatedAt: sql`CURRENT_TIMESTAMP`,
-    })
-    .where(and(eq(clientProfileOptions.id, id), eq(clientProfileOptions.category, category)));
+): Promise<ProfileOption | null> =>
+  runAtomically(exec, async (tx) => {
+    await lockClientsForProfileOptionMutation(tx);
+    const existing = await lockByCategoryAndId(category, id, tx);
+    if (!existing) return null;
 
-  if ((updateResult.rowCount ?? 0) === 0) return null;
+    await tx
+      .update(clientProfileOptions)
+      .set({
+        value: patch.value,
+        sortOrder: sql`COALESCE(${patch.sortOrder}, ${clientProfileOptions.sortOrder})`,
+        updatedAt: sql`CURRENT_TIMESTAMP`,
+      })
+      .where(and(eq(clientProfileOptions.id, id), eq(clientProfileOptions.category, category)));
 
-  if (patch.previousValue !== patch.value) {
-    const fieldName = VALUE_FIELD_BY_CATEGORY[category];
-    // Cross-table cascade into `clients`. `sql.identifier` pulls the column from the
-    // internal `VALUE_FIELD_BY_CATEGORY` allowlist - no caller input reaches the SQL
-    // identifier.
-    await executeRows(
-      exec,
-      sql`UPDATE clients SET ${sql.identifier(fieldName)} = ${patch.value}
-          WHERE ${sql.identifier(fieldName)} = ${patch.previousValue}`,
+    if (existing.value !== patch.value) {
+      const fieldName = VALUE_FIELD_BY_CATEGORY[category];
+      // Cross-table cascade into `clients`. `sql.identifier` pulls the column from the
+      // internal `VALUE_FIELD_BY_CATEGORY` allowlist - no caller input reaches the SQL
+      // identifier.
+      await executeRows(
+        tx,
+        sql`UPDATE clients SET ${sql.identifier(fieldName)} = ${patch.value}
+            WHERE ${sql.identifier(fieldName)} = ${existing.value}`,
+      );
+    }
+
+    const rows = await executeRows<ProfileOptionRow>(
+      tx,
+      sql`SELECT
+         o.id,
+         o.category,
+         o.value,
+         o.sort_order,
+         o.created_at,
+         o.updated_at,
+         ${usageCountSubquery(category)} as usage_count
+       FROM client_profile_options o
+       WHERE o.id = ${id} AND o.category = ${category}`,
     );
-  }
-
-  const rows = await executeRows<ProfileOptionRow>(
-    exec,
-    sql`SELECT
-       o.id,
-       o.category,
-       o.value,
-       o.sort_order,
-       o.created_at,
-       o.updated_at,
-       ${usageCountSubquery(category)} as usage_count
-     FROM client_profile_options o
-     WHERE o.id = ${id} AND o.category = ${category}`,
-  );
-  return rows[0] ? mapRow(rows[0]) : null;
-};
+    return rows[0] ? mapRow(rows[0]) : null;
+  });
 
 export const getUsageCount = async (
   category: ProfileOptionCategory,
@@ -235,3 +258,31 @@ export const deleteById = async (id: string, exec: DbExecutor = db): Promise<boo
   const result = await exec.delete(clientProfileOptions).where(eq(clientProfileOptions.id, id));
   return (result.rowCount ?? 0) > 0;
 };
+
+export type DeleteUnusedResult =
+  | { status: 'not_found' }
+  | { status: 'in_use'; value: string; usageCount: number }
+  | { status: 'deleted'; value: string };
+
+/**
+ * Deletes an unused option under the same client-table and option-row locks used by update().
+ * This makes the usage check authoritative until the delete commits.
+ */
+export const deleteUnused = async (
+  category: ProfileOptionCategory,
+  id: string,
+  exec: DbExecutor = db,
+): Promise<DeleteUnusedResult> =>
+  runAtomically(exec, async (tx) => {
+    await lockClientsForProfileOptionMutation(tx);
+    const existing = await lockByCategoryAndId(category, id, tx);
+    if (!existing) return { status: 'not_found' };
+
+    const usageCount = await getUsageCount(category, id, tx);
+    if (usageCount > 0) {
+      return { status: 'in_use', value: existing.value, usageCount };
+    }
+
+    await deleteById(id, tx);
+    return { status: 'deleted', value: existing.value };
+  });

--- a/server/routes/clients.ts
+++ b/server/routes/clients.ts
@@ -1220,11 +1220,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const valueResult = requireNonEmptyString(value, 'value');
       if (!valueResult.ok) return badRequest(reply, valueResult.message);
 
-      const existing = await clientProfileOptionsRepo.findByCategoryAndId(
-        categoryResult.value,
-        idResult.value,
-      );
-      if (!existing) {
+      if (
+        !(await clientProfileOptionsRepo.findByCategoryAndId(categoryResult.value, idResult.value))
+      ) {
         return replyError(request, reply, {
           statusCode: 404,
           message: 'Profile option not found',
@@ -1252,7 +1250,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           {
             value: valueResult.value,
             sortOrder: sortOrderValue,
-            previousValue: existing.value,
           },
           tx,
         ),
@@ -1312,11 +1309,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(params.id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      const existing = await clientProfileOptionsRepo.findByCategoryAndId(
-        categoryResult.value,
-        idResult.value,
+      const result = await withDbTransaction((tx) =>
+        clientProfileOptionsRepo.deleteUnused(categoryResult.value, idResult.value, tx),
       );
-      if (!existing) {
+      if (result.status === 'not_found') {
         return replyError(request, reply, {
           statusCode: 404,
           message: 'Profile option not found',
@@ -1326,26 +1322,20 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         });
       }
 
-      const usageCount = await clientProfileOptionsRepo.getUsageCount(
-        categoryResult.value,
-        idResult.value,
-      );
-      if (usageCount > 0) {
+      if (result.status === 'in_use') {
         return replyError(request, reply, {
           statusCode: 409,
-          message: `Cannot delete option "${existing.value}" because it is used by ${usageCount} client(s)`,
+          message: `Cannot delete option "${result.value}" because it is used by ${result.usageCount} client(s)`,
           action: 'client_profile_option.delete.conflict',
           entityType: 'client_profile_option',
           entityId: idResult.value,
           details: {
-            targetLabel: existing.value,
+            targetLabel: result.value,
             secondaryLabel: 'option_in_use',
-            counts: { clients: usageCount },
+            counts: { clients: result.usageCount },
           },
         });
       }
-
-      await clientProfileOptionsRepo.deleteById(idResult.value);
 
       await logAudit({
         request,
@@ -1353,7 +1343,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         entityType: 'client_profile_option',
         entityId: idResult.value,
         details: {
-          targetLabel: existing.value,
+          targetLabel: result.value,
           secondaryLabel: categoryResult.value,
         },
       });

--- a/server/test/repositories/clientProfileOptionsRepo.test.ts
+++ b/server/test/repositories/clientProfileOptionsRepo.test.ts
@@ -10,7 +10,7 @@ beforeEach(() => {
   ({ exec, testDb } = setupTestDb());
 });
 
-// listByCategory/getUsageCount/update use executeRows for the usage_count subquery - rows
+// listByCategory/getUsageCount/update/deleteUnused use executeRows for raw SQL - rows
 // come back with snake_case named keys (matching the SQL aliases). findByCategoryAndId,
 // findByCategoryAndValue, getNextSortOrder, create, deleteById use the query builder
 // (rowMode: 'array' positional rows in schema declaration order).
@@ -139,59 +139,55 @@ describe('create', () => {
 
 describe('update', () => {
   test('updates option only when value did not change (no cascade)', async () => {
+    exec.enqueue({ rows: [] }); // LOCK clients table
+    exec.enqueue({ rows: [['cpo-1', 'tech']] }); // SELECT option FOR UPDATE
     exec.enqueue({ rows: [], rowCount: 1 }); // UPDATE option
     exec.enqueue({ rows: [optionAggRow] }); // SELECT updated row via executeRows
-    const result = await repo.update(
-      'sector',
-      'cpo-1',
-      { value: 'tech', sortOrder: null, previousValue: 'tech' },
-      testDb,
+    const result = await repo.update('sector', 'cpo-1', { value: 'tech', sortOrder: null }, testDb);
+    expect(exec.calls).toHaveLength(4);
+    expect(exec.calls[0].sql.toLowerCase()).toContain(
+      'lock table clients in share row exclusive mode',
     );
-    // 2 calls only - no cascade UPDATE clients
-    expect(exec.calls).toHaveLength(2);
-    expect(exec.calls[0].sql.toLowerCase()).toContain('update "client_profile_options"');
+    expect(exec.calls[1].sql.toLowerCase()).toContain('for update');
+    expect(exec.calls[2].sql.toLowerCase()).toContain('update "client_profile_options"');
     expect(result?.value).toBe('tech');
   });
 
-  test('cascades to clients table via internal allowlist when value changes (sector)', async () => {
-    exec.enqueue({ rows: [], rowCount: 1 });
+  test('cascades from the locked current value instead of caller state', async () => {
+    exec.enqueue({ rows: [] });
+    exec.enqueue({ rows: [['cpo-1', 'intermediate']] });
+    exec.enqueue({ rows: [], rowCount: 5 });
     exec.enqueue({ rows: [], rowCount: 5 });
     exec.enqueue({ rows: [{ ...optionAggRow, value: 'finance' }] });
-    await repo.update(
-      'sector',
-      'cpo-1',
-      { value: 'finance', sortOrder: null, previousValue: 'tech' },
-      testDb,
-    );
-    expect(exec.calls).toHaveLength(3);
-    expect(exec.calls[1].sql.toLowerCase()).toContain('update clients set "sector"');
-    expect(exec.calls[1].params).toContain('finance');
-    expect(exec.calls[1].params).toContain('tech');
+    await repo.update('sector', 'cpo-1', { value: 'finance', sortOrder: null }, testDb);
+    expect(exec.calls).toHaveLength(5);
+    expect(exec.calls[3].sql.toLowerCase()).toContain('update clients set "sector"');
+    expect(exec.calls[3].params).toContain('finance');
+    expect(exec.calls[3].params).toContain('intermediate');
+    expect(exec.calls[3].params).not.toContain('tech');
   });
 
   test('cascade for officeCountRange uses office_count_range column', async () => {
+    exec.enqueue({ rows: [] });
+    exec.enqueue({ rows: [['cpo-2', '1']] });
     exec.enqueue({ rows: [], rowCount: 1 });
     exec.enqueue({ rows: [], rowCount: 1 });
     exec.enqueue({ rows: [{ ...optionAggRow, category: 'officeCountRange', value: '2-5' }] });
-    await repo.update(
-      'officeCountRange',
-      'cpo-2',
-      { value: '2-5', sortOrder: null, previousValue: '1' },
-      testDb,
-    );
-    expect(exec.calls[1].sql.toLowerCase()).toContain('update clients set "office_count_range"');
+    await repo.update('officeCountRange', 'cpo-2', { value: '2-5', sortOrder: null }, testDb);
+    expect(exec.calls[3].sql.toLowerCase()).toContain('update clients set "office_count_range"');
   });
 
-  test('returns null and skips cascade/select when option UPDATE matched no rows', async () => {
-    exec.enqueue({ rows: [], rowCount: 0 });
+  test('returns null and skips writes when the locked option does not exist', async () => {
+    exec.enqueue({ rows: [] });
+    exec.enqueue({ rows: [] });
     const result = await repo.update(
       'sector',
       'cpo-x',
-      { value: 'finance', sortOrder: null, previousValue: 'tech' },
+      { value: 'finance', sortOrder: null },
       testDb,
     );
     expect(result).toBeNull();
-    expect(exec.calls).toHaveLength(1);
+    expect(exec.calls).toHaveLength(2);
   });
 });
 
@@ -216,5 +212,48 @@ describe('deleteById', () => {
   test('returns false when no row matched', async () => {
     exec.enqueue({ rows: [], rowCount: 0 });
     expect(await repo.deleteById('cpo-x', testDb)).toBe(false);
+  });
+});
+
+describe('deleteUnused', () => {
+  test('locks clients and the option before checking usage and deleting', async () => {
+    exec.enqueue({ rows: [] });
+    exec.enqueue({ rows: [['cpo-1', 'tech']] });
+    exec.enqueue({ rows: [{ usage_count: '0' }] });
+    exec.enqueue({ rows: [], rowCount: 1 });
+
+    expect(await repo.deleteUnused('sector', 'cpo-1', testDb)).toEqual({
+      status: 'deleted',
+      value: 'tech',
+    });
+    expect(exec.calls[0].sql.toLowerCase()).toContain(
+      'lock table clients in share row exclusive mode',
+    );
+    expect(exec.calls[1].sql.toLowerCase()).toContain('for update');
+    expect(exec.calls[2].sql.toLowerCase()).toContain('count(*)');
+    expect(exec.calls[3].sql.toLowerCase()).toContain('delete from "client_profile_options"');
+  });
+
+  test('reports current usage without deleting', async () => {
+    exec.enqueue({ rows: [] });
+    exec.enqueue({ rows: [['cpo-1', 'tech']] });
+    exec.enqueue({ rows: [{ usage_count: '3' }] });
+
+    expect(await repo.deleteUnused('sector', 'cpo-1', testDb)).toEqual({
+      status: 'in_use',
+      value: 'tech',
+      usageCount: 3,
+    });
+    expect(exec.calls).toHaveLength(3);
+  });
+
+  test('reports not found after acquiring mutation locks', async () => {
+    exec.enqueue({ rows: [] });
+    exec.enqueue({ rows: [] });
+
+    expect(await repo.deleteUnused('sector', 'missing', testDb)).toEqual({
+      status: 'not_found',
+    });
+    expect(exec.calls).toHaveLength(2);
   });
 });

--- a/server/test/routes/clients.test.ts
+++ b/server/test/routes/clients.test.ts
@@ -49,8 +49,7 @@ const cpoFindByCategoryAndValueMock = mock();
 const cpoGetNextSortOrderMock = mock();
 const cpoCreateMock = mock();
 const cpoUpdateMock = mock();
-const cpoGetUsageCountMock = mock();
-const cpoDeleteByIdMock = mock();
+const cpoDeleteUnusedMock = mock();
 
 // userAssignmentsRepo
 const assignClientToUserMock = mock(async () => undefined);
@@ -97,8 +96,7 @@ beforeAll(async () => {
     getNextSortOrder: cpoGetNextSortOrderMock,
     create: cpoCreateMock,
     update: cpoUpdateMock,
-    getUsageCount: cpoGetUsageCountMock,
-    deleteById: cpoDeleteByIdMock,
+    deleteUnused: cpoDeleteUnusedMock,
   }));
   mock.module('../../repositories/userAssignmentsRepo.ts', () => ({
     ...userAssignmentsRepoSnap,
@@ -212,8 +210,7 @@ const allMocks = [
   cpoGetNextSortOrderMock,
   cpoCreateMock,
   cpoUpdateMock,
-  cpoGetUsageCountMock,
-  cpoDeleteByIdMock,
+  cpoDeleteUnusedMock,
   assignClientToUserMock,
   assignClientToTopManagersMock,
   isClientAssignedToUserMock,
@@ -1432,7 +1429,7 @@ describe('POST /api/clients/profile-options/:category', () => {
 });
 
 describe('PUT /api/clients/profile-options/:category/:id', () => {
-  test('200 updates profile option', async () => {
+  test('200 updates profile option atomically without caller-supplied previous state', async () => {
     cpoFindByCategoryAndIdMock.mockResolvedValue({ id: 'cpo-1', value: 'Tech' });
     cpoFindByCategoryAndValueMock.mockResolvedValue(false);
     cpoUpdateMock.mockResolvedValue({ ...SAMPLE_PROFILE_OPTION, value: 'Tech v2' });
@@ -1446,7 +1443,12 @@ describe('PUT /api/clients/profile-options/:category/:id', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(cpoUpdateMock).toHaveBeenCalled();
+    expect(cpoUpdateMock).toHaveBeenCalledWith(
+      'sector',
+      'cpo-1',
+      { value: 'Tech v2', sortOrder: null },
+      TX_SENTINEL,
+    );
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'client.profile_option.updated' }),
     );
@@ -1464,6 +1466,8 @@ describe('PUT /api/clients/profile-options/:category/:id', () => {
 
     expect(res.statusCode).toBe(404);
     expect(JSON.parse(res.body)).toEqual({ error: 'Profile option not found' });
+    expect(cpoFindByCategoryAndValueMock).not.toHaveBeenCalled();
+    expect(cpoUpdateMock).not.toHaveBeenCalled();
   });
 
   test('400 duplicate value collision with another row', async () => {
@@ -1494,10 +1498,8 @@ describe('PUT /api/clients/profile-options/:category/:id', () => {
 });
 
 describe('DELETE /api/clients/profile-options/:category/:id', () => {
-  test('204 deletes profile option when unused', async () => {
-    cpoFindByCategoryAndIdMock.mockResolvedValue({ id: 'cpo-1', value: 'Tech' });
-    cpoGetUsageCountMock.mockResolvedValue(0);
-    cpoDeleteByIdMock.mockResolvedValue(true);
+  test('204 atomically deletes profile option when unused', async () => {
+    cpoDeleteUnusedMock.mockResolvedValue({ status: 'deleted', value: 'Tech' });
 
     const res = await testApp.inject({
       method: 'DELETE',
@@ -1507,13 +1509,15 @@ describe('DELETE /api/clients/profile-options/:category/:id', () => {
 
     expect(res.statusCode).toBe(204);
     expect(res.body).toBe('');
+    expect(cpoDeleteUnusedMock).toHaveBeenCalledWith('sector', 'cpo-1', TX_SENTINEL);
+    expect(withDbTransactionMock).toHaveBeenCalledTimes(1);
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'client.profile_option.deleted' }),
     );
   });
 
   test('404 when option not found', async () => {
-    cpoFindByCategoryAndIdMock.mockResolvedValue(null);
+    cpoDeleteUnusedMock.mockResolvedValue({ status: 'not_found' });
 
     const res = await testApp.inject({
       method: 'DELETE',
@@ -1526,8 +1530,11 @@ describe('DELETE /api/clients/profile-options/:category/:id', () => {
   });
 
   test('409 when option still in use', async () => {
-    cpoFindByCategoryAndIdMock.mockResolvedValue({ id: 'cpo-1', value: 'Tech' });
-    cpoGetUsageCountMock.mockResolvedValue(3);
+    cpoDeleteUnusedMock.mockResolvedValue({
+      status: 'in_use',
+      value: 'Tech',
+      usageCount: 3,
+    });
 
     const res = await testApp.inject({
       method: 'DELETE',
@@ -1539,7 +1546,7 @@ describe('DELETE /api/clients/profile-options/:category/:id', () => {
     expect(JSON.parse(res.body)).toEqual({
       error: 'Cannot delete option "Tech" because it is used by 3 client(s)',
     });
-    expect(cpoDeleteByIdMock).not.toHaveBeenCalled();
+    expect(cpoDeleteUnusedMock).toHaveBeenCalledWith('sector', 'cpo-1', TX_SENTINEL);
   });
 
   test('401 missing token', async () => {


### PR DESCRIPTION
## Summary
- Serialize client profile-option updates so cascades always use the latest locked value.
- Make usage checks and option deletion one atomic operation.
- Add repository and route regression coverage for update and delete races.

## Changes
- Lock client writes and the target profile-option row within a transaction before updating or deleting.
- Remove caller-supplied previous option values from the repository API.
- Return explicit deleted, in-use, and not-found outcomes from atomic deletion.

## Testing
- `bun test test/repositories/clientProfileOptionsRepo.test.ts test/routes/clients.test.ts` (93 passed)
- `bun run typecheck` (passed)
- `bunx biome check` on all four changed files (passed)
- `bun run test:react-doctor` (75/100, unchanged from baseline)
- Full backend suite: 4,738 passed, 0 failed
- Full frontend suite did not complete because Bun 1.3.14 crashed with an internal assertion after about 7.5 minutes; focused frontend behavior is unaffected by this backend-only change.

## Risks / Rollout
- No migration or configuration changes.
- Profile-option update/delete operations briefly take a PostgreSQL `SHARE ROW EXCLUSIVE` lock on `clients`; these administrative mutations are expected to be infrequent and the lock prevents concurrent writes from reintroducing stale text values.

## Issues
Issue: Not linked