### PR TITLE
webhooks(security): encrypt custom header values

### DIFF
--- a/components/administration/WebhooksView.tsx
+++ b/components/administration/WebhooksView.tsx
@@ -58,14 +58,29 @@ export interface WebhooksViewProps {
 
 type LoadStatus = 'loading' | 'ready' | 'error';
 
-// Editable header row. `uid` is a stable client-only key for React lists (the API shape is just
-// `{ key, value }`); it's stripped when building the request payload.
-type HeaderRow = { uid: string; key: string; value: string };
+// Editable custom header. Values returned by the API are masked, so stored rows use the same
+// explicit Keep / Replace state as the main authentication secret.
+type HeaderRow = {
+  uid: string;
+  key: string;
+  originalKey: string;
+  value: string;
+  isStored: boolean;
+  isReplacingValue: boolean;
+};
 
 let headerRowCounter = 0;
 const newHeaderRow = (key = '', value = ''): HeaderRow => {
   headerRowCounter += 1;
-  return { uid: `webhook-header-${headerRowCounter}`, key, value };
+  const isStored = isStoredSecret(value);
+  return {
+    uid: `webhook-header-${headerRowCounter}`,
+    key,
+    originalKey: key,
+    value: isStored ? '' : value,
+    isStored,
+    isReplacingValue: false,
+  };
 };
 
 const asSingleValue = (value: string | string[]): string =>
@@ -134,6 +149,8 @@ type FormAction =
   | { type: 'cancelReplaceSecret' }
   | { type: 'addHeader'; row: HeaderRow }
   | { type: 'updateHeader'; uid: string; field: 'key' | 'value'; value: string }
+  | { type: 'startReplaceHeader'; uid: string }
+  | { type: 'cancelReplaceHeader'; uid: string }
   | { type: 'removeHeader'; uid: string };
 
 const formReducer = (state: FormState, action: FormAction): FormState => {
@@ -188,8 +205,39 @@ const formReducer = (state: FormState, action: FormAction): FormState => {
     case 'updateHeader':
       return {
         ...state,
+        customHeaders: state.customHeaders.map((header) => {
+          if (header.uid !== action.uid) return header;
+          if (action.field === 'value') return { ...header, value: action.value };
+          const keepsStoredValue =
+            header.isStored &&
+            action.value.trim().toLowerCase() === header.originalKey.trim().toLowerCase();
+          return {
+            ...header,
+            key: action.value,
+            value: keepsStoredValue ? '' : header.value,
+            isReplacingValue: header.isStored ? !keepsStoredValue : header.isReplacingValue,
+          };
+        }),
+      };
+    case 'startReplaceHeader':
+      return {
+        ...state,
         customHeaders: state.customHeaders.map((header) =>
-          header.uid === action.uid ? { ...header, [action.field]: action.value } : header,
+          header.uid === action.uid ? { ...header, isReplacingValue: true, value: '' } : header,
+        ),
+      };
+    case 'cancelReplaceHeader':
+      return {
+        ...state,
+        customHeaders: state.customHeaders.map((header) =>
+          header.uid === action.uid
+            ? {
+                ...header,
+                key: header.originalKey,
+                value: '',
+                isReplacingValue: false,
+              }
+            : header,
         ),
       };
     case 'removeHeader':
@@ -495,37 +543,52 @@ const WebhookFormModal: React.FC<{
                 ) : (
                   <div className="space-y-2">
                     {form.customHeaders.map((header) => (
-                      <div key={header.uid} className="flex items-center gap-2">
-                        <Input
-                          aria-label={t('administration:webhooks.fields.headerKey')}
-                          placeholder={t('administration:webhooks.placeholders.headerKey')}
-                          value={header.key}
-                          onChange={(event) =>
-                            dispatch({
-                              type: 'updateHeader',
-                              uid: header.uid,
-                              field: 'key',
-                              value: event.target.value,
-                            })
-                          }
-                        />
-                        <Input
-                          aria-label={t('administration:webhooks.fields.headerValue')}
-                          placeholder={t('administration:webhooks.placeholders.headerValue')}
+                      <div key={header.uid} className="grid gap-2 sm:grid-cols-[1fr_1fr_auto]">
+                        <Field>
+                          <FieldLabel>{t('administration:webhooks.fields.headerKey')}</FieldLabel>
+                          <Input
+                            aria-label={t('administration:webhooks.fields.headerKey')}
+                            placeholder={t('administration:webhooks.placeholders.headerKey')}
+                            value={header.key}
+                            onChange={(event) =>
+                              dispatch({
+                                type: 'updateHeader',
+                                uid: header.uid,
+                                field: 'key',
+                                value: event.target.value,
+                              })
+                            }
+                          />
+                        </Field>
+                        <SecretField
+                          label={t('administration:webhooks.fields.headerValue')}
                           value={header.value}
-                          onChange={(event) =>
+                          onChange={(value) =>
                             dispatch({
                               type: 'updateHeader',
                               uid: header.uid,
                               field: 'value',
-                              value: event.target.value,
+                              value,
                             })
                           }
+                          isStored={header.isStored}
+                          isReplacing={header.isReplacingValue}
+                          onStartReplace={() =>
+                            dispatch({ type: 'startReplaceHeader', uid: header.uid })
+                          }
+                          onCancelReplace={() =>
+                            dispatch({ type: 'cancelReplaceHeader', uid: header.uid })
+                          }
+                          storedLabel={t('administration:webhooks.secretStored')}
+                          storedHelp={t('administration:webhooks.secretStoredHelp')}
+                          placeholder={t('administration:webhooks.placeholders.headerValue')}
+                          testId={`webhook-header-${header.uid}`}
                         />
                         <Button
                           type="button"
                           variant="ghost"
                           size="icon-sm"
+                          className="self-end"
                           aria-label={t('administration:webhooks.actions.removeHeader')}
                           onClick={() => dispatch({ type: 'removeHeader', uid: header.uid })}
                         >
@@ -655,7 +718,12 @@ const WebhooksView: React.FC<WebhooksViewProps> = ({ permissions }) => {
       customHeaders: form.customHeaders.reduce<NonNullable<WebhookPayload['customHeaders']>>(
         (headers, header) => {
           const key = header.key.trim();
-          if (key.length > 0) headers.push({ key, value: header.value });
+          if (key.length > 0) {
+            headers.push({
+              key,
+              ...(header.isStored && !header.isReplacingValue ? {} : { value: header.value }),
+            });
+          }
           return headers;
         },
         [],
@@ -686,7 +754,9 @@ const WebhooksView: React.FC<WebhooksViewProps> = ({ permissions }) => {
       errors.authHeaderName = t('administration:webhooks.errors.headerNameRequired');
     }
     if (
-      form.customHeaders.some((header) => header.value.trim() !== '' && header.key.trim() === '')
+      form.customHeaders.some(
+        (header) => (header.isStored || header.value.trim() !== '') && header.key.trim() === '',
+      )
     ) {
       errors.customHeaders = t('administration:webhooks.errors.headerKeyRequired');
     }

--- a/docs-site/src/content/docs/administration.md
+++ b/docs-site/src/content/docs/administration.md
@@ -154,7 +154,7 @@ Ogni destinazione definisce:
 - **URL** — l'endpoint HTTPS pubblico che Praetor chiama. Non sono accettati URL con credenziali incorporate né destinazioni loopback, private, link-local o riservate. Praetor risolve e vincola l'indirizzo prima della connessione e non segue i reindirizzamenti.
 - **Metodo HTTP** — `GET`, `POST` (predefinito), `PUT`, `PATCH` o `DELETE`.
 - **Autenticazione** — come Praetor si autentica verso la destinazione: **Nessuna**, **Bearer token**, **Basic** (nome utente e password) o **Chiave API** (un valore inviato in un header personalizzato che assegni). La credenziale segreta è cifrata a riposo e non viene mai restituita al browser; in modifica mostra un badge **Memorizzato — Sostituisci**, e lo stesso comportamento Mantieni / Sostituisci degli altri campi segreti la preserva finché non la sostituisci o la rimuovi esplicitamente.
-- **Header personalizzati** — coppie chiave/valore facoltative allegate a ogni richiesta, sovrapposte all'header di autenticazione. Usali per valori di instradamento non segreti come un id tenant.
+- **Header personalizzati** — coppie chiave/valore facoltative allegate a ogni richiesta, sovrapposte all'header di autenticazione. Ogni valore è cifrato a riposo e mascherato nell'API e nel browser. La modifica usa i controlli **Salvato — Sostituisci**: lascia invariato un valore salvato per conservarlo oppure scegli **Sostituisci** per impostarlo o cancellarlo.
 - **Abilitato** — un interruttore che marca la destinazione come attiva o inattiva.
 
 Le azioni di creazione, modifica ed eliminazione sono regolate rispettivamente dai permessi create, update e delete, e ogni modifica viene scritta nel log di audit.
@@ -162,3 +162,5 @@ Le azioni di creazione, modifica ed eliminazione sono regolate rispettivamente d
 Questa pagina configura solo le destinazioni; gli eventi che attivano ciascun webhook vengono collegati separatamente, ad esempio nelle azioni delle regole commessa.
 
 > Nota di aggiornamento: le destinazioni `http://` salvate da versioni precedenti non vengono più inviate. Modificale con un endpoint HTTPS pubblico prima di riabilitare le regole che le usano.
+>
+> Per aggiornare una versione che salvava in chiaro i valori degli header personalizzati, arresta tutte le istanze API precedenti ed esegui un backup del database prima di avviare la nuova versione. All'avvio i valori esistenti vengono cifrati sul posto; un'immagine precedente non può inviare questi header cifrati. Per eseguire il rollback, ripristina il backup precedente all'aggiornamento prima di riavviare l'immagine precedente.

--- a/docs-site/src/content/docs/en/administration.md
+++ b/docs-site/src/content/docs/en/administration.md
@@ -154,7 +154,7 @@ Each target defines:
 - **URL** — the public HTTPS endpoint Praetor calls. URLs with embedded credentials and loopback, private, link-local, or reserved destinations are rejected. Praetor resolves and pins the address before connecting and does not follow redirects.
 - **HTTP method** — `GET`, `POST` (default), `PUT`, `PATCH`, or `DELETE`.
 - **Authentication** — how Praetor authenticates to the target: **None**, **Bearer token**, **Basic** (username and password), or **API key** (a value sent under a custom header you name). The secret credential is encrypted at rest and never returned to the browser; when editing it shows a **Stored — Replace** badge, and the same Keep / Replace behavior as the other secret fields preserves it unless you explicitly replace or clear it.
-- **Custom headers** — optional key/value pairs attached to every request, layered on top of the authentication header. Use these for non-secret routing values such as a tenant id.
+- **Custom headers** — optional key/value pairs attached to every request, layered on top of the authentication header. Every value is encrypted at rest and masked in the API and browser. Editing uses **Stored — Replace** controls; leave a stored value untouched to preserve it, or choose **Replace** to set or clear it.
 - **Enabled** — a toggle that marks the target active or inactive.
 
 Create, edit, and delete actions are gated by the create, update, and delete permissions respectively, and every change is written to the audit log.
@@ -162,3 +162,5 @@ Create, edit, and delete actions are gated by the create, update, and delete per
 This page configures targets only; the events that trigger each webhook are wired up separately, for example in job-rule actions.
 
 > Upgrade note: `http://` targets saved by earlier versions are no longer dispatched. Update them to a public HTTPS endpoint before re-enabling rules that use them.
+>
+> When upgrading from a version that stored custom header values in plaintext, stop all older API instances and take a database backup before starting the new version. Startup encrypts existing values in place; an older image cannot dispatch those encrypted headers. Roll back by restoring the pre-upgrade backup before restarting the older image.

--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -13701,6 +13701,7 @@
         "tags": [
           "projects"
         ],
+        "description": "Omits rules whose condition fields require permissions the caller does not have.",
         "parameters": [
           {
             "schema": {
@@ -44064,7 +44065,10 @@
                 ],
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 100,
+                    "pattern": "^[A-Za-z0-9_-]*$",
+                    "description": "Optional manual order code. Letters, numbers, underscores, and hyphens only; blank allocates the configured automatic code."
                   },
                   "description": {
                     "type": "string"
@@ -44636,7 +44640,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Order code. A renamed code must use at most 100 letters, numbers, underscores, or hyphens; an unchanged legacy code remains accepted."
                   },
                   "description": {
                     "type": [
@@ -46514,7 +46519,10 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 100,
+                    "pattern": "^[A-Za-z0-9_-]*$",
+                    "description": "Leave blank to allocate automatically. Manual values may contain letters, numbers, underscores, and hyphens."
                   },
                   "linkedSaleId": {
                     "type": "string"
@@ -46903,7 +46911,9 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 100,
+                    "description": "When changed, may contain letters, numbers, underscores, and hyphens. An unchanged legacy id remains accepted."
                   },
                   "clientId": {
                     "type": "string"
@@ -46994,7 +47004,8 @@
         "parameters": [
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "maxLength": 2048
             },
             "in": "path",
             "name": "id",
@@ -47288,7 +47299,8 @@
         "parameters": [
           {
             "schema": {
-              "type": "string"
+              "type": "string",
+              "maxLength": 2048
             },
             "in": "path",
             "name": "id",
@@ -54990,7 +55002,10 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 100,
+                    "pattern": "^[A-Za-z0-9_-]*$",
+                    "description": "Optional manual invoice code. Letters, numbers, underscores, and hyphens only; blank allocates the configured automatic code."
                   },
                   "linkedSaleId": {
                     "type": "string"
@@ -55366,7 +55381,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Invoice code. A renamed code must use at most 100 letters, numbers, underscores, or hyphens; an unchanged legacy code remains accepted."
                   },
                   "supplierId": {
                     "type": "string"
@@ -59331,6 +59347,27 @@
               }
             }
           },
+          "429": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
           "503": {
             "description": "Default Response",
             "content": {
@@ -59476,6 +59513,27 @@
             }
           },
           "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
             "description": "Default Response",
             "content": {
               "application/json": {
@@ -59690,6 +59748,27 @@
             }
           },
           "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
             "description": "Default Response",
             "content": {
               "application/json": {
@@ -62821,8 +62900,7 @@
                         }
                       },
                       "required": [
-                        "key",
-                        "value"
+                        "key"
                       ],
                       "additionalProperties": false
                     },

--- a/server/db/schema/webhooks.ts
+++ b/server/db/schema/webhooks.ts
@@ -25,10 +25,13 @@ export const WEBHOOK_AUTH_TYPES = ['none', 'basic', 'bearer', 'api_key'] as cons
 export type WebhookAuthType = (typeof WEBHOOK_AUTH_TYPES)[number];
 
 // Arbitrary request headers attached to every dispatch, layered on top of (and lower priority
-// than) the headers the auth type contributes. Stored as a JSON array so order is preserved.
+// than) the headers the auth type contributes. Values are encrypted ciphertext (except the empty
+// string), and the JSON array preserves header order.
 export type StoredWebhookHeader = {
   key: string;
   value: string;
+  // Absent on legacy plaintext rows; true once `value` has been encrypted by the service.
+  encrypted?: true;
 };
 
 export const webhooks = pgTable(

--- a/server/index.ts
+++ b/server/index.ts
@@ -13,6 +13,7 @@ import {
   startProjectRulesScheduler,
 } from './services/projectRulesScheduler.ts';
 import siemService from './services/siem.ts';
+import { migrateLegacyWebhookHeaders } from './services/webhookHeaders.ts';
 import { performShutdown } from './shutdown.ts';
 import { createChildLogger, serializeError } from './utils/logger.ts';
 import {
@@ -93,6 +94,11 @@ try {
   const migratedLegacyAiApiKeys = await migrateLegacyAiApiKeys();
   if (migratedLegacyAiApiKeys) {
     logger.info('Legacy AI provider credentials encrypted');
+  }
+
+  const migratedWebhookHeaders = await migrateLegacyWebhookHeaders();
+  if (migratedWebhookHeaders > 0) {
+    logger.info({ webhookCount: migratedWebhookHeaders }, 'Legacy webhook header values encrypted');
   }
 
   // Ensure required bootstrap user data always exists.

--- a/server/repositories/webhooksRepo.ts
+++ b/server/repositories/webhooksRepo.ts
@@ -1,4 +1,4 @@
-import { desc, eq, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, gt, sql } from 'drizzle-orm';
 import { type DbExecutor, db } from '../db/drizzle.ts';
 import {
   type StoredWebhookHeader,
@@ -9,9 +9,9 @@ import {
 
 export type WebhookHeader = StoredWebhookHeader;
 
-// Domain shape returned to routes. `authSecret` is the ciphertext as stored — the route masks it
-// with MASKED_SECRET before serializing, and a future dispatcher must `decrypt()` it. Timestamps
-// are intentionally omitted from the public shape (mirrors ssoProvidersRepo).
+// Domain shape returned to routes. Secret fields are ciphertext as stored; the route masks them
+// before serializing and the dispatcher decrypts them. Timestamps are intentionally omitted from
+// the public shape (mirrors ssoProvidersRepo).
 export type Webhook = {
   id: string;
   name: string;
@@ -81,6 +81,22 @@ export const list = async (exec: DbExecutor = db): Promise<Webhook[]> => {
   return rows.map(mapRow);
 };
 
+export const listBatchAfterId = async (
+  afterId: string | undefined,
+  limit: number,
+  exec: DbExecutor = db,
+): Promise<Webhook[]> => {
+  const rows = afterId
+    ? await exec
+        .select(WEBHOOK_PROJECTION)
+        .from(webhooks)
+        .where(gt(webhooks.id, afterId))
+        .orderBy(asc(webhooks.id))
+        .limit(limit)
+    : await exec.select(WEBHOOK_PROJECTION).from(webhooks).orderBy(asc(webhooks.id)).limit(limit);
+  return rows.map(mapRow);
+};
+
 export const findById = async (id: string, exec: DbExecutor = db): Promise<Webhook | null> => {
   const rows = await exec.select(WEBHOOK_PROJECTION).from(webhooks).where(eq(webhooks.id, id));
   return rows[0] ? mapRow(rows[0]) : null;
@@ -110,6 +126,20 @@ export const update = async (
     .where(eq(webhooks.id, id))
     .returning(WEBHOOK_PROJECTION);
   return rows[0] ? mapRow(rows[0]) : null;
+};
+
+export const replaceCustomHeadersIfUnchanged = async (
+  id: string,
+  expected: StoredWebhookHeader[],
+  replacement: StoredWebhookHeader[],
+  exec: DbExecutor = db,
+): Promise<boolean> => {
+  const rows = await exec
+    .update(webhooks)
+    .set({ customHeaders: replacement, updatedAt: sql`CURRENT_TIMESTAMP` })
+    .where(and(eq(webhooks.id, id), eq(webhooks.customHeaders, expected)))
+    .returning({ id: webhooks.id });
+  return rows.length > 0;
 };
 
 export const deleteById = async (id: string, exec: DbExecutor = db): Promise<boolean> => {

--- a/server/routes/webhooks.ts
+++ b/server/routes/webhooks.ts
@@ -1,12 +1,9 @@
 import type { FastifyInstance, FastifyReply } from 'fastify';
-import {
-  type StoredWebhookHeader,
-  WEBHOOK_AUTH_TYPES,
-  WEBHOOK_HTTP_METHODS,
-} from '../db/schema/webhooks.ts';
+import { WEBHOOK_AUTH_TYPES, WEBHOOK_HTTP_METHODS } from '../db/schema/webhooks.ts';
 import { authenticateToken, requirePermission } from '../middleware/auth.ts';
 import * as webhooksRepo from '../repositories/webhooksRepo.ts';
 import { standardRateLimitedErrorResponses } from '../schemas/common.ts';
+import { maskHeaders, type WebhookHeaderInput } from '../services/webhookHeaders.ts';
 import * as webhooksService from '../services/webhooks.ts';
 import { logAudit } from '../utils/audit.ts';
 import { MASKED_SECRET } from '../utils/crypto.ts';
@@ -27,14 +24,19 @@ const MAX_NAME_LEN = 255;
 const MAX_URL_LEN = 2000;
 const MAX_AUTH_FIELD_LEN = 255;
 
-const customHeaderSchema = {
+const customHeaderInputSchema = {
   type: 'object',
   properties: {
     key: { type: 'string' },
     value: { type: 'string' },
   },
-  required: ['key', 'value'],
+  required: ['key'],
   additionalProperties: false,
+} as const;
+
+const customHeaderResponseSchema = {
+  ...customHeaderInputSchema,
+  required: ['key', 'value'],
 } as const;
 
 // Full webhook as returned to the admin UI. `authSecret` is always masked here (never the
@@ -51,7 +53,7 @@ const webhookResponseSchema = {
     authUsername: { type: 'string' },
     authHeaderName: { type: 'string' },
     authSecret: { type: 'string' },
-    customHeaders: { type: 'array', items: customHeaderSchema },
+    customHeaders: { type: 'array', items: customHeaderResponseSchema },
     enabled: { type: 'boolean' },
   },
   required: [
@@ -82,7 +84,11 @@ const webhookBodyProperties = {
   authUsername: { type: 'string', maxLength: MAX_AUTH_FIELD_LEN },
   authHeaderName: { type: 'string', maxLength: MAX_AUTH_FIELD_LEN },
   authSecret: { type: 'string' },
-  customHeaders: { type: 'array', items: customHeaderSchema, maxItems: MAX_CUSTOM_HEADERS },
+  customHeaders: {
+    type: 'array',
+    items: customHeaderInputSchema,
+    maxItems: MAX_CUSTOM_HEADERS,
+  },
   enabled: { type: 'boolean' },
 } as const;
 
@@ -99,7 +105,14 @@ const webhookBodySchema = {
 // checks still live in validateWebhookBody.)
 const webhookCreateBodySchema = {
   type: 'object',
-  properties: webhookBodyProperties,
+  properties: {
+    ...webhookBodyProperties,
+    customHeaders: {
+      type: 'array',
+      items: customHeaderResponseSchema,
+      maxItems: MAX_CUSTOM_HEADERS,
+    },
+  },
   additionalProperties: false,
   required: ['name', 'url'],
 } as const;
@@ -121,22 +134,29 @@ const isValidWebhookUrl = (value: string): boolean => {
 
 const parseCustomHeaders = (
   value: unknown,
-): { ok: true; value: StoredWebhookHeader[] } | { ok: false; message: string } => {
+  options: { isCreate: boolean },
+): { ok: true; value: WebhookHeaderInput[] } | { ok: false; message: string } => {
   if (!Array.isArray(value)) {
     return { ok: false, message: 'customHeaders must be an array' };
   }
   if (value.length > MAX_CUSTOM_HEADERS) {
     return { ok: false, message: `customHeaders cannot exceed ${MAX_CUSTOM_HEADERS} entries` };
   }
-  const headers: StoredWebhookHeader[] = [];
+  const headers: WebhookHeaderInput[] = [];
   for (let i = 0; i < value.length; i++) {
     const entry = value[i] as { key?: unknown; value?: unknown };
     const key = requireNonEmptyString(entry?.key, `customHeaders[${i}].key`);
     if (!key.ok) return { ok: false, message: key.message };
-    if (typeof entry?.value !== 'string') {
+    if (entry?.value !== undefined && typeof entry.value !== 'string') {
       return { ok: false, message: `customHeaders[${i}].value must be a string` };
     }
-    headers.push({ key: key.value, value: entry.value });
+    if (options.isCreate && entry?.value === undefined) {
+      return { ok: false, message: `customHeaders[${i}].value is required` };
+    }
+    headers.push({
+      key: key.value,
+      ...(entry.value !== undefined ? { value: entry.value } : {}),
+    });
   }
   return { ok: true, value: headers };
 };
@@ -226,7 +246,7 @@ const validateWebhookBody = (
   }
 
   if (body.customHeaders !== undefined) {
-    const headers = parseCustomHeaders(body.customHeaders);
+    const headers = parseCustomHeaders(body.customHeaders, options);
     if (!headers.ok) {
       badRequest(reply, headers.message);
       return null;
@@ -262,6 +282,7 @@ const validateWebhookBody = (
 const serializeForResponse = (webhook: webhooksRepo.Webhook) => ({
   ...webhook,
   authSecret: webhook.authSecret ? MASKED_SECRET : '',
+  customHeaders: maskHeaders(webhook.customHeaders),
 });
 
 export default async function (fastify: FastifyInstance, _opts: unknown) {

--- a/server/services/webhookHeaders.ts
+++ b/server/services/webhookHeaders.ts
@@ -1,0 +1,114 @@
+import type { StoredWebhookHeader } from '../db/schema/webhooks.ts';
+import * as webhooksRepo from '../repositories/webhooksRepo.ts';
+import { decrypt, encrypt, MASKED_SECRET } from '../utils/crypto.ts';
+
+export type WebhookHeaderInput = {
+  key: string;
+  value?: string;
+};
+
+const badRequest = (message: string): Error => {
+  const error = new Error(message) as Error & { statusCode: number };
+  error.statusCode = 400;
+  return error;
+};
+
+const normalizeKey = (key: string): string => key.trim().toLowerCase();
+
+const encryptHeader = (key: string, value: string): StoredWebhookHeader => ({
+  key,
+  value: value === '' ? '' : encrypt(value),
+  encrypted: true,
+});
+
+const ensureEncrypted = (header: StoredWebhookHeader): StoredWebhookHeader =>
+  header.encrypted ? header : encryptHeader(header.key, header.value);
+
+export const encryptNewHeaders = (headers: WebhookHeaderInput[]): StoredWebhookHeader[] =>
+  headers.map((header, index) => {
+    if (header.value === undefined) {
+      throw badRequest(`customHeaders[${index}].value is required`);
+    }
+    return encryptHeader(header.key, header.value);
+  });
+
+export const mergeEncryptedHeaders = (
+  headers: WebhookHeaderInput[],
+  existing: StoredWebhookHeader[],
+): StoredWebhookHeader[] => {
+  const existingByKey = new Map<string, StoredWebhookHeader[]>();
+  for (const header of existing) {
+    const key = normalizeKey(header.key);
+    existingByKey.set(key, [...(existingByKey.get(key) ?? []), header]);
+  }
+
+  return headers.map((header, index) => {
+    if (header.value !== undefined) {
+      return encryptHeader(header.key, header.value);
+    }
+    const matches = existingByKey.get(normalizeKey(header.key));
+    const stored = matches?.shift();
+    if (!stored) {
+      throw badRequest(`customHeaders[${index}].value is required for a new header`);
+    }
+    return { ...ensureEncrypted(stored), key: header.key };
+  });
+};
+
+export const decryptHeaderValue = (header: StoredWebhookHeader): string => {
+  if (header.value === '' || !header.encrypted) return header.value;
+  return decrypt(header.value);
+};
+
+export const maskHeaders = (headers: StoredWebhookHeader[]): StoredWebhookHeader[] =>
+  headers.map((header) => ({
+    key: header.key,
+    value: header.value === '' ? '' : MASKED_SECRET,
+  }));
+
+const encryptLegacyValues = (
+  headers: StoredWebhookHeader[],
+): { headers: StoredWebhookHeader[]; changed: boolean } => {
+  let changed = false;
+  const encrypted = headers.map((header) => {
+    if (header.encrypted) return header;
+    changed = true;
+    return encryptHeader(header.key, header.value);
+  });
+  return { headers: encrypted, changed };
+};
+
+const MIGRATION_BATCH_SIZE = 100;
+const hasLegacyValues = (headers: StoredWebhookHeader[]): boolean =>
+  headers.some((header) => !header.encrypted);
+
+// Existing installations stored custom header values as plaintext JSON. Migrate them before the
+// server accepts traffic, in bounded batches and with a compare-and-swap update so concurrent
+// startup or an administrator edit cannot overwrite a newer value.
+export const migrateLegacyWebhookHeaders = async (): Promise<number> => {
+  let afterId: string | undefined;
+  let migrated = 0;
+
+  while (true) {
+    const batch = await webhooksRepo.listBatchAfterId(afterId, MIGRATION_BATCH_SIZE);
+    for (const webhook of batch) {
+      const result = encryptLegacyValues(webhook.customHeaders);
+      if (!result.changed) continue;
+      const replaced = await webhooksRepo.replaceCustomHeadersIfUnchanged(
+        webhook.id,
+        webhook.customHeaders,
+        result.headers,
+      );
+      if (replaced) {
+        migrated += 1;
+        continue;
+      }
+      const latest = await webhooksRepo.findById(webhook.id);
+      if (latest && hasLegacyValues(latest.customHeaders)) {
+        throw new Error('Failed to encrypt legacy webhook header values during startup');
+      }
+    }
+    if (batch.length < MIGRATION_BATCH_SIZE) return migrated;
+    afterId = batch.at(-1)?.id;
+  }
+};

--- a/server/services/webhooks.ts
+++ b/server/services/webhooks.ts
@@ -1,12 +1,14 @@
-import type {
-  StoredWebhookHeader,
-  WebhookAuthType,
-  WebhookHttpMethod,
-} from '../db/schema/webhooks.ts';
+import type { WebhookAuthType, WebhookHttpMethod } from '../db/schema/webhooks.ts';
 import * as webhooksRepo from '../repositories/webhooksRepo.ts';
 import { decrypt, encrypt } from '../utils/crypto.ts';
 import { generatePrefixedId } from '../utils/order-ids.ts';
 import { fetchPinnedRemoteUrl, resolveSafeRemoteAddresses } from '../utils/safe-remote-fetch.ts';
+import {
+  decryptHeaderValue,
+  encryptNewHeaders,
+  mergeEncryptedHeaders,
+  type WebhookHeaderInput,
+} from './webhookHeaders.ts';
 
 // Plaintext input from the route. `authSecret` carries the raw credential the admin typed, or
 // `undefined` (the field omitted) to mean "keep the stored value". The UI signals "unchanged" by
@@ -22,7 +24,7 @@ export type WebhookInput = {
   authUsername?: string;
   authHeaderName?: string;
   authSecret?: string;
-  customHeaders?: StoredWebhookHeader[];
+  customHeaders?: WebhookHeaderInput[];
   enabled?: boolean;
 };
 
@@ -110,7 +112,7 @@ export const createWebhook = async (input: WebhookInput): Promise<webhooksRepo.W
     authUsername: auth.authUsername,
     authHeaderName: auth.authHeaderName,
     authSecret: auth.authSecret,
-    customHeaders: input.customHeaders ?? [],
+    customHeaders: encryptNewHeaders(input.customHeaders ?? []),
     enabled: input.enabled ?? true,
   });
 };
@@ -136,7 +138,9 @@ export const updateWebhook = async (
   if (input.description !== undefined) patch.description = input.description;
   if (input.url !== undefined) patch.url = input.url;
   if (input.httpMethod !== undefined) patch.httpMethod = input.httpMethod;
-  if (input.customHeaders !== undefined) patch.customHeaders = input.customHeaders;
+  if (input.customHeaders !== undefined) {
+    patch.customHeaders = mergeEncryptedHeaders(input.customHeaders, existing.customHeaders);
+  }
   if (input.enabled !== undefined) patch.enabled = input.enabled;
 
   return webhooksRepo.update(id, patch);
@@ -174,7 +178,7 @@ const buildDispatchHeaders = (
   if (hasJsonBody) headers['Content-Type'] = 'application/json';
 
   for (const header of webhook.customHeaders) {
-    setHeader(headers, header.key, header.value);
+    setHeader(headers, header.key, decryptHeaderValue(header));
   }
 
   switch (webhook.authType) {

--- a/server/test/repositories/webhooksRepo.test.ts
+++ b/server/test/repositories/webhooksRepo.test.ts
@@ -81,6 +81,21 @@ describe('list', () => {
   });
 });
 
+describe('listBatchAfterId', () => {
+  test('uses stable id ordering, cursor, and limit for bounded migrations', async () => {
+    exec.enqueue({ rows: [buildRow({ id: 'webhook-2' })] });
+
+    const result = await webhooksRepo.listBatchAfterId('webhook-1', 100, testDb);
+
+    expect(result[0]?.id).toBe('webhook-2');
+    expect(exec.calls[0].sql).toMatch(/"webhooks"\."id"\s*>\s*\$1/i);
+    expect(exec.calls[0].sql).toMatch(/order by\s+"webhooks"\."id"\s+asc/i);
+    expect(exec.calls[0].sql).toMatch(/limit/i);
+    expect(exec.calls[0].params).toContain('webhook-1');
+    expect(exec.calls[0].params).toContain(100);
+  });
+});
+
 describe('findById', () => {
   test('returns null when no row matches', async () => {
     exec.enqueue({ rows: [] });
@@ -145,6 +160,40 @@ describe('update', () => {
     const result = await webhooksRepo.update('webhook-1', {}, testDb);
     expect(result?.id).toBe('webhook-1');
     expect(exec.calls[0].sql).toMatch(/select/i);
+  });
+});
+
+describe('replaceCustomHeadersIfUnchanged', () => {
+  test('compares the old JSON value before replacing it', async () => {
+    exec.enqueue({ rows: [['webhook-1']] });
+    const expected = [{ key: 'X-API-Key', value: 'plaintext' }];
+    const replacement = [{ key: 'X-API-Key', value: 'encrypted' }];
+
+    expect(
+      await webhooksRepo.replaceCustomHeadersIfUnchanged(
+        'webhook-1',
+        expected,
+        replacement,
+        testDb,
+      ),
+    ).toBe(true);
+
+    expect(exec.calls[0].sql).toMatch(/update "webhooks" set/i);
+    expect(exec.calls[0].sql).toMatch(/"custom_headers"\s*=\s*/i);
+    expect(exec.calls[0].sql).toMatch(/where.*"webhooks"\."id".*"custom_headers"/i);
+    expect(exec.calls[0].params).toContain('webhook-1');
+  });
+
+  test('returns false after a concurrent change', async () => {
+    exec.enqueue({ rows: [] });
+    expect(
+      await webhooksRepo.replaceCustomHeadersIfUnchanged(
+        'webhook-1',
+        [{ key: 'X', value: 'old' }],
+        [{ key: 'X', value: 'new' }],
+        testDb,
+      ),
+    ).toBe(false);
   });
 });
 

--- a/server/test/routes/webhooks.test.ts
+++ b/server/test/routes/webhooks.test.ts
@@ -104,7 +104,10 @@ const SAMPLE_WEBHOOK: realWebhooksRepo.Webhook = {
   authUsername: '',
   authHeaderName: '',
   authSecret: 'enc:ciphertext',
-  customHeaders: [],
+  customHeaders: [
+    { key: 'X-API-Key', value: 'encrypted-api-key', encrypted: true },
+    { key: 'X-Empty', value: '', encrypted: true },
+  ],
   enabled: true,
 };
 
@@ -139,7 +142,7 @@ afterEach(async () => {
 const authHeader = () => ({ authorization: `Bearer ${signToken({ userId: 'u1' })}` });
 
 describe('GET /api/webhooks', () => {
-  test('200 lists webhooks with the secret masked', async () => {
+  test('200 lists webhooks with all secret values masked', async () => {
     listMock.mockResolvedValue([SAMPLE_WEBHOOK]);
 
     const res = await testApp.inject({
@@ -153,6 +156,11 @@ describe('GET /api/webhooks', () => {
     expect(body).toHaveLength(1);
     expect(body[0].url).toBe(SAMPLE_WEBHOOK.url);
     expect(body[0].authSecret).toBe(MASKED_SECRET);
+    expect(body[0].customHeaders).toEqual([
+      { key: 'X-API-Key', value: MASKED_SECRET },
+      { key: 'X-Empty', value: '' },
+    ]);
+    expect(res.body).not.toContain('encrypted-api-key');
   });
 
   test('401 missing token', async () => {
@@ -172,7 +180,7 @@ describe('GET /api/webhooks', () => {
 });
 
 describe('GET /api/webhooks/:id', () => {
-  test('200 returns the masked webhook', async () => {
+  test('200 returns the webhook with all secret values masked', async () => {
     findByIdMock.mockResolvedValue(SAMPLE_WEBHOOK);
     const res = await testApp.inject({
       method: 'GET',
@@ -180,7 +188,10 @@ describe('GET /api/webhooks/:id', () => {
       headers: authHeader(),
     });
     expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body).authSecret).toBe(MASKED_SECRET);
+    const body = JSON.parse(res.body);
+    expect(body.authSecret).toBe(MASKED_SECRET);
+    expect(body.customHeaders[0].value).toBe(MASKED_SECRET);
+    expect(res.body).not.toContain('encrypted-api-key');
   });
 
   test('404 when the webhook does not exist', async () => {
@@ -195,7 +206,7 @@ describe('GET /api/webhooks/:id', () => {
 });
 
 describe('POST /api/webhooks', () => {
-  test('201 creates, emits an audit row and returns masked', async () => {
+  test('201 creates, emits an audit row and returns every secret masked', async () => {
     createWebhookMock.mockResolvedValue(SAMPLE_WEBHOOK);
 
     const res = await testApp.inject({
@@ -208,6 +219,7 @@ describe('POST /api/webhooks', () => {
         httpMethod: 'POST',
         authType: 'bearer',
         authSecret: 'plain-token',
+        customHeaders: [{ key: 'X-API-Key', value: 'plain-api-key' }],
         enabled: true,
       },
     });
@@ -219,7 +231,10 @@ describe('POST /api/webhooks', () => {
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'webhook.created', entityType: 'webhook' }),
     );
-    expect(JSON.parse(res.body).authSecret).toBe(MASKED_SECRET);
+    const body = JSON.parse(res.body);
+    expect(body.authSecret).toBe(MASKED_SECRET);
+    expect(body.customHeaders[0].value).toBe(MASKED_SECRET);
+    expect(res.body).not.toContain('encrypted-api-key');
   });
 
   test('400 when the URL scheme is unsupported', async () => {
@@ -285,6 +300,22 @@ describe('POST /api/webhooks', () => {
       payload: { name: 'K', url: 'https://example.com/hook', authType: 'bogus' },
     });
     expect(res.statusCode).toBe(400);
+  });
+
+  test('400 when a new custom header omits its value', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/webhooks',
+      headers: authHeader(),
+      payload: {
+        name: 'Missing header value',
+        url: 'https://example.com/hook',
+        customHeaders: [{ key: 'X-API-Key' }],
+      },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(createWebhookMock).not.toHaveBeenCalled();
   });
 
   test('400 (not 500) when the url exceeds the column length', async () => {
@@ -361,6 +392,21 @@ describe('PUT /api/webhooks/:id', () => {
       'webhook-1',
       expect.objectContaining({ authType: 'api_key', enabled: false }),
     );
+  });
+
+  test('200 allows a stored custom header value to be omitted and preserved', async () => {
+    updateWebhookMock.mockResolvedValue(SAMPLE_WEBHOOK);
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/webhooks/webhook-1',
+      headers: authHeader(),
+      payload: { customHeaders: [{ key: 'X-API-Key' }] },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(updateWebhookMock).toHaveBeenCalledWith('webhook-1', {
+      customHeaders: [{ key: 'X-API-Key' }],
+    });
   });
 
   test('404 when the service reports the webhook is missing', async () => {

--- a/server/test/services/webhooks.test.ts
+++ b/server/test/services/webhooks.test.ts
@@ -14,10 +14,13 @@ const decryptMock = mock((ciphertext: string) => `dec(${ciphertext})`);
 const insertMock = mock();
 const updateMock = mock();
 const findByIdMock = mock();
+const listBatchAfterIdMock = mock();
+const replaceCustomHeadersIfUnchangedMock = mock();
 const resolveSafeRemoteAddressesMock = mock();
 const fetchPinnedRemoteUrlMock = mock();
 
 let webhooksService: typeof import('../../services/webhooks.ts');
+let webhookHeadersService: typeof import('../../services/webhookHeaders.ts');
 
 beforeAll(async () => {
   mock.module('../../utils/crypto.ts', () => ({
@@ -31,6 +34,8 @@ beforeAll(async () => {
     insert: insertMock,
     update: updateMock,
     findById: findByIdMock,
+    listBatchAfterId: listBatchAfterIdMock,
+    replaceCustomHeadersIfUnchanged: replaceCustomHeadersIfUnchangedMock,
   }));
   mock.module('../../utils/safe-remote-fetch.ts', () => ({
     ...safeRemoteFetchSnapshot,
@@ -38,6 +43,7 @@ beforeAll(async () => {
     fetchPinnedRemoteUrl: fetchPinnedRemoteUrlMock,
   }));
   webhooksService = await import('../../services/webhooks.ts');
+  webhookHeadersService = await import('../../services/webhookHeaders.ts');
 });
 
 afterAll(() => {
@@ -74,10 +80,14 @@ beforeEach(() => {
   insertMock.mockReset();
   updateMock.mockReset();
   findByIdMock.mockReset();
+  listBatchAfterIdMock.mockReset();
+  replaceCustomHeadersIfUnchangedMock.mockReset();
   resolveSafeRemoteAddressesMock.mockReset();
   fetchPinnedRemoteUrlMock.mockReset();
   insertMock.mockImplementation(async (webhook) => webhook);
   updateMock.mockImplementation(async (_id, patch) => ({ ...existingWebhook(), ...patch }));
+  listBatchAfterIdMock.mockResolvedValue([]);
+  replaceCustomHeadersIfUnchangedMock.mockResolvedValue(true);
   resolveSafeRemoteAddressesMock.mockResolvedValue(PUBLIC_ADDRESSES);
   fetchPinnedRemoteUrlMock.mockImplementation(async () => new Response(null, { status: 204 }));
 });
@@ -158,6 +168,23 @@ describe('createWebhook', () => {
     expect(insertedArg().enabled).toBe(true);
     expect(insertedArg().customHeaders).toEqual([]);
     expect(insertedArg().authType).toBe('none');
+  });
+
+  test('encrypts non-empty custom header values before storing them', async () => {
+    await webhooksService.createWebhook({
+      name: 'X',
+      url: 'https://x.com',
+      customHeaders: [
+        { key: 'X-API-Key', value: 'header-secret' },
+        { key: 'X-Empty', value: '' },
+      ],
+    });
+
+    expect(encryptMock).toHaveBeenCalledWith('header-secret');
+    expect(insertedArg().customHeaders).toEqual([
+      { key: 'X-API-Key', value: 'enc(header-secret)', encrypted: true },
+      { key: 'X-Empty', value: '', encrypted: true },
+    ]);
   });
 
   test('rejects api_key without a header name', async () => {
@@ -286,6 +313,100 @@ describe('updateWebhook', () => {
     ).rejects.toThrow('authHeaderName is required');
     expect(updateMock).not.toHaveBeenCalled();
   });
+
+  test('preserves an encrypted custom header when its value is omitted', async () => {
+    findByIdMock.mockResolvedValue(
+      existingWebhook({
+        customHeaders: [{ key: 'X-API-Key', value: 'enc(existing)', encrypted: true }],
+      }),
+    );
+
+    await webhooksService.updateWebhook('webhook-1', {
+      customHeaders: [{ key: 'x-api-key' }],
+    });
+
+    expect(updatedPatch().customHeaders).toEqual([
+      { key: 'x-api-key', value: 'enc(existing)', encrypted: true },
+    ]);
+    expect(encryptMock).not.toHaveBeenCalledWith('enc(existing)');
+  });
+
+  test('encrypts a replaced custom header value', async () => {
+    findByIdMock.mockResolvedValue(
+      existingWebhook({
+        customHeaders: [{ key: 'X-API-Key', value: 'enc(existing)', encrypted: true }],
+      }),
+    );
+
+    await webhooksService.updateWebhook('webhook-1', {
+      customHeaders: [{ key: 'X-API-Key', value: 'replacement' }],
+    });
+
+    expect(updatedPatch().customHeaders).toEqual([
+      { key: 'X-API-Key', value: 'enc(replacement)', encrypted: true },
+    ]);
+  });
+
+  test('rejects an omitted value for a new custom header', async () => {
+    findByIdMock.mockResolvedValue(existingWebhook({ customHeaders: [] }));
+
+    await expect(
+      webhooksService.updateWebhook('webhook-1', {
+        customHeaders: [{ key: 'X-New' }],
+      }),
+    ).rejects.toThrow('value is required for a new header');
+    expect(updateMock).not.toHaveBeenCalled();
+  });
+});
+
+describe('migrateLegacyWebhookHeaders', () => {
+  test('encrypts legacy plaintext values with a compare-and-swap update', async () => {
+    const legacy = existingWebhook({
+      customHeaders: [
+        { key: 'X-Legacy', value: 'plaintext-secret' },
+        { key: 'X-Shaped', value: 'enc(shaped-plaintext)' },
+        { key: 'X-Current', value: 'enc(current)', encrypted: true },
+        { key: 'X-Empty', value: '' },
+      ],
+    });
+    listBatchAfterIdMock.mockResolvedValueOnce([legacy]);
+
+    await expect(webhookHeadersService.migrateLegacyWebhookHeaders()).resolves.toBe(1);
+
+    expect(replaceCustomHeadersIfUnchangedMock).toHaveBeenCalledWith(
+      legacy.id,
+      legacy.customHeaders,
+      [
+        { key: 'X-Legacy', value: 'enc(plaintext-secret)', encrypted: true },
+        { key: 'X-Shaped', value: 'enc(enc(shaped-plaintext))', encrypted: true },
+        { key: 'X-Current', value: 'enc(current)', encrypted: true },
+        { key: 'X-Empty', value: '', encrypted: true },
+      ],
+    );
+    expect(encryptMock).toHaveBeenCalledWith('plaintext-secret');
+    expect(encryptMock).toHaveBeenCalledWith('enc(shaped-plaintext)');
+    expect(encryptMock).not.toHaveBeenCalledWith('enc(current)');
+  });
+
+  test('keeps legacy plaintext dispatch-compatible until startup migration completes', () => {
+    expect(
+      webhookHeadersService.decryptHeaderValue({ key: 'X-Legacy', value: 'legacy-plaintext' }),
+    ).toBe('legacy-plaintext');
+    expect(decryptMock).not.toHaveBeenCalled();
+  });
+
+  test('fails closed when a concurrent write leaves a plaintext value behind', async () => {
+    const legacy = existingWebhook({
+      customHeaders: [{ key: 'X-Legacy', value: 'do-not-log-this' }],
+    });
+    listBatchAfterIdMock.mockResolvedValueOnce([legacy]);
+    replaceCustomHeadersIfUnchangedMock.mockResolvedValueOnce(false);
+    findByIdMock.mockResolvedValueOnce(legacy);
+
+    const migration = webhookHeadersService.migrateLegacyWebhookHeaders();
+    await expect(migration).rejects.toThrow('Failed to encrypt legacy webhook header values');
+    await expect(migration).rejects.not.toThrow('do-not-log-this');
+  });
 });
 
 describe('dispatchWebhook', () => {
@@ -304,11 +425,11 @@ describe('dispatchWebhook', () => {
     expect(decryptMock).not.toHaveBeenCalled();
   });
 
-  test('sends a JSON body with custom headers and bearer auth', async () => {
+  test('decrypts custom headers before sending a JSON body with bearer auth', async () => {
     const webhook = existingWebhook({
       authType: 'bearer',
       authSecret: 'enc(tok)',
-      customHeaders: [{ key: 'X-Custom', value: '1' }],
+      customHeaders: [{ key: 'X-Custom', value: 'enc(header-value)', encrypted: true }],
     });
 
     const result = await webhooksService.dispatchWebhook(webhook, {
@@ -317,6 +438,7 @@ describe('dispatchWebhook', () => {
 
     expect(result).toEqual({ delivered: true, skipped: false, status: 204 });
     expect(decryptMock).toHaveBeenCalledWith('enc(tok)');
+    expect(decryptMock).toHaveBeenCalledWith('enc(header-value)');
     expect(fetchPinnedRemoteUrlMock).toHaveBeenCalledWith(
       expect.objectContaining({ href: 'https://example.com/hook' }),
       PUBLIC_ADDRESSES,
@@ -326,7 +448,7 @@ describe('dispatchWebhook', () => {
         body: JSON.stringify({ eventType: 'project_rule_triggered' }),
         headers: expect.objectContaining({
           'Content-Type': 'application/json',
-          'X-Custom': '1',
+          'X-Custom': 'dec(enc(header-value))',
           Authorization: 'Bearer dec(enc(tok))',
         }),
       }),

--- a/test/components/administration/WebhooksView.test.tsx
+++ b/test/components/administration/WebhooksView.test.tsx
@@ -155,6 +155,28 @@ describe('<WebhooksView />', () => {
     expect(screen.getByRole('button', { name: 'common:buttons.edit' })).toBeDefined();
     expect(screen.getByRole('button', { name: 'common:buttons.delete' })).toBeDefined();
   });
+
+  test('keeps a masked custom header without exposing or echoing its value', async () => {
+    listMock.mockResolvedValue([
+      {
+        ...SAMPLE,
+        customHeaders: [{ key: 'Authorization', value: '********' }],
+      },
+    ]);
+    render(<WebhooksView permissions={FULL_PERMS} />);
+    await screen.findByText('Slack hook');
+
+    fireEvent.click(screen.getByRole('button', { name: 'common:buttons.edit' }));
+    await screen.findByDisplayValue('Authorization');
+
+    expect(screen.queryByLabelText('administration:webhooks.fields.headerValue')).toBeNull();
+
+    fireEvent.click(screen.getByRole('button', { name: 'common:buttons.update' }));
+    await waitFor(() => expect(updateMock).toHaveBeenCalled());
+
+    expect(updateMock.mock.calls[0][1].customHeaders).toEqual([{ key: 'Authorization' }]);
+    expect(JSON.stringify(updateMock.mock.calls[0][1])).not.toContain('********');
+  });
 });
 
 describe('resolveSecretForPayload', () => {

--- a/types.ts
+++ b/types.ts
@@ -1084,8 +1084,14 @@ export interface WebhookHeader {
   value: string;
 }
 
-// A configured webhook target. `authSecret` arrives masked from the server (the mask sentinel when
-// a secret is stored, '' otherwise) — never the real credential.
+export interface WebhookHeaderInput {
+  key: string;
+  // Omit a stored header's value on update to preserve it; provide a value for new/replaced headers.
+  value?: string;
+}
+
+// A configured webhook target. Secret values arrive masked from the server (the mask sentinel when
+// stored, '' otherwise) — never the real credentials.
 export interface Webhook {
   id: string;
   name: string;
@@ -1100,10 +1106,9 @@ export interface Webhook {
   enabled: boolean;
 }
 
-// Create/update body. Omit `authSecret` to keep the stored secret; send a new value to replace it,
-// or '' to clear it. There is no input mask sentinel: any string sent is stored as-is (a literal
-// '********' is saved verbatim), so callers must OMIT the field to preserve the credential — echoing
-// the masked value back from a fetched webhook would overwrite the stored secret with asterisks.
+// Create/update body. Omit `authSecret`, or a stored custom header's `value`, to preserve it. Send a
+// new value to replace it or '' to clear it. There is no input mask sentinel: any string sent is
+// stored as-is, so callers preserve a credential by omitting its field rather than echoing the mask.
 export interface WebhookPayload {
   name: string;
   description: string;
@@ -1113,7 +1118,7 @@ export interface WebhookPayload {
   authUsername: string;
   authHeaderName: string;
   authSecret?: string;
-  customHeaders: WebhookHeader[];
+  customHeaders: WebhookHeaderInput[];
   enabled: boolean;
 }
 


### PR DESCRIPTION
## Summary
- Encrypt webhook custom-header values at rest and mask every non-empty value in API responses.
- Add explicit keep/replace controls so administrators can edit webhook metadata without re-exposing or overwriting stored header secrets.
- Migrate legacy plaintext values in bounded, compare-and-swap batches before the API starts serving traffic.

## Changes
- Centralize custom-header encryption, decryption, masking, preserve/replace semantics, and startup migration.
- Add an explicit encrypted marker to distinguish legacy plaintext safely, including plaintext that resembles ciphertext.
- Update request/response schemas, generated OpenAPI output, frontend types, and Italian/English administration documentation.
- Add route, service, repository, and UI regression coverage.

## Testing
- `bun test ./test/routes/webhooks.test.ts ./test/services/webhooks.test.ts ./test/repositories/webhooksRepo.test.ts` (74 passed)
- `bun test ./test/components/administration/WebhooksView.test.tsx` (18 passed)
- `bun run typecheck`
- `bun run build`
- Changed-file `biome check` (12 files)
- Full backend suite: 4,747 passed, 29 skipped, 0 failed
- React Doctor: 75/100 before and after
- Full frontend suite was attempted but stopped after it made no progress in the pre-existing `ClientsOrdersView` tests; focused frontend tests pass.

## Risks / Rollout
- Deployment requires stopping older API instances and taking a database backup before starting this version. Startup encrypts legacy values in place; older images cannot dispatch the encrypted representation.
- Rollback requires restoring the pre-upgrade backup before restarting an older image. These steps are documented in both administration guides.

## Issues
- DeepSec finding `a6d75bd6ba`; no GitHub issue linked.