### PR TITLE
resales(security): prevent category deletion races

### DIFF
--- a/server/repositories/resalesRepo.ts
+++ b/server/repositories/resalesRepo.ts
@@ -495,7 +495,7 @@ export const updateCategory = async (
   return row ? mapCategory(row) : null;
 };
 
-export const countActivitiesByCategory = async (
+const countActivitiesByCategory = async (
   categoryId: string,
   exec: DbExecutor = db,
 ): Promise<number> => {
@@ -506,9 +506,30 @@ export const countActivitiesByCategory = async (
   return row?.value ?? 0;
 };
 
-export const deleteCategoryById = async (id: string, exec: DbExecutor = db): Promise<boolean> => {
-  const result = await exec.delete(resaleCategories).where(eq(resaleCategories.id, id));
-  return (result.rowCount ?? 0) > 0;
+export type DeleteCategoryResult =
+  | { status: 'deleted' }
+  | { status: 'not_found' }
+  | { status: 'in_use'; activityCount: number };
+
+export const deleteCategoryIfUnused = async (
+  id: string,
+  exec: DbExecutor = db,
+): Promise<DeleteCategoryResult> => {
+  const deleted = await executeRows<{ id: string }>(
+    exec,
+    sql`DELETE FROM resale_categories AS c
+        WHERE c.id = ${id}
+          AND NOT EXISTS (
+            SELECT 1 FROM resale_activities a WHERE a.category_id = c.id
+          )
+        RETURNING c.id`,
+  );
+  if (deleted.length > 0) return { status: 'deleted' };
+
+  const activityCount = await countActivitiesByCategory(id, exec);
+  if (activityCount > 0) return { status: 'in_use', activityCount };
+
+  return { status: 'not_found' };
 };
 
 export const listOrderOptions = async (exec: DbExecutor = db): Promise<ResaleOrderOption[]> => {

--- a/server/routes/resales.ts
+++ b/server/routes/resales.ts
@@ -396,19 +396,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       const { id } = request.params as { id: string };
       const idResult = requireNonEmptyString(id, 'id');
       if (!idResult.ok) return badRequest(reply, idResult.message);
-      const linkedCount = await resalesRepo.countActivitiesByCategory(idResult.value);
-      if (linkedCount > 0) {
-        return replyError(request, reply, {
-          statusCode: 409,
-          message: 'Cannot delete a category used by resale activities',
-          action: 'resale_category.delete.conflict',
-          entityType: 'resale_category',
-          entityId: idResult.value,
-          details: { secondaryLabel: 'in_use', counts: { activities: linkedCount } },
-        });
-      }
-      const deleted = await resalesRepo.deleteCategoryById(idResult.value);
-      if (!deleted) {
+
+      const result = await resalesRepo.deleteCategoryIfUnused(idResult.value);
+      if (result.status === 'not_found') {
         return replyError(request, reply, {
           statusCode: 404,
           message: 'Category not found',
@@ -417,6 +407,20 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           entityId: idResult.value,
         });
       }
+      if (result.status === 'in_use') {
+        return replyError(request, reply, {
+          statusCode: 409,
+          message: 'Cannot delete a category used by resale activities',
+          action: 'resale_category.delete.conflict',
+          entityType: 'resale_category',
+          entityId: idResult.value,
+          details: {
+            secondaryLabel: 'in_use',
+            counts: { activities: result.activityCount },
+          },
+        });
+      }
+
       await logAudit({
         request,
         action: 'resale_category.deleted',

--- a/server/test/repositories/resalesRepo.test.ts
+++ b/server/test/repositories/resalesRepo.test.ts
@@ -1,11 +1,19 @@
-import { describe, expect, test } from 'bun:test';
+import { beforeEach, describe, expect, test } from 'bun:test';
 import type { DbExecutor } from '../../db/drizzle.ts';
-import { computeSupplierOrderTotal, listOrderOptions } from '../../repositories/resalesRepo.ts';
+import {
+  computeSupplierOrderTotal,
+  deleteCategoryIfUnused,
+  listOrderOptions,
+} from '../../repositories/resalesRepo.ts';
 import type { SupplierOrder, SupplierOrderItem } from '../../repositories/supplierOrdersRepo.ts';
 import { type FakeExecutor, makeRow, setupTestDb } from '../helpers/fakeExecutor.ts';
 
 let exec: FakeExecutor;
 let testDb: DbExecutor;
+
+beforeEach(() => {
+  ({ exec, testDb } = setupTestDb());
+});
 
 const makeOrder = (overrides: Partial<Pick<SupplierOrder, 'discount' | 'discountType'>>) =>
   ({
@@ -125,7 +133,6 @@ describe('computeSupplierOrderTotal', () => {
 
 describe('listOrderOptions', () => {
   test('includes draft client orders when they have linked supplier orders', async () => {
-    ({ exec, testDb } = setupTestDb());
     exec.enqueue({
       rows: [
         {
@@ -149,5 +156,43 @@ describe('listOrderOptions', () => {
         supplierOrders: [{ id: 'so-1', supplierName: 'CloudSeat Licensing', total: 9 }],
       },
     ]);
+  });
+});
+
+describe('deleteCategoryIfUnused', () => {
+  test('deletes with a conditional NOT EXISTS guard in one statement', async () => {
+    exec.enqueue({ rows: [{ id: 'rvc-1' }] });
+
+    const result = await deleteCategoryIfUnused('rvc-1', testDb);
+
+    expect(result).toEqual({ status: 'deleted' });
+    expect(exec.calls).toHaveLength(1);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).toContain('delete from resale_categories');
+    expect(sql).toContain('not exists');
+    expect(sql).toContain('resale_activities');
+    expect(sql).toContain('returning');
+    expect(exec.calls[0].params).toContain('rvc-1');
+  });
+
+  test('returns in_use when activities reference the category (no unconditional delete)', async () => {
+    exec.enqueue({ rows: [] });
+    exec.enqueue({ rows: [['2']] });
+
+    const result = await deleteCategoryIfUnused('rvc-1', testDb);
+
+    expect(result).toEqual({ status: 'in_use', activityCount: 2 });
+    expect(exec.calls).toHaveLength(2);
+    expect(exec.calls[0].sql.toLowerCase()).toContain('not exists');
+    expect(exec.calls[1].sql.toLowerCase()).toContain('resale_activities');
+  });
+
+  test('returns not_found when the category is missing and unused', async () => {
+    exec.enqueue({ rows: [] });
+    exec.enqueue({ rows: [['0']] });
+
+    const result = await deleteCategoryIfUnused('missing', testDb);
+
+    expect(result).toEqual({ status: 'not_found' });
   });
 });

--- a/server/test/routes/resales.test.ts
+++ b/server/test/routes/resales.test.ts
@@ -28,6 +28,7 @@ const existsByOrderPairMock = mock();
 const createMock = mock();
 const createActivityMock = mock();
 const findByIdMock = mock();
+const deleteCategoryIfUnusedMock = mock();
 const txExecutor = {};
 const withDbTransactionMock = mock(async (callback: (tx: unknown) => Promise<unknown>) =>
   callback(txExecutor),
@@ -115,6 +116,7 @@ beforeAll(async () => {
     create: createMock,
     createActivity: createActivityMock,
     findById: findByIdMock,
+    deleteCategoryIfUnused: deleteCategoryIfUnusedMock,
   }));
   mock.module('../../utils/audit.ts', () => ({
     ...auditSnap,
@@ -144,6 +146,7 @@ beforeEach(async () => {
     createMock,
     createActivityMock,
     findByIdMock,
+    deleteCategoryIfUnusedMock,
     withDbTransactionMock,
     logAuditMock,
   ]) {
@@ -158,6 +161,7 @@ beforeEach(async () => {
   createMock.mockResolvedValue(SAMPLE_RESALE);
   createActivityMock.mockResolvedValue(SAMPLE_ACTIVITY);
   findByIdMock.mockResolvedValue(SAMPLE_RESALE);
+  deleteCategoryIfUnusedMock.mockResolvedValue({ status: 'deleted' });
   withDbTransactionMock.mockImplementation(async (callback: (tx: unknown) => Promise<unknown>) =>
     callback(txExecutor),
   );
@@ -300,5 +304,79 @@ describe('resale routes', () => {
       dueDate: '2026-06-30',
       activities: [expect.objectContaining({ name: 'Setup rivendita' })],
     });
+  });
+});
+
+describe('DELETE /categories/:id', () => {
+  test('204 deletes an unused category via the atomic repo helper', async () => {
+    currentPermissions = ['projects.resales.delete'];
+    deleteCategoryIfUnusedMock.mockResolvedValue({ status: 'deleted' });
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/projects/resales/categories/rvc-1',
+      headers: authHeaders(),
+    });
+
+    expect(res.statusCode).toBe(204);
+    expect(deleteCategoryIfUnusedMock).toHaveBeenCalledWith('rvc-1');
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'resale_category.deleted', entityId: 'rvc-1' }),
+    );
+  });
+
+  test('409 when activities reference the category (including concurrent insert races)', async () => {
+    currentPermissions = ['projects.resales.delete'];
+    deleteCategoryIfUnusedMock.mockResolvedValue({ status: 'in_use', activityCount: 1 });
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/projects/resales/categories/rvc-1',
+      headers: authHeaders(),
+    });
+
+    expect(res.statusCode).toBe(409);
+    expect(JSON.parse(res.body)).toMatchObject({
+      error: 'Cannot delete a category used by resale activities',
+    });
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'resale_category.delete.conflict',
+        entityId: 'rvc-1',
+        details: { secondaryLabel: 'in_use', counts: { activities: 1 } },
+      }),
+    );
+  });
+
+  test('404 when the category does not exist', async () => {
+    currentPermissions = ['projects.resales.delete'];
+    deleteCategoryIfUnusedMock.mockResolvedValue({ status: 'not_found' });
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/projects/resales/categories/missing',
+      headers: authHeaders(),
+    });
+
+    expect(res.statusCode).toBe(404);
+    expect(logAuditMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        action: 'resale_category.delete.not_found',
+        entityId: 'missing',
+      }),
+    );
+  });
+
+  test('403 without delete permission', async () => {
+    currentPermissions = ['projects.resales.view'];
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/projects/resales/categories/rvc-1',
+      headers: authHeaders(),
+    });
+
+    expect(res.statusCode).toBe(403);
+    expect(deleteCategoryIfUnusedMock).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- Make resale category deletion atomic with `DELETE ... WHERE NOT EXISTS (... ) RETURNING` so a concurrent activity insert cannot turn the delete into an unhandled FK RESTRICT failure.
- Map unused/missing/in-use outcomes to the existing 204 / 404 / 409 responses from a single repo helper.
- Add repo and route regression coverage for the race-safe delete path.

## Changes
- Replace `countActivitiesByCategory` + `deleteCategoryById` TOCTOU sequence with `deleteCategoryIfUnused`.
- Update `DELETE /categories/:id` to consume the typed delete result.
- Extend `resalesRepo` and `resales` route unit tests.

## Testing
- `bun test test/repositories/resalesRepo.test.ts test/routes/resales.test.ts` (from `server/`)

## Risks / Rollout
- Low risk. Behavior for unused categories and pre-existing in-use categories is unchanged; only the concurrent race path now returns 409 instead of a 500-style FK error.

## Issues
Issue: Not linked

Made with [Cursor](https://cursor.com)