### PR TITLE
tasks(fix): key progress hours by task id

### DIFF
--- a/components/projects/ProjectTasksTable.tsx
+++ b/components/projects/ProjectTasksTable.tsx
@@ -260,7 +260,7 @@ const useProjectTaskColumns = ({
             return <span className="text-xs text-muted-foreground">...</span>;
           if (hoursState.loadState === 'error')
             return <span className="text-xs text-destructive">-</span>;
-          const logged = hoursState.hours[row.name] ?? 0;
+          const logged = hoursState.hours[row.id] ?? 0;
           const expected = row.expectedEffort ?? 0;
           const pct = expected > 0 ? Math.round((logged / expected) * 100) : 0;
           const overBudget = expected > 0 && logged > expected;

--- a/components/projects/ProjectsView.tsx
+++ b/components/projects/ProjectsView.tsx
@@ -448,7 +448,7 @@ const useProjectsController = ({
       const progressValues = projectTasks.reduce<number[]>((values, task) => {
         const effort = task.expectedEffort ?? 0;
         if (effort <= 0) return values;
-        const logged = hours[task.name] ?? 0;
+        const logged = hours[task.id] ?? 0;
         values.push((logged / effort) * 100);
         return values;
       }, []);

--- a/components/projects/TasksView.tsx
+++ b/components/projects/TasksView.tsx
@@ -358,7 +358,7 @@ const useTaskColumns = ({
           }
           if (hoursLoadState === 'error') return <span className="text-red-500 text-xs">-</span>;
           const projectHours = taskHours[row.projectId] ?? {};
-          const logged = projectHours[row.name] ?? 0;
+          const logged = projectHours[row.id] ?? 0;
           const expected = row.expectedEffort ?? 0;
           if (!expected) return <span className="text-zinc-400 text-xs">-</span>;
           const pct = Math.round((logged / expected) * 100);

--- a/server/repositories/tasksRepo.ts
+++ b/server/repositories/tasksRepo.ts
@@ -365,12 +365,12 @@ export const sumHoursByProjects = async (
   projectIds: string[],
   scope: TaskHoursScope,
   exec: DbExecutor = db,
-): Promise<Array<{ projectId: string; task: string; total: number }>> => {
+): Promise<Array<{ projectId: string; taskId: string; total: number }>> => {
   if (projectIds.length === 0) return [];
-  const taskVisibilityJoin = scope.taskAssigneeId
+  const taskJoin = scope.taskAssigneeId
     ? sql`${timeEntriesTasksJoin}
           JOIN user_tasks ut ON ut.task_id = ${tasksT.id}`
-    : sql``;
+    : timeEntriesTasksJoin;
   const conditions = [inArray(timeEntriesTe.projectId, projectIds)];
 
   if (scope.taskAssigneeId) {
@@ -385,11 +385,11 @@ export const sumHoursByProjects = async (
     );
   }
 
-  const query = sql`SELECT ${timeEntriesTe.projectId} AS "projectId", ${timeEntriesTe.task}, COALESCE(SUM(${timeEntriesTe.duration}), 0)::float AS total
+  const query = sql`SELECT ${timeEntriesTe.projectId} AS "projectId", ${tasksT.id} AS "taskId", COALESCE(SUM(${timeEntriesTe.duration}), 0)::float AS total
                       FROM time_entries te
-                      ${taskVisibilityJoin}
+                      ${taskJoin}
                      WHERE ${and(...conditions)}
-                     GROUP BY ${timeEntriesTe.projectId}, ${timeEntriesTe.task}`;
-  const rows = await executeRows<{ projectId: string; task: string; total: number }>(exec, query);
-  return rows.map((r) => ({ projectId: r.projectId, task: r.task, total: Number(r.total) }));
+                     GROUP BY ${timeEntriesTe.projectId}, ${tasksT.id}`;
+  const rows = await executeRows<{ projectId: string; taskId: string; total: number }>(exec, query);
+  return rows.map((r) => ({ projectId: r.projectId, taskId: r.taskId, total: Number(r.total) }));
 };

--- a/server/routes/tasks.ts
+++ b/server/routes/tasks.ts
@@ -405,7 +405,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         tags: ['tasks'],
         summary: 'Get total logged hours per task for multiple projects',
         description:
-          'Task visibility and time-entry ownership are scoped independently. Viewing totals across all entry owners requires timesheets.tracker_all.view.',
+          'Returns project maps keyed by stable task ID. Task visibility and time-entry ownership are scoped independently. Viewing totals across all entry owners requires timesheets.tracker_all.view.',
         querystring: {
           type: 'object',
           required: ['projectIds'],
@@ -445,7 +445,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const hours: Record<string, Record<string, number>> = {};
       for (const row of rows) {
         if (!hours[row.projectId]) hours[row.projectId] = {};
-        hours[row.projectId][row.task] = row.total;
+        hours[row.projectId][row.taskId] = row.total;
       }
       return reply.send(hours);
     },
@@ -471,7 +471,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         tags: ['tasks'],
         summary: 'Get total logged hours per task for a project',
         description:
-          'Task visibility and time-entry ownership are scoped independently. Viewing totals across all entry owners requires timesheets.tracker_all.view.',
+          'Returns totals keyed by stable task ID. Task visibility and time-entry ownership are scoped independently. Viewing totals across all entry owners requires timesheets.tracker_all.view.',
         querystring: {
           type: 'object',
           required: ['projectId'],
@@ -496,7 +496,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       );
 
       const hours: Record<string, number> = {};
-      for (const row of rows) hours[row.task] = row.total;
+      for (const row of rows) hours[row.taskId] = row.total;
       return reply.send(hours);
     },
   );

--- a/server/test/repositories/tasksRepo.test.ts
+++ b/server/test/repositories/tasksRepo.test.ts
@@ -274,11 +274,35 @@ describe('clearNonTopManagerAssignments / addManualAssignments', () => {
 });
 
 describe('hours aggregation', () => {
+  test('groups renamed and duplicate-name entries by stable task id', async () => {
+    exec.enqueue({
+      rows: [
+        { projectId: 'p-1', taskId: 't-renamed', total: '4' },
+        { projectId: 'p-1', taskId: 't-duplicate', total: '2' },
+      ],
+    });
+
+    const result = await tasksRepo.sumHoursByProjects(
+      ['p-1'],
+      { timeEntries: { kind: 'all' } },
+      testDb,
+    );
+    const sql = exec.calls[0].sql;
+
+    expect(sql).toContain('JOIN LATERAL');
+    expect(sql).toContain('"t"."id" AS "taskId"');
+    expect(sql).toContain('GROUP BY "te"."project_id", "t"."id"');
+    expect(result).toEqual([
+      { projectId: 'p-1', taskId: 't-renamed', total: 4 },
+      { projectId: 'p-1', taskId: 't-duplicate', total: 2 },
+    ]);
+  });
+
   test('sumHoursByProjects with all-entry scope returns mapped numeric totals', async () => {
     exec.enqueue({
       rows: [
-        { projectId: 'p-1', task: 'Dev', total: 4.5 },
-        { projectId: 'p-1', task: 'QA', total: '2' },
+        { projectId: 'p-1', taskId: 't-dev', total: 4.5 },
+        { projectId: 'p-1', taskId: 't-qa', total: '2' },
       ],
     });
     const result = await tasksRepo.sumHoursByProjects(
@@ -290,8 +314,8 @@ describe('hours aggregation', () => {
     expect(exec.calls[0].params).toContain('p-2');
     expect(exec.calls[0].sql).not.toContain('"te"."user_id"');
     expect(result).toEqual([
-      { projectId: 'p-1', task: 'Dev', total: 4.5 },
-      { projectId: 'p-1', task: 'QA', total: 2 },
+      { projectId: 'p-1', taskId: 't-dev', total: 4.5 },
+      { projectId: 'p-1', taskId: 't-qa', total: 2 },
     ]);
   });
 
@@ -355,7 +379,7 @@ describe('hours aggregation', () => {
   // that prevents it: a LATERAL subquery with LIMIT 1, ordering FK matches first then by
   // lowest task id (matching findIdByProjectAndName's contract).
   test('legacy fallback resolves duplicate task names to a single row (no multiplication)', async () => {
-    exec.enqueue({ rows: [{ projectId: 'p-1', task: 'Dev', total: 4 }] });
+    exec.enqueue({ rows: [{ projectId: 'p-1', taskId: 't-dev', total: 4 }] });
     const result = await tasksRepo.sumHoursByProjects(
       ['p-1'],
       {
@@ -369,7 +393,7 @@ describe('hours aggregation', () => {
     expect(sql).toContain('JOIN LATERAL');
     expect(sql).toMatch(/LIMIT\s+1/);
     expect(sql).toMatch(/ORDER BY[\s\S]*t_inner\.id/);
-    expect(result).toEqual([{ projectId: 'p-1', task: 'Dev', total: 4 }]);
+    expect(result).toEqual([{ projectId: 'p-1', taskId: 't-dev', total: 4 }]);
   });
 });
 

--- a/server/test/routes/tasks.test.ts
+++ b/server/test/routes/tasks.test.ts
@@ -701,9 +701,9 @@ describe('POST /api/tasks', () => {
 describe('GET /api/tasks/hours/batch', () => {
   test('200: tasks_all without tracker_all remains scoped to the entry owner', async () => {
     sumHoursByProjectsMock.mockResolvedValue([
-      { projectId: 'p-1', task: 'Dev', total: 4 },
-      { projectId: 'p-1', task: 'QA', total: 2 },
-      { projectId: 'p-2', task: 'Dev', total: 1 },
+      { projectId: 'p-1', taskId: 't-dev', total: 4 },
+      { projectId: 'p-1', taskId: 't-qa', total: 2 },
+      { projectId: 'p-2', taskId: 't-p2-dev', total: 1 },
     ]);
 
     const res = await testApp.inject({
@@ -714,8 +714,8 @@ describe('GET /api/tasks/hours/batch', () => {
 
     expect(res.statusCode).toBe(200);
     expect(JSON.parse(res.body)).toEqual({
-      'p-1': { Dev: 4, QA: 2 },
-      'p-2': { Dev: 1 },
+      'p-1': { 't-dev': 4, 't-qa': 2 },
+      'p-2': { 't-p2-dev': 1 },
     });
     expect(sumHoursByProjectsMock).toHaveBeenCalledWith(['p-1', 'p-2'], {
       taskAssigneeId: undefined,
@@ -789,10 +789,10 @@ describe('GET /api/tasks/hours/batch', () => {
 });
 
 describe('GET /api/tasks/hours', () => {
-  test('200: returns owner-scoped hours for a single project without tracker_all', async () => {
+  test('200: keys renamed and duplicate-name task totals by task id', async () => {
     sumHoursByProjectsMock.mockResolvedValue([
-      { projectId: 'p-1', task: 'Dev', total: 4 },
-      { projectId: 'p-1', task: 'QA', total: 2 },
+      { projectId: 'p-1', taskId: 't-renamed', total: 4 },
+      { projectId: 'p-1', taskId: 't-duplicate', total: 2 },
     ]);
 
     const res = await testApp.inject({
@@ -802,7 +802,23 @@ describe('GET /api/tasks/hours', () => {
     });
 
     expect(res.statusCode).toBe(200);
-    expect(JSON.parse(res.body)).toEqual({ Dev: 4, QA: 2 });
+    expect(JSON.parse(res.body)).toEqual({ 't-renamed': 4, 't-duplicate': 2 });
+  });
+
+  test('200: returns owner-scoped hours for a single project without tracker_all', async () => {
+    sumHoursByProjectsMock.mockResolvedValue([
+      { projectId: 'p-1', taskId: 't-dev', total: 4 },
+      { projectId: 'p-1', taskId: 't-qa', total: 2 },
+    ]);
+
+    const res = await testApp.inject({
+      method: 'GET',
+      url: '/api/tasks/hours?projectId=p-1',
+      headers: authHeader(),
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(JSON.parse(res.body)).toEqual({ 't-dev': 4, 't-qa': 2 });
     expect(sumHoursByProjectsMock).toHaveBeenCalledWith(['p-1'], {
       taskAssigneeId: undefined,
       timeEntries: { kind: 'owner', userId: 'u1' },

--- a/test/components/projects/TaskHoursKeying.test.ts
+++ b/test/components/projects/TaskHoursKeying.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, test } from 'bun:test';
+
+const readProjectSource = (fileName: string) =>
+  Bun.file(new URL(`../../../components/projects/${fileName}`, import.meta.url)).text();
+
+describe('task progress hour keying', () => {
+  test('all project task progress views use stable task ids', async () => {
+    const [projectTasksTable, tasksView, projectsView] = await Promise.all([
+      readProjectSource('ProjectTasksTable.tsx'),
+      readProjectSource('TasksView.tsx'),
+      readProjectSource('ProjectsView.tsx'),
+    ]);
+
+    expect(projectTasksTable).toContain('hoursState.hours[row.id]');
+    expect(projectTasksTable).not.toContain('hoursState.hours[row.name]');
+    expect(tasksView).toContain('projectHours[row.id]');
+    expect(tasksView).not.toContain('projectHours[row.name]');
+    expect(projectsView).toContain('hours[task.id]');
+    expect(projectsView).not.toContain('hours[task.name]');
+  });
+});


### PR DESCRIPTION
## Summary
- key task-hour aggregates by stable task IDs instead of mutable task names
- preserve deterministic legacy entry attribution through the existing task-name fallback
- update every task progress consumer and document the API response key contract

## Testing
- `bun test ./test/repositories/tasksRepo.test.ts ./test/routes/tasks.test.ts` (from `server/`)
- `bun test test/components/projects/TaskHoursKeying.test.ts`
- `bun run typecheck`
- `bunx biome check components/projects/ProjectTasksTable.tsx components/projects/ProjectsView.tsx components/projects/TasksView.tsx server/repositories/tasksRepo.ts server/routes/tasks.ts server/test/repositories/tasksRepo.test.ts server/test/routes/tasks.test.ts test/components/projects/TaskHoursKeying.test.ts`
- `bun run build`
- `bun run test:react-doctor` (75/100 before and after; exits 1 on pre-existing diagnostics)

## Risks / Rollout
- Low application risk; frontend and backend change together.
- The `/api/tasks/hours` and `/api/tasks/hours/batch` map keys intentionally change from task names to task IDs.
- No database migration or configuration change.

## Issues
- DeepSec finding `7afea63922`; no GitHub issue linked.