### PR TITLE
timesheets(fix): parse weekly entry date-only strings as local dates

### DIFF
--- a/components/timesheet/WeeklyEntryForm.tsx
+++ b/components/timesheet/WeeklyEntryForm.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { cn } from '@/lib/utils';
 import type { Client, Project, ProjectTask, TimeEntryLocation } from '../../types';
+import { formatDateOnlyForLocale } from '../../utils/date';
 import { hasScopedActionPermission } from '../../utils/permissions';
 import TaskFormModal, {
   type RecurringConfig,
@@ -81,8 +82,6 @@ const WeeklyEntryForm: React.FC<WeeklyEntryFormProps> = ({
     return created;
   };
 
-  const dateForDisplay = new Date(selectedDate);
-
   return (
     <div className="rounded-lg border border-border bg-background shadow-sm p-5">
       <div className="flex justify-between items-center gap-4 mb-4">
@@ -93,10 +92,10 @@ const WeeklyEntryForm: React.FC<WeeklyEntryFormProps> = ({
             </span>
             <div className="flex flex-wrap items-baseline gap-x-2 gap-y-1 leading-none">
               <span className="text-base sm:text-lg font-black text-praetor uppercase">
-                {dateForDisplay.toLocaleDateString(undefined, { weekday: 'long' })}
+                {formatDateOnlyForLocale(selectedDate, undefined, { weekday: 'long' })}
               </span>
               <span className="text-sm sm:text-base font-medium text-muted-foreground">
-                {dateForDisplay.toLocaleDateString(undefined, {
+                {formatDateOnlyForLocale(selectedDate, undefined, {
                   month: 'short',
                   day: 'numeric',
                   year: 'numeric',

--- a/test/components/timesheet/WeeklyEntryForm.test.ts
+++ b/test/components/timesheet/WeeklyEntryForm.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, test } from 'bun:test';
+import { dateOnlyStringToLocalDate, formatDateOnlyForLocale } from '../../../utils/date';
+
+describe('WeeklyEntryForm date-only display', () => {
+  test('formats selectedDate via local date-only helper, not UTC Date parsing', async () => {
+    const source = await Bun.file(
+      new URL('../../../components/timesheet/WeeklyEntryForm.tsx', import.meta.url),
+    ).text();
+
+    expect(source).toContain("import { formatDateOnlyForLocale } from '../../utils/date'");
+    expect(source).toContain(
+      "formatDateOnlyForLocale(selectedDate, undefined, { weekday: 'long' })",
+    );
+    expect(source).toContain('formatDateOnlyForLocale(selectedDate, undefined, {');
+    expect(source).not.toContain('new Date(selectedDate)');
+  });
+
+  test('local helper keeps the calendar day for date-only strings', () => {
+    // Regression for UTC-negative zones: `new Date('YYYY-MM-DD')` is UTC midnight
+    // and can render as the previous local day via toLocaleDateString.
+    const dateOnly = '2026-05-15';
+    const localDate = dateOnlyStringToLocalDate(dateOnly);
+
+    expect(localDate.getFullYear()).toBe(2026);
+    expect(localDate.getMonth()).toBe(4);
+    expect(localDate.getDate()).toBe(15);
+    expect(formatDateOnlyForLocale(dateOnly, 'en-US', { weekday: 'long' })).toBe(
+      localDate.toLocaleDateString('en-US', { weekday: 'long' }),
+    );
+    expect(
+      formatDateOnlyForLocale(dateOnly, 'en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      }),
+    ).toBe(
+      localDate.toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- Fixes WeeklyEntryForm header displaying the previous calendar day in UTC-negative timezones when `selectedDate` is a YYYY-MM-DD string.
- Uses the existing `formatDateOnlyForLocale` helper so date-only values are parsed as local midnight instead of UTC.

## Changes
- Replace `new Date(selectedDate).toLocaleDateString(...)` with `formatDateOnlyForLocale(selectedDate, ...)`.
- Add regression tests that pin local date-only formatting and forbid UTC `Date` parsing in WeeklyEntryForm.

## Testing
- `bun test test/components/timesheet/WeeklyEntryForm.test.ts`
- `bunx biome check components/timesheet/WeeklyEntryForm.tsx test/components/timesheet/WeeklyEntryForm.test.ts`
- `bun run test:react-doctor` (score unchanged at 75/100)

## Risks / Rollout
- Low risk. Display-only change in the weekly timesheet entry header; submission still uses the original date-only string.

## Issues
Issue: Not linked