### PR TITLE
sales(security): resolve supplier quote names from supplierId

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -1457,8 +1457,152 @@
         ],
         "security": [],
         "responses": {
-          "200": {
-            "description": "Default Response"
+          "400": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "409": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "429": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
+          },
+          "503": {
+            "description": "Default Response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "type": "object",
+                  "properties": {
+                    "error": {
+                      "type": "string"
+                    },
+                    "errorCode": {
+                      "type": "string"
+                    }
+                  },
+                  "required": [
+                    "error"
+                  ]
+                }
+              }
+            }
           }
         }
       }
@@ -50092,7 +50236,8 @@
                     "type": "string"
                   },
                   "supplierName": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Ignored. The canonical supplier name is resolved server-side from supplierId."
                   },
                   "clientId": {
                     "type": [
@@ -50178,7 +50323,6 @@
                 },
                 "required": [
                   "supplierId",
-                  "supplierName",
                   "items",
                   "expirationDate",
                   "communicationChannelId"
@@ -50536,7 +50680,8 @@
                     "type": "string"
                   },
                   "supplierName": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Ignored. The canonical supplier name is resolved server-side when supplierId changes."
                   },
                   "clientId": {
                     "type": [
@@ -53001,7 +53146,10 @@
                 ],
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "maxLength": 100,
+                    "pattern": "^[A-Za-z0-9_-]*$",
+                    "description": "Optional manual supplier-order code. Letters, numbers, underscores, and hyphens only; blank allocates the configured automatic code."
                   },
                   "linkedQuoteId": {
                     "type": "string"
@@ -53410,7 +53558,8 @@
                 "type": "object",
                 "properties": {
                   "id": {
-                    "type": "string"
+                    "type": "string",
+                    "description": "Supplier-order code. A renamed code must use at most 100 letters, numbers, underscores, or hyphens; an unchanged legacy code remains accepted."
                   },
                   "supplierId": {
                     "type": "string"

--- a/server/routes/supplier-quotes.ts
+++ b/server/routes/supplier-quotes.ts
@@ -223,7 +223,11 @@ const supplierQuoteCreateBodySchema = {
     },
     description: { type: 'string' },
     supplierId: { type: 'string' },
-    supplierName: { type: 'string' },
+    // Accepted for backward compatibility; ignored. Canonical supplierName is resolved from supplierId.
+    supplierName: {
+      type: 'string',
+      description: 'Ignored. The canonical supplier name is resolved server-side from supplierId.',
+    },
     // clientName is resolved server-side from clientId; the body only carries the id.
     clientId: { type: ['string', 'null'] },
     items: { type: 'array', items: supplierQuoteItemBodySchema },
@@ -233,7 +237,7 @@ const supplierQuoteCreateBodySchema = {
     communicationChannelId: { type: 'string' },
     notes: { type: 'string' },
   },
-  required: ['supplierId', 'supplierName', 'items', 'expirationDate', 'communicationChannelId'],
+  required: ['supplierId', 'items', 'expirationDate', 'communicationChannelId'],
 } as const;
 
 const supplierQuoteUpdateBodySchema = {
@@ -247,7 +251,12 @@ const supplierQuoteUpdateBodySchema = {
     },
     description: { type: ['string', 'null'] },
     supplierId: { type: 'string' },
-    supplierName: { type: 'string' },
+    // Accepted for backward compatibility; ignored. Canonical supplierName is resolved when supplierId changes.
+    supplierName: {
+      type: 'string',
+      description:
+        'Ignored. The canonical supplier name is resolved server-side when supplierId changes.',
+    },
     // clientName is resolved server-side from clientId; the body only carries the id.
     clientId: { type: ['string', 'null'] },
     items: { type: 'array', items: supplierQuoteItemBodySchema },
@@ -414,6 +423,26 @@ const resolveClientLink = async (
     return null;
   }
   return { clientId: clientIdResult.value, clientName };
+};
+
+// Resolves the required supplier association from `supplierId`. Caller-supplied `supplierName` is
+// never trusted: the canonical name is read from the suppliers table so quote labels, audit
+// secondary labels, and version snapshots stay tied to the referenced supplier row.
+const resolveSupplierLink = async (
+  rawSupplierId: unknown,
+  reply: FastifyReply,
+): Promise<{ supplierId: string; supplierName: string } | null> => {
+  const supplierIdResult = requireNonEmptyString(rawSupplierId, 'supplierId');
+  if (!supplierIdResult.ok) {
+    badRequest(reply, supplierIdResult.message);
+    return null;
+  }
+  const supplierName = await suppliersRepo.findNameById(supplierIdResult.value);
+  if (supplierName === null) {
+    badRequest(reply, 'supplierId does not reference an existing supplier');
+    return null;
+  }
+  return { supplierId: supplierIdResult.value, supplierName };
 };
 
 const resolveCommunicationChannel = async (
@@ -587,7 +616,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         id: nextId,
         description,
         supplierId,
-        supplierName,
         clientId,
         items,
         paymentTerms,
@@ -598,7 +626,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         id?: string;
         description?: string;
         supplierId?: string;
-        supplierName?: string;
         clientId?: string | null;
         items?: ItemBody[];
         paymentTerms?: string;
@@ -607,11 +634,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         notes?: string;
       };
 
-      const supplierIdResult = requireNonEmptyString(supplierId, 'supplierId');
-      if (!supplierIdResult.ok) return badRequest(reply, supplierIdResult.message);
-
-      const supplierNameResult = requireNonEmptyString(supplierName, 'supplierName');
-      if (!supplierNameResult.ok) return badRequest(reply, supplierNameResult.message);
       const nextIdResult = validateOptionalDocumentCode(nextId, 'id');
       if (!nextIdResult.ok) return badRequest(reply, nextIdResult.message);
 
@@ -634,6 +656,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       const expirationDateResult = parseDateString(expirationDate, 'expirationDate');
       if (!expirationDateResult.ok) return badRequest(reply, expirationDateResult.message);
+
+      // supplierName from the body is ignored; resolve the canonical label from supplierId.
+      const supplierLink = await resolveSupplierLink(supplierId, reply);
+      if (!supplierLink) return;
 
       const clientLink = await resolveClientLink(clientId, reply);
       if (!clientLink) return;
@@ -667,8 +693,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             {
               id: quoteId,
               description: description ?? null,
-              supplierId: supplierIdResult.value,
-              supplierName: supplierNameResult.value,
+              supplierId: supplierLink.supplierId,
+              supplierName: supplierLink.supplierName,
               clientId: clientLink.clientId,
               clientName: clientLink.clientName,
               paymentTerms: paymentTerms || 'immediate',
@@ -748,7 +774,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         id: nextId,
         description,
         supplierId,
-        supplierName,
         clientId,
         items,
         paymentTerms,
@@ -759,7 +784,6 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         id?: string;
         description?: string | null;
         supplierId?: string;
-        supplierName?: string;
         clientId?: string | null;
         items?: ItemBody[];
         paymentTerms?: string;
@@ -778,10 +802,10 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       // field, expiration included) decides whether to take a version snapshot before writing;
       // id-only renames do not. Derived from one list so the field sets can't drift. A client-sent
       // `status` is IGNORED entirely: the status is fully derived from the linked client documents.
+      // `supplierName` is also ignored (resolved from supplierId when the id changes).
       const hasNonExpirationContentUpdate =
         description !== undefined ||
         supplierId !== undefined ||
-        supplierName !== undefined ||
         clientId !== undefined ||
         items !== undefined ||
         paymentTerms !== undefined ||
@@ -793,16 +817,13 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
 
       if (description !== undefined) patch.description = description;
 
+      // Validate supplierId format here; resolve/write the canonical name later and only when the
+      // id actually changes (mirrors clientId/#759). Caller-supplied supplierName is never trusted.
+      let incomingSupplierId: string | null = null;
       if (supplierId !== undefined) {
         const supplierIdResult = optionalNonEmptyString(supplierId, 'supplierId');
         if (!supplierIdResult.ok) return badRequest(reply, supplierIdResult.message);
-        if (supplierIdResult.value !== null) patch.supplierId = supplierIdResult.value;
-      }
-
-      if (supplierName !== undefined) {
-        const supplierNameResult = optionalNonEmptyString(supplierName, 'supplierName');
-        if (!supplierNameResult.ok) return badRequest(reply, supplierNameResult.message);
-        if (supplierNameResult.value !== null) patch.supplierName = supplierNameResult.value;
+        if (supplierIdResult.value !== null) incomingSupplierId = supplierIdResult.value;
       }
 
       // Validate the clientId format here, but resolve/write the link later and only when it
@@ -908,6 +929,17 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           entityId: idResult.value,
           details: { secondaryLabel: 'duplicate_id' },
         });
+      }
+
+      // Touch the supplier link only when it actually changes. An unchanged supplierId (the edit
+      // form resubmits it on every save) leaves the stored supplierName intact so it survives later
+      // supplier renames; a changed id re-resolves the canonical name. Caller-supplied supplierName
+      // is never written.
+      if (incomingSupplierId !== null && incomingSupplierId !== current.supplierId) {
+        const supplierLink = await resolveSupplierLink(incomingSupplierId, reply);
+        if (!supplierLink) return;
+        patch.supplierId = supplierLink.supplierId;
+        patch.supplierName = supplierLink.supplierName;
       }
 
       // Touch the customer link only when it actually changes. An unchanged clientId (the edit

