### PR TITLE
catalog(security): prevent product type deletion races

### DIFF
--- a/server/repositories/productsRepo.ts
+++ b/server/repositories/productsRepo.ts
@@ -6,6 +6,7 @@ import { products } from '../db/schema/products.ts';
 import { productTypes } from '../db/schema/productTypes.ts';
 import { suppliers } from '../db/schema/suppliers.ts';
 import type { CostUnit } from '../utils/cost-unit.ts';
+import { ForeignKeyError } from '../utils/http-errors.ts';
 import { numericForDb, parseDbNumber, parseNullableDbNumber } from '../utils/parse.ts';
 
 // Accepts whatever pg returns for a timestamp column. Drizzle's typed `.select()` paths
@@ -17,6 +18,15 @@ const epochMs = (v: unknown): number | null => {
 };
 
 const LEGACY_HOURS_TYPES = new Set(['service', 'consulting']);
+
+const lockProductTypeReference = async (typeName: string, exec: DbExecutor): Promise<void> => {
+  const rows = await exec
+    .select({ id: productTypes.id })
+    .from(productTypes)
+    .where(eq(productTypes.name, typeName))
+    .for('share');
+  if (!rows[0]) throw new ForeignKeyError(`Product type "${typeName}"`);
+};
 
 // Transaction-item tables holding a `product_id` foreign key.
 const TRANSACTION_ITEM_TABLES = [
@@ -226,25 +236,27 @@ export const existsProductByCode = async (
 export const insertProduct = async (
   product: NewProduct,
   exec: DbExecutor = db,
-): Promise<ProductRow> => {
-  const rows = await exec
-    .insert(products)
-    .values({
-      id: product.id,
-      name: product.name,
-      productCode: product.productCode,
-      description: product.description,
-      costo: numericForDb(product.costo),
-      molPercentage: numericForDb(product.molPercentage),
-      costUnit: product.costUnit,
-      category: product.category,
-      subcategory: product.subcategory,
-      type: product.type,
-      supplierId: product.supplierId,
-    })
-    .returning();
-  return mapProductRow(rows[0]);
-};
+): Promise<ProductRow> =>
+  runAtomically(exec, async (tx) => {
+    await lockProductTypeReference(product.type, tx);
+    const rows = await tx
+      .insert(products)
+      .values({
+        id: product.id,
+        name: product.name,
+        productCode: product.productCode,
+        description: product.description,
+        costo: numericForDb(product.costo),
+        molPercentage: numericForDb(product.molPercentage),
+        costUnit: product.costUnit,
+        category: product.category,
+        subcategory: product.subcategory,
+        type: product.type,
+        supplierId: product.supplierId,
+      })
+      .returning();
+    return mapProductRow(rows[0]);
+  });
 
 export const updateProductDynamic = async (
   id: string,
@@ -267,8 +279,12 @@ export const updateProductDynamic = async (
 
   if (Object.keys(setClause).length === 0) return null;
 
-  const rows = await exec.update(products).set(setClause).where(eq(products.id, id)).returning();
-  return rows[0] ? mapProductRow(rows[0]) : null;
+  const update = async (tx: DbExecutor): Promise<ProductRow | null> => {
+    if (fields.type !== undefined) await lockProductTypeReference(fields.type, tx);
+    const rows = await tx.update(products).set(setClause).where(eq(products.id, id)).returning();
+    return rows[0] ? mapProductRow(rows[0]) : null;
+  };
+  return fields.type === undefined ? update(exec) : runAtomically(exec, update);
 };
 
 export const deleteProductById = async (
@@ -389,6 +405,18 @@ export const findProductTypeById = async (
   return rows[0] ?? null;
 };
 
+export const lockProductTypeById = async (
+  id: string,
+  exec: DbExecutor,
+): Promise<ProductTypeCore | null> => {
+  const rows = await exec
+    .select({ id: productTypes.id, name: productTypes.name, costUnit: productTypes.costUnit })
+    .from(productTypes)
+    .where(eq(productTypes.id, id))
+    .for('update');
+  return rows[0] ?? null;
+};
+
 export const insertProductType = async (
   id: string,
   name: string,
@@ -469,13 +497,33 @@ export const countCategoriesForType = async (
   return row?.value ?? 0;
 };
 
-export const deleteProductTypeById = async (
+export type DeleteProductTypeResult =
+  | { status: 'deleted'; type: ProductTypeCore }
+  | { status: 'not_found' }
+  | {
+      status: 'in_use';
+      type: ProductTypeCore;
+      productCount: number;
+      categoryCount: number;
+    };
+
+export const deleteProductTypeIfUnused = (
   id: string,
   exec: DbExecutor = db,
-): Promise<boolean> => {
-  const result = await exec.delete(productTypes).where(eq(productTypes.id, id));
-  return (result.rowCount ?? 0) > 0;
-};
+): Promise<DeleteProductTypeResult> =>
+  runAtomically(exec, async (tx) => {
+    const type = await lockProductTypeById(id, tx);
+    if (!type) return { status: 'not_found' };
+
+    const productCount = await countProductsForType(type.name, tx);
+    const categoryCount = await countCategoriesForType(type.name, tx);
+    if (productCount > 0 || categoryCount > 0) {
+      return { status: 'in_use', type, productCount, categoryCount };
+    }
+
+    const deleted = await tx.delete(productTypes).where(eq(productTypes.id, id));
+    return (deleted.rowCount ?? 0) > 0 ? { status: 'deleted', type } : { status: 'not_found' };
+  });
 
 // ===========================================================================
 // Internal product categories
@@ -592,13 +640,15 @@ export const insertInternalCategory = async (
   type: string,
   costUnit: CostUnit,
   exec: DbExecutor = db,
-): Promise<InternalCategoryRow> => {
-  const rows = await exec
-    .insert(productCategories)
-    .values({ id, name, type, costUnit })
-    .returning();
-  return mapInternalCategoryRow(rows[0]);
-};
+): Promise<InternalCategoryRow> =>
+  runAtomically(exec, async (tx) => {
+    await lockProductTypeReference(type, tx);
+    const rows = await tx
+      .insert(productCategories)
+      .values({ id, name, type, costUnit })
+      .returning();
+    return mapInternalCategoryRow(rows[0]);
+  });
 
 export const updateInternalCategoryFields = async (
   id: string,

--- a/server/routes/products.ts
+++ b/server/routes/products.ts
@@ -1350,49 +1350,53 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      const current = await productsRepo.findProductTypeById(idResult.value);
-      if (!current) {
-        return replyError(request, reply, {
-          statusCode: 404,
-          message: 'Product type not found',
-          action: 'product_type.update.not_found',
-          entityType: 'product_type',
-          entityId: idResult.value,
-        });
-      }
-
-      let newName = current.name;
-      let newCostUnit = current.costUnit;
-
+      let requestedName: string | undefined;
       if (body.name !== undefined) {
         const nameResult = requireNonEmptyString(body.name, 'name');
         if (!nameResult.ok) return badRequest(reply, nameResult.message);
-        newName = nameResult.value;
+        requestedName = nameResult.value;
       }
 
+      let requestedCostUnit: CostUnit | undefined;
       if (body.costUnit !== undefined) {
         const costUnitResult = validateEnum(body.costUnit, ['unit', 'hours'] as const, 'costUnit');
         if (!costUnitResult.ok) return badRequest(reply, costUnitResult.message);
-        newCostUnit = costUnitResult.value;
+        requestedCostUnit = costUnitResult.value;
       }
 
-      if (newName !== current.name) {
-        if (await productsRepo.existsProductTypeByName(newName, idResult.value)) {
-          return badRequest(reply, 'Product type with this name already exists');
+      const updateResult = await withDbTransaction(async (tx) => {
+        const current = await productsRepo.lockProductTypeById(idResult.value, tx);
+        if (!current) return { status: 'not_found' } as const;
+
+        const newName = requestedName ?? current.name;
+        const newCostUnit = requestedCostUnit ?? current.costUnit;
+        if (
+          newName !== current.name &&
+          (await productsRepo.existsProductTypeByName(newName, idResult.value, tx))
+        ) {
+          return { status: 'duplicate' } as const;
         }
-      }
-
-      const updated = await withDbTransaction(async (tx) => {
         if (newName !== current.name) {
           await productsRepo.propagateProductTypeName(current.name, newName, tx);
         }
         if (newCostUnit !== current.costUnit) {
           await productsRepo.propagateProductTypeCostUnit(newName, newCostUnit, tx);
         }
-        return await productsRepo.updateProductTypeFields(idResult.value, newName, newCostUnit, tx);
+        const updated = await productsRepo.updateProductTypeFields(
+          idResult.value,
+          newName,
+          newCostUnit,
+          tx,
+        );
+        return updated
+          ? ({ status: 'updated', updated, newName, newCostUnit } as const)
+          : ({ status: 'not_found' } as const);
       });
 
-      if (!updated) {
+      if (updateResult.status === 'duplicate') {
+        return badRequest(reply, 'Product type with this name already exists');
+      }
+      if (updateResult.status === 'not_found') {
         return replyError(request, reply, {
           statusCode: 404,
           message: 'Product type not found',
@@ -1401,6 +1405,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           entityId: idResult.value,
         });
       }
+      const { updated, newName, newCostUnit } = updateResult;
 
       await logAudit({
         request,
@@ -1447,8 +1452,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
 
-      const type = await productsRepo.findProductTypeById(idResult.value);
-      if (!type) {
+      const result = await productsRepo.deleteProductTypeIfUnused(idResult.value);
+      if (result.status === 'not_found') {
         return replyError(request, reply, {
           statusCode: 404,
           message: 'Product type not found',
@@ -1457,43 +1462,36 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           entityId: idResult.value,
         });
       }
-      const { name } = type;
+      const { name } = result.type;
 
-      const [productCount, categoryCount] = await Promise.all([
-        productsRepo.countProductsForType(name),
-        productsRepo.countCategoriesForType(name),
-      ]);
-
-      if (productCount > 0) {
+      if (result.status === 'in_use' && result.productCount > 0) {
         return replyError(request, reply, {
           statusCode: 409,
-          message: `Cannot delete type "${name}" because ${productCount} product(s) are using it`,
+          message: `Cannot delete type "${name}" because ${result.productCount} product(s) are using it`,
           action: 'product_type.delete.conflict',
           entityType: 'product_type',
           entityId: idResult.value,
           details: {
             targetLabel: name,
             secondaryLabel: 'in_use_by_products',
-            counts: { products: productCount },
+            counts: { products: result.productCount },
           },
         });
       }
-      if (categoryCount > 0) {
+      if (result.status === 'in_use' && result.categoryCount > 0) {
         return replyError(request, reply, {
           statusCode: 409,
-          message: `Cannot delete type "${name}" because ${categoryCount} category(s) are using it`,
+          message: `Cannot delete type "${name}" because ${result.categoryCount} category(s) are using it`,
           action: 'product_type.delete.conflict',
           entityType: 'product_type',
           entityId: idResult.value,
           details: {
             targetLabel: name,
             secondaryLabel: 'in_use_by_categories',
-            counts: { categories: categoryCount },
+            counts: { categories: result.categoryCount },
           },
         });
       }
-
-      await productsRepo.deleteProductTypeById(idResult.value);
 
       await logAudit({
         request,

--- a/server/test/repositories/productsRepo.test.ts
+++ b/server/test/repositories/productsRepo.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, test } from 'bun:test';
 import type { DbExecutor } from '../../db/drizzle.ts';
 import * as productsRepo from '../../repositories/productsRepo.ts';
+import { ForeignKeyError } from '../../utils/http-errors.ts';
 import { type FakeExecutor, makeRow, setupTestDb } from '../helpers/fakeExecutor.ts';
 
 let exec: FakeExecutor;
@@ -186,6 +187,7 @@ describe('existsProductByName / existsProductByCode', () => {
 
 describe('insertProduct', () => {
   test('passes all 11 input columns through and maps the returned row', async () => {
+    exec.enqueue({ rows: [['pt-1']] });
     // INSERT ... RETURNING with no explicit cols returns all 13 products columns.
     exec.enqueue({ rows: [productRow()], rowCount: 1 });
     const result = await productsRepo.insertProduct(
@@ -206,7 +208,8 @@ describe('insertProduct', () => {
     );
     // The 11 user-provided values appear among the bound params; Drizzle's order matches
     // the insert object's key order.
-    const params = exec.calls[0].params;
+    expect(exec.calls[0].sql.toLowerCase()).toContain('for share');
+    const params = exec.calls[1].params;
     expect(params).toContain('p-1');
     expect(params).toContain('Widget');
     expect(params).toContain('WGT-001');
@@ -215,6 +218,30 @@ describe('insertProduct', () => {
     expect(params).toContain('unit');
     expect(params).toContain('good');
     expect(result.id).toBe('p-1');
+  });
+
+  test('rejects a product whose type disappeared before the write', async () => {
+    exec.enqueue({ rows: [] });
+    await expect(
+      productsRepo.insertProduct(
+        {
+          id: 'p-1',
+          name: 'Widget',
+          productCode: 'WGT-001',
+          description: null,
+          costo: 12.5,
+          molPercentage: 30,
+          costUnit: 'unit',
+          category: null,
+          subcategory: null,
+          type: 'deleted',
+          supplierId: null,
+        },
+        testDb,
+      ),
+    ).rejects.toBeInstanceOf(ForeignKeyError);
+    expect(exec.calls).toHaveLength(1);
+    expect(exec.calls[0].sql.toLowerCase()).toContain('for share');
   });
 });
 
@@ -261,6 +288,14 @@ describe('updateProductDynamic', () => {
     exec.enqueue({ rows: [], rowCount: 0 });
     const result = await productsRepo.updateProductDynamic('p-1', { name: 'X' }, testDb);
     expect(result).toBeNull();
+  });
+
+  test('locks a new type reference through the product update', async () => {
+    exec.enqueue({ rows: [['pt-1']] });
+    exec.enqueue({ rows: [productRow({ 7: 'service' })], rowCount: 1 });
+    await productsRepo.updateProductDynamic('p-1', { type: 'service' }, testDb);
+    expect(exec.calls[0].sql.toLowerCase()).toContain('for share');
+    expect(exec.calls[1].sql.toLowerCase()).toContain('update "products"');
   });
 });
 
@@ -339,6 +374,13 @@ describe('findProductTypeById / insertProductType / updateProductTypeFields', ()
 
     exec.enqueue({ rows: [] });
     expect(await productsRepo.findProductTypeById('pt-99', testDb)).toBeNull();
+  });
+
+  test('lockProductTypeById holds an update lock for mutation checks', async () => {
+    exec.enqueue({ rows: [['pt-1', 'good', 'unit']] });
+    const result = await productsRepo.lockProductTypeById('pt-1', testDb);
+    expect(result).toEqual({ id: 'pt-1', name: 'good', costUnit: 'unit' });
+    expect(exec.calls[0].sql.toLowerCase()).toContain('for update');
   });
 
   test('insertProductType passes id/name/costUnit and returns row with zero counts', async () => {
@@ -459,13 +501,39 @@ describe('countProductsForType / countCategoriesForType', () => {
   });
 });
 
-describe('deleteProductTypeById', () => {
-  test.each([
-    [1, true],
-    [0, false],
-  ] as const)('returns %s when rowCount is %s', async (rowCount, expected) => {
-    exec.enqueue({ rows: [], rowCount });
-    expect(await productsRepo.deleteProductTypeById('pt-1', testDb)).toBe(expected);
+describe('deleteProductTypeIfUnused', () => {
+  test('locks the type before checking references and deleting it', async () => {
+    exec.enqueue({ rows: [['pt-1', 'good', 'unit']] });
+    exec.enqueue({ rows: [['0']] });
+    exec.enqueue({ rows: [['0']] });
+    exec.enqueue({ rows: [], rowCount: 1 });
+
+    const result = await productsRepo.deleteProductTypeIfUnused('pt-1', testDb);
+
+    expect(result).toEqual({
+      status: 'deleted',
+      type: { id: 'pt-1', name: 'good', costUnit: 'unit' },
+    });
+    expect(exec.calls[0].sql.toLowerCase()).toContain('for update');
+    expect(exec.calls[1].sql.toLowerCase()).toContain('from "products"');
+    expect(exec.calls[2].sql.toLowerCase()).toContain('from "internal_product_categories"');
+    expect(exec.calls[3].sql.toLowerCase()).toContain('delete from "product_types"');
+  });
+
+  test('does not delete a type that gained a reference before the lock', async () => {
+    exec.enqueue({ rows: [['pt-1', 'good', 'unit']] });
+    exec.enqueue({ rows: [['1']] });
+    exec.enqueue({ rows: [['0']] });
+
+    const result = await productsRepo.deleteProductTypeIfUnused('pt-1', testDb);
+
+    expect(result).toEqual({
+      status: 'in_use',
+      type: { id: 'pt-1', name: 'good', costUnit: 'unit' },
+      productCount: 1,
+      categoryCount: 0,
+    });
+    expect(exec.calls).toHaveLength(3);
   });
 });
 
@@ -542,6 +610,7 @@ describe('existsInternalCategoryByNameType', () => {
 
 describe('insertInternalCategory / updateInternalCategoryFields', () => {
   test('insertInternalCategory binds [id, name, type, costUnit] and starts with zero counts', async () => {
+    exec.enqueue({ rows: [['pt-1']] });
     exec.enqueue({ rows: [categoryRow()], rowCount: 1 });
     const result = await productsRepo.insertInternalCategory(
       'ipc-1',
@@ -550,7 +619,8 @@ describe('insertInternalCategory / updateInternalCategoryFields', () => {
       'unit',
       testDb,
     );
-    const params = exec.calls[0].params;
+    expect(exec.calls[0].sql.toLowerCase()).toContain('for share');
+    const params = exec.calls[1].params;
     expect(params).toContain('ipc-1');
     expect(params).toContain('Mechanical');
     expect(params).toContain('good');

--- a/server/test/routes/products.test.ts
+++ b/server/test/routes/products.test.ts
@@ -52,14 +52,14 @@ const listAllProductTypesWithCountsMock = mock();
 const findProductTypeByNameMock = mock();
 const getCostUnitForTypeMock = mock();
 const existsProductTypeByNameMock = mock();
-const findProductTypeByIdMock = mock();
+const lockProductTypeByIdMock = mock();
 const insertProductTypeMock = mock();
 const updateProductTypeFieldsMock = mock();
 const propagateProductTypeNameMock = mock();
 const propagateProductTypeCostUnitMock = mock();
 const countProductsForTypeMock = mock();
 const countCategoriesForTypeMock = mock();
-const deleteProductTypeByIdMock = mock();
+const deleteProductTypeIfUnusedMock = mock();
 
 const listInternalCategoriesByTypeMock = mock();
 const findInternalCategoryByIdMock = mock();
@@ -118,14 +118,14 @@ beforeAll(async () => {
     findProductTypeByName: findProductTypeByNameMock,
     getCostUnitForType: getCostUnitForTypeMock,
     existsProductTypeByName: existsProductTypeByNameMock,
-    findProductTypeById: findProductTypeByIdMock,
+    lockProductTypeById: lockProductTypeByIdMock,
     insertProductType: insertProductTypeMock,
     updateProductTypeFields: updateProductTypeFieldsMock,
     propagateProductTypeName: propagateProductTypeNameMock,
     propagateProductTypeCostUnit: propagateProductTypeCostUnitMock,
     countProductsForType: countProductsForTypeMock,
     countCategoriesForType: countCategoriesForTypeMock,
-    deleteProductTypeById: deleteProductTypeByIdMock,
+    deleteProductTypeIfUnused: deleteProductTypeIfUnusedMock,
     listInternalCategoriesByType: listInternalCategoriesByTypeMock,
     findInternalCategoryById: findInternalCategoryByIdMock,
     findCategoryIdByNameAndType: findCategoryIdByNameAndTypeMock,
@@ -247,14 +247,14 @@ const allMocks = [
   findProductTypeByNameMock,
   getCostUnitForTypeMock,
   existsProductTypeByNameMock,
-  findProductTypeByIdMock,
+  lockProductTypeByIdMock,
   insertProductTypeMock,
   updateProductTypeFieldsMock,
   propagateProductTypeNameMock,
   propagateProductTypeCostUnitMock,
   countProductsForTypeMock,
   countCategoriesForTypeMock,
-  deleteProductTypeByIdMock,
+  deleteProductTypeIfUnusedMock,
   listInternalCategoriesByTypeMock,
   findInternalCategoryByIdMock,
   findCategoryIdByNameAndTypeMock,
@@ -1176,7 +1176,7 @@ describe('POST /api/products/internal-types', () => {
 
 describe('PUT /api/products/internal-types/:id', () => {
   test('200 updates type', async () => {
-    findProductTypeByIdMock.mockResolvedValue({ ...SAMPLE_TYPE });
+    lockProductTypeByIdMock.mockResolvedValue({ ...SAMPLE_TYPE });
     existsProductTypeByNameMock.mockResolvedValue(false);
     updateProductTypeFieldsMock.mockResolvedValue({ ...SAMPLE_TYPE, name: 'svc' });
     countProductsForTypeMock.mockResolvedValue(0);
@@ -1190,13 +1190,15 @@ describe('PUT /api/products/internal-types/:id', () => {
     });
 
     expect(res.statusCode).toBe(200);
+    expect(lockProductTypeByIdMock).toHaveBeenCalledWith('pt-1', expect.anything());
+    expect(existsProductTypeByNameMock).toHaveBeenCalledWith('svc', 'pt-1', expect.anything());
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'product_type.updated' }),
     );
   });
 
   test('404 type not found', async () => {
-    findProductTypeByIdMock.mockResolvedValue(null);
+    lockProductTypeByIdMock.mockResolvedValue(null);
 
     const res = await testApp.inject({
       method: 'PUT',
@@ -1209,7 +1211,7 @@ describe('PUT /api/products/internal-types/:id', () => {
   });
 
   test('400 duplicate name', async () => {
-    findProductTypeByIdMock.mockResolvedValue({ ...SAMPLE_TYPE });
+    lockProductTypeByIdMock.mockResolvedValue({ ...SAMPLE_TYPE });
     existsProductTypeByNameMock.mockResolvedValue(true);
 
     const res = await testApp.inject({
@@ -1225,10 +1227,10 @@ describe('PUT /api/products/internal-types/:id', () => {
 
 describe('DELETE /api/products/internal-types/:id', () => {
   test('204 deletes type', async () => {
-    findProductTypeByIdMock.mockResolvedValue({ ...SAMPLE_TYPE });
-    countProductsForTypeMock.mockResolvedValue(0);
-    countCategoriesForTypeMock.mockResolvedValue(0);
-    deleteProductTypeByIdMock.mockResolvedValue(undefined);
+    deleteProductTypeIfUnusedMock.mockResolvedValue({
+      status: 'deleted',
+      type: SAMPLE_TYPE,
+    });
 
     const res = await testApp.inject({
       method: 'DELETE',
@@ -1237,13 +1239,16 @@ describe('DELETE /api/products/internal-types/:id', () => {
     });
 
     expect(res.statusCode).toBe(204);
+    expect(deleteProductTypeIfUnusedMock).toHaveBeenCalledWith('pt-1');
+    expect(countProductsForTypeMock).not.toHaveBeenCalled();
+    expect(countCategoriesForTypeMock).not.toHaveBeenCalled();
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'product_type.deleted' }),
     );
   });
 
   test('404 not found', async () => {
-    findProductTypeByIdMock.mockResolvedValue(null);
+    deleteProductTypeIfUnusedMock.mockResolvedValue({ status: 'not_found' });
 
     const res = await testApp.inject({
       method: 'DELETE',
@@ -1255,9 +1260,12 @@ describe('DELETE /api/products/internal-types/:id', () => {
   });
 
   test('409 products linked', async () => {
-    findProductTypeByIdMock.mockResolvedValue({ ...SAMPLE_TYPE });
-    countProductsForTypeMock.mockResolvedValue(3);
-    countCategoriesForTypeMock.mockResolvedValue(0);
+    deleteProductTypeIfUnusedMock.mockResolvedValue({
+      status: 'in_use',
+      type: SAMPLE_TYPE,
+      productCount: 3,
+      categoryCount: 0,
+    });
 
     const res = await testApp.inject({
       method: 'DELETE',
@@ -1270,9 +1278,12 @@ describe('DELETE /api/products/internal-types/:id', () => {
   });
 
   test('409 categories linked', async () => {
-    findProductTypeByIdMock.mockResolvedValue({ ...SAMPLE_TYPE });
-    countProductsForTypeMock.mockResolvedValue(0);
-    countCategoriesForTypeMock.mockResolvedValue(2);
+    deleteProductTypeIfUnusedMock.mockResolvedValue({
+      status: 'in_use',
+      type: SAMPLE_TYPE,
+      productCount: 0,
+      categoryCount: 2,
+    });
 
     const res = await testApp.inject({
       method: 'DELETE',


### PR DESCRIPTION
## Summary
- serialize product type deletion with product and category reference writes
- prevent concurrent creates, type changes, and type renames from leaving orphaned catalog type names
- add repository and route regression coverage for the locking contract

## Changes
- hold shared product-type row locks while creating products/categories or changing a product type
- hold an exclusive row lock while renaming or conditionally deleting a product type
- perform reference counts and deletion in one repository transaction

## Testing
- `bun test test/repositories/productsRepo.test.ts test/routes/products.test.ts` (140 passed)
- `bun run typecheck` (passed)
- `bunx biome check server/repositories/productsRepo.ts server/routes/products.ts server/test/repositories/productsRepo.test.ts server/test/routes/products.test.ts` (passed)
- `bun run test`: backend passed (4,739 tests, 0 failures); frontend run reached unrelated accounting component tests before Bun 1.3.14 crashed with an internal assertion on Windows
- `bun run test:react-doctor`: unavailable before and after the change because the latest bunx package failed to resolve Sentry modules

## Risks / Rollout
- Low risk. No schema, migration, API contract, or documentation changes; lock scope is limited to catalog type reference mutations.

## Issues
- DeepSec finding `a10d742bf1`; no GitHub issue linked.