### PR TITLE
tasks(docs): document hours APIs keyed by task id

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -18856,7 +18856,7 @@
         "tags": [
           "tasks"
         ],
-        "description": "Task visibility and time-entry ownership are scoped independently. Viewing totals across all entry owners requires timesheets.tracker_all.view.",
+        "description": "Returns project maps keyed by stable task ID. Task visibility and time-entry ownership are scoped independently. Viewing totals across all entry owners requires timesheets.tracker_all.view.",
         "parameters": [
           {
             "schema": {
@@ -19019,7 +19019,7 @@
         "tags": [
           "tasks"
         ],
-        "description": "Task visibility and time-entry ownership are scoped independently. Viewing totals across all entry owners requires timesheets.tracker_all.view.",
+        "description": "Returns totals keyed by stable task ID. Task visibility and time-entry ownership are scoped independently. Viewing totals across all entry owners requires timesheets.tracker_all.view.",
         "parameters": [
           {
             "schema": {

--- a/services/api/tasks.ts
+++ b/services/api/tasks.ts
@@ -44,9 +44,11 @@ export const tasksApi = {
 
   delete: (id: string): Promise<void> => fetchApi(`/tasks/${id}`, { method: 'DELETE' }),
 
+  /** Totals keyed by stable task id (not task name). */
   getHours: (projectId: string, signal?: AbortSignal): Promise<Record<string, number>> =>
     fetchApi(`/tasks/hours?projectId=${encodeURIComponent(projectId)}`, { signal }),
 
+  /** Per-project maps of totals keyed by stable task id (not task name). */
   getHoursForProjects: (
     projectIds: string[],
     signal?: AbortSignal,


### PR DESCRIPTION
## Summary
- Align OpenAPI `/api/tasks/hours` descriptions and client helper comments with the task-id keyed progress totals contract from #1069.

## Changes
- Update `docs/api/openapi.json` descriptions for `/hours` and `/hours/batch`.
- Document that `tasksApi.getHours` / `getHoursForProjects` keys are stable task ids.

## Testing
- Focused server hours route/repo tests previously verified by #1069 CI (green, merged).
- Diff is docs/comments only.

## Risks / Rollout
- None. Documentation-only follow-up; no runtime behavior change.

## Issues
Issue: Not linked
Related to https://github.com/xBounceIT/praetor/pull/1069