--- a/server/test/routes/supplier-quotes.test.ts
+++ b/server/test/routes/supplier-quotes.test.ts
@@ -6,6 +6,7 @@ import * as realQuoteCommunicationChannelsRepo from '../../repositories/quoteCom
 import * as realRolesRepo from '../../repositories/rolesRepo.ts';
 import * as realSupplierQuotesRepo from '../../repositories/supplierQuotesRepo.ts';
 import * as realSupplierQuoteVersionsRepo from '../../repositories/supplierQuoteVersionsRepo.ts';
+import * as realSuppliersRepo from '../../repositories/suppliersRepo.ts';
 import * as realUsersRepo from '../../repositories/usersRepo.ts';
 import * as realDocumentCodes from '../../services/documentCodes.ts';
 import * as realAudit from '../../utils/audit.ts';
@@ -26,6 +27,7 @@ const supplierQuotesRepoSnap = { ...realSupplierQuotesRepo };
 const supplierQuoteVersionsRepoSnap = { ...realSupplierQuoteVersionsRepo };
 const quoteCommunicationChannelsRepoSnap = { ...realQuoteCommunicationChannelsRepo };
 const clientsRepoSnap = { ...realClientsRepo };
+const suppliersRepoSnap = { ...realSuppliersRepo };
 const documentCodesSnap = { ...realDocumentCodes };
 const auditSnap = { ...realAudit };
 const drizzleSnap = { ...realDrizzle };
