### PR TITLE
sales(fix): prevent attachment download cancellation

### DIFF
--- a/components/sales/SupplierQuoteAttachmentsSection.tsx
+++ b/components/sales/SupplierQuoteAttachmentsSection.tsx
@@ -5,6 +5,7 @@ import { useLatestRef } from '../../hooks/useLatestRef';
 import { supplierQuotesApi } from '../../services/api/supplierQuotes';
 import type { SupplierQuoteAttachment } from '../../types';
 import { formatInsertDateTime } from '../../utils/date';
+import { downloadBlob } from '../../utils/download';
 import {
   attachmentValidationMessage,
   formatAttachmentFileSize,
@@ -127,14 +128,7 @@ const SupplierQuoteAttachmentsSection: React.FC<SupplierQuoteAttachmentsSectionP
     async (attachment: SupplierQuoteAttachment) => {
       try {
         const blob = await supplierQuotesApi.downloadAttachment(quoteId, attachment.id);
-        const url = URL.createObjectURL(blob);
-        const link = document.createElement('a');
-        link.href = url;
-        link.download = attachment.fileName;
-        document.body.appendChild(link);
-        link.click();
-        link.remove();
-        URL.revokeObjectURL(url);
+        downloadBlob(attachment.fileName, blob);
       } catch (e) {
         dispatchAttachments({
           type: 'error',

--- a/test/components/SupplierQuoteAttachmentsSection.test.tsx
+++ b/test/components/SupplierQuoteAttachmentsSection.test.tsx
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { afterEach, beforeEach, describe, expect, mock, spyOn, test } from 'bun:test';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
 import type { SupplierQuoteAttachment } from '../../types';
@@ -26,7 +26,6 @@ const listAttachmentsMock = mock<(id: string) => Promise<SupplierQuoteAttachment
 const uploadAttachmentMock = mock<(id: string, file: File) => Promise<SupplierQuoteAttachment>>();
 const downloadAttachmentMock = mock<(id: string, attachmentId: string) => Promise<Blob>>();
 const deleteAttachmentMock = mock<(id: string, attachmentId: string) => Promise<void>>();
-const downloadBlobMock = mock<(filename: string, blob: Blob) => void>();
 
 mock.module('../../services/api/supplierQuotes', () => ({
   supplierQuotesApi: {
@@ -35,10 +34,6 @@ mock.module('../../services/api/supplierQuotes', () => ({
     downloadAttachment: (id: string, aid: string) => downloadAttachmentMock(id, aid),
     deleteAttachment: (id: string, aid: string) => deleteAttachmentMock(id, aid),
   },
-}));
-
-mock.module('../../utils/download', () => ({
-  downloadBlob: (filename: string, blob: Blob) => downloadBlobMock(filename, blob),
 }));
 
 const realDate = await import('../../utils/date');
@@ -68,6 +63,11 @@ mock.module('../../components/shared/DeleteConfirmModal', () => ({
       </div>
     ) : null,
 }));
+
+// Prefer spyOn over mock.module for utils/download: mock.module leaks across files and
+// breaks suites that assert real createObjectURL / deferred revokeObjectURL behavior.
+const downloadModule = await import('../../utils/download');
+const downloadBlobSpy = spyOn(downloadModule, 'downloadBlob').mockImplementation(() => {});
 
 clearSpyStateAfterAll();
 
@@ -100,7 +100,8 @@ beforeEach(() => {
   uploadAttachmentMock.mockReset();
   downloadAttachmentMock.mockReset();
   deleteAttachmentMock.mockReset();
-  downloadBlobMock.mockReset();
+  downloadBlobSpy.mockReset();
+  downloadBlobSpy.mockImplementation(() => {});
   listAttachmentsMock.mockImplementation(() => Promise.resolve([]));
 });
 
@@ -176,7 +177,7 @@ describe('<SupplierQuoteAttachmentsSection />', () => {
     await waitFor(() =>
       expect(downloadAttachmentMock).toHaveBeenCalledWith('sq-1', ATTACHMENT_A.id),
     );
-    expect(downloadBlobMock).toHaveBeenCalledWith(ATTACHMENT_A.fileName, blob);
+    expect(downloadBlobSpy).toHaveBeenCalledWith(ATTACHMENT_A.fileName, blob);
   });
 
   test('uploads a valid file and prepends it to the list', async () => {

--- a/test/components/SupplierQuoteAttachmentsSection.test.tsx
+++ b/test/components/SupplierQuoteAttachmentsSection.test.tsx
@@ -26,6 +26,7 @@ const listAttachmentsMock = mock<(id: string) => Promise<SupplierQuoteAttachment
 const uploadAttachmentMock = mock<(id: string, file: File) => Promise<SupplierQuoteAttachment>>();
 const downloadAttachmentMock = mock<(id: string, attachmentId: string) => Promise<Blob>>();
 const deleteAttachmentMock = mock<(id: string, attachmentId: string) => Promise<void>>();
+const downloadBlobMock = mock<(filename: string, blob: Blob) => void>();
 
 mock.module('../../services/api/supplierQuotes', () => ({
   supplierQuotesApi: {
@@ -34,6 +35,10 @@ mock.module('../../services/api/supplierQuotes', () => ({
     downloadAttachment: (id: string, aid: string) => downloadAttachmentMock(id, aid),
     deleteAttachment: (id: string, aid: string) => deleteAttachmentMock(id, aid),
   },
+}));
+
+mock.module('../../utils/download', () => ({
+  downloadBlob: (filename: string, blob: Blob) => downloadBlobMock(filename, blob),
 }));
 
 const realDate = await import('../../utils/date');
@@ -95,6 +100,7 @@ beforeEach(() => {
   uploadAttachmentMock.mockReset();
   downloadAttachmentMock.mockReset();
   deleteAttachmentMock.mockReset();
+  downloadBlobMock.mockReset();
   listAttachmentsMock.mockImplementation(() => Promise.resolve([]));
 });
 
@@ -149,6 +155,28 @@ describe('<SupplierQuoteAttachmentsSection />', () => {
     expect(screen.queryByLabelText('Delete')).not.toBeInTheDocument();
     // Download stays visible - view-only users can still grab the file.
     expect(screen.getByLabelText('Download')).toBeInTheDocument();
+  });
+
+  test('downloads attachments through the shared blob helper', async () => {
+    const blob = new Blob(['quote contents'], { type: ATTACHMENT_A.mimeType });
+    listAttachmentsMock.mockImplementation(() => Promise.resolve([ATTACHMENT_A]));
+    downloadAttachmentMock.mockImplementation(() => Promise.resolve(blob));
+    render(
+      <SupplierQuoteAttachmentsSection
+        quoteId="sq-1"
+        isReadOnly={true}
+        readOnlyStatus="Read-only"
+        statusLabel="Status:"
+      />,
+    );
+    await waitFor(() => expect(screen.getByText('first.xlsx')).toBeInTheDocument());
+
+    fireEvent.click(screen.getByLabelText('Download'));
+
+    await waitFor(() =>
+      expect(downloadAttachmentMock).toHaveBeenCalledWith('sq-1', ATTACHMENT_A.id),
+    );
+    expect(downloadBlobMock).toHaveBeenCalledWith(ATTACHMENT_A.fileName, blob);
   });
 
   test('uploads a valid file and prepends it to the list', async () => {


### PR DESCRIPTION
## Summary
- Prevent supplier quote attachment downloads from revoking their blob URL before the browser starts reading it.
- Add regression coverage that verifies the fetched blob and filename are handed to the shared deferred-cleanup download helper.

## Changes
- Replace the component-local anchor and synchronous URL cleanup with `downloadBlob`.
- Mock the shared helper in the attachment component tests and assert the download contract.

## Testing
- `bun test test/components/SupplierQuoteAttachmentsSection.test.tsx` (10 passed)
- `bun run typecheck` (passed)
- `bun run build` (passed)
- `bun run test:server` via the full suite (4,736 passed, 29 skipped, 0 failed)
- React Doctor: 75/100 before and after (unchanged)
- Full frontend suite could not complete locally because Bun 1.3.14 reproducibly panicked with an internal assertion; the focused changed suite passes.
- Changed files pass Biome. The repository-wide lint command reports pre-existing Windows CRLF formatting diagnostics across the checkout.

## Risks / Rollout
- Low risk. The change reuses the established download helper and does not alter API, permissions, database, or configuration behavior.

## Issues
Issue: Not linked