@@ -35,6 +37,7 @@ const userHasRoleMock = mock();
 const getRolePermissionsMock = mock();
 
 const clientsFindNameMock = mock();
+const suppliersFindNameByIdMock = mock();
 
 const sqFindByIdMock = mock();
 const sqFindLinkedOrderIdMock = mock();
@@ -108,6 +111,10 @@ beforeAll(async () => {
     ...clientsRepoSnap,
     findName: clientsFindNameMock,
   }));
+  mock.module('../../repositories/suppliersRepo.ts', () => ({
+    ...suppliersRepoSnap,
+    findNameById: suppliersFindNameByIdMock,
+  }));
   mock.module('../../utils/audit.ts', () => ({
     ...auditSnap,
     logAudit: logAuditMock,
@@ -140,6 +147,7 @@ afterAll(() => {
     () => quoteCommunicationChannelsRepoSnap,
   );
   mock.module('../../repositories/clientsRepo.ts', () => clientsRepoSnap);
+  mock.module('../../repositories/suppliersRepo.ts', () => suppliersRepoSnap);
   mock.module('../../services/documentCodes.ts', () => documentCodesSnap);
   mock.module('../../utils/audit.ts', () => auditSnap);
   mock.module('../../db/drizzle.ts', () => drizzleSnap);
@@ -205,6 +213,7 @@ const allMocks = [
   userHasRoleMock,
   getRolePermissionsMock,
   clientsFindNameMock,
+  suppliersFindNameByIdMock,
   sqFindByIdMock,
   sqFindLinkedOrderIdMock,
   sqLockEffectiveStatusByIdMock,
@@ -252,6 +261,10 @@ beforeEach(async () => {
   sqFindItemsForQuoteMock.mockResolvedValue([SAMPLE_ITEM]);
   sqFindIdConflictMock.mockResolvedValue(false);
   qccFindByIdMock.mockResolvedValue({ id: 'qcc_email', name: 'Email' });
+  // Default: create/update resolve supplierName from supplierId against this fixture supplier.
+  suppliersFindNameByIdMock.mockImplementation((id: string) =>
+    Promise.resolve(id === 's1' ? 'Acme' : id === 's-other' ? 'Other Co' : null),
+  );
   // Default: the quote is not sourced by any client line, so item edits on a draft are allowed.
   sqIsSourcedByClientDocumentsMock.mockResolvedValue(false);
   sqFindSourcedItemIdsMock.mockResolvedValue(new Set<string>());
@@ -424,6 +437,58 @@ describe('POST /api/sales/supplier-quotes', () => {
 
     expect(res.statusCode).toBe(400);
     expect(JSON.parse(res.body)).toEqual({ error: 'Bad Request' });
+    expect(sqCreateMock).not.toHaveBeenCalled();
+  });
+
+  test('201 resolves supplierName from supplierId and ignores a forged body name', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/sales/supplier-quotes',
+      headers: authHeader(),
+      payload: { ...CREATE_PAYLOAD, supplierName: 'FORGED SUPPLIER' },
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(suppliersFindNameByIdMock).toHaveBeenCalledWith('s1');
+    expect(sqCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        supplierId: 's1',
+        supplierName: 'Acme',
+      }),
+      expect.anything(),
+    );
+    expect(JSON.parse(res.body).supplierName).toBe('Acme');
+  });
+
+  test('201 resolves supplierName when the body omits supplierName', async () => {
+    const { supplierName: _omitted, ...payload } = CREATE_PAYLOAD;
+
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/sales/supplier-quotes',
+      headers: authHeader(),
+      payload,
+    });
+
+    expect(res.statusCode).toBe(201);
+    expect(sqCreateMock).toHaveBeenCalledWith(
+      expect.objectContaining({ supplierId: 's1', supplierName: 'Acme' }),
+      expect.anything(),
+    );
+  });
+
+  test('400 when supplierId does not reference an existing supplier on create', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/sales/supplier-quotes',
+      headers: authHeader(),
+      payload: { ...CREATE_PAYLOAD, supplierId: 'ghost', supplierName: 'Ghost Co' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'supplierId does not reference an existing supplier',
+    });
     expect(sqCreateMock).not.toHaveBeenCalled();
   });
 });
@@ -1398,6 +1463,92 @@ describe('PUT /api/sales/supplier-quotes/:id', () => {
     expect(sqUpdateMock.mock.calls[0]?.[1]).toEqual(
       expect.objectContaining({ clientId: 'cli-1', clientName: 'Globex Corp' }),
     );
+  });
+
+  test('200 reassigns supplier and resolves canonical supplierName from supplierId', async () => {
+    sqFindByIdMock.mockResolvedValue(DRAFT_QUOTE);
+    sqFindLinkedOrderIdMock.mockResolvedValue(null);
+    sqUpdateMock.mockResolvedValue({
+      ...DRAFT_QUOTE,
+      supplierId: 's-other',
+      supplierName: 'Other Co',
+    });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/sales/supplier-quotes/sq-1',
+      headers: authHeader(),
+      payload: { supplierId: 's-other', supplierName: 'FORGED OTHER' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(suppliersFindNameByIdMock).toHaveBeenCalledWith('s-other');
+    expect(sqUpdateMock.mock.calls[0]?.[1]).toEqual(
+      expect.objectContaining({ supplierId: 's-other', supplierName: 'Other Co' }),
+    );
+  });
+
+  test('200 preserves stored supplierName when an edit resubmits the unchanged supplierId', async () => {
+    sqFindByIdMock.mockResolvedValue({
+      ...DRAFT_QUOTE,
+      supplierName: 'Name At Link Time',
+    });
+    sqFindLinkedOrderIdMock.mockResolvedValue(null);
+    sqUpdateMock.mockResolvedValue({
+      ...DRAFT_QUOTE,
+      supplierName: 'Name At Link Time',
+      notes: 'edited',
+    });
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/sales/supplier-quotes/sq-1',
+      headers: authHeader(),
+      payload: { supplierId: 's1', supplierName: 'Renamed Later', notes: 'edited' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(suppliersFindNameByIdMock).not.toHaveBeenCalled();
+    const patch = sqUpdateMock.mock.calls[0]?.[1];
+    expect(patch).toEqual(expect.objectContaining({ notes: 'edited' }));
+    expect(patch).not.toHaveProperty('supplierId');
+    expect(patch).not.toHaveProperty('supplierName');
+  });
+
+  test('200 ignores a forged supplierName-only update', async () => {
+    sqFindByIdMock.mockResolvedValue(DRAFT_QUOTE);
+    sqFindLinkedOrderIdMock.mockResolvedValue(null);
+    sqUpdateMock.mockResolvedValue(DRAFT_QUOTE);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/sales/supplier-quotes/sq-1',
+      headers: authHeader(),
+      payload: { supplierName: 'FORGED SUPPLIER' },
+    });
+
+    expect(res.statusCode).toBe(200);
+    expect(suppliersFindNameByIdMock).not.toHaveBeenCalled();
+    expect(sqUpdateMock.mock.calls[0]?.[1]).toEqual({});
+    expect(sqvInsertMock).not.toHaveBeenCalled();
+  });
+
+  test('400 when supplierId does not reference an existing supplier on update', async () => {
+    sqFindByIdMock.mockResolvedValue(DRAFT_QUOTE);
+    sqFindLinkedOrderIdMock.mockResolvedValue(null);
+
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/sales/supplier-quotes/sq-1',
+      headers: authHeader(),
+      payload: { supplierId: 'ghost' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(JSON.parse(res.body)).toEqual({
+      error: 'supplierId does not reference an existing supplier',
+    });
+    expect(sqUpdateMock).not.toHaveBeenCalled();
   });
 
   test('200 clears the customer link when clientId is empty', async () => {


### PR DESCRIPTION
## Summary
- Fixes DeepSec finding `praetor-other-data-integrity-dcc57ffd45`: supplier quote create/update no longer trust client-supplied `supplierName`.
- Canonical supplier name is resolved server-side from `supplierId` on create and whenever `supplierId` changes; unknown ids are rejected with 400.
- Unchanged `supplierId` leaves the stored historical name intact (same snapshot pattern as client links).

## Changes
- Adds `resolveSupplierLink` in `server/routes/supplier-quotes.ts` and wires it into POST/PUT.
- Keeps optional request `supplierName` for backward compatibility but documents it as ignored.
- Adds route regression tests for forge prevention, unknown supplier, reassignment, and name preservation.
- Regenerates `docs/api/openapi.json`.

## Testing
- `bun test server/test/routes/supplier-quotes.test.ts` (62 pass)
- `bun run test:react-doctor` baseline/post: 75/100 (backend-only change)
- Three consecutive clean iterative-review-simplify passes after the final simplify edits

## Risks / Rollout
- Low. API clients that still send `supplierName` continue to work; forged names are ignored.
- Existing quotes keep their stored names until supplier reassignment.

## Issues
Issue: Not linked