### PR TITLE
catalog(security): lock products during linked-transaction catalog gates

### DIFF
--- a/server/repositories/productsRepo.ts
+++ b/server/repositories/productsRepo.ts
@@ -913,6 +913,11 @@ export const countProductsForSubcategory = async (
 // Cross-domain link checks
 // ===========================================================================
 
+// TOCTOU gate for category/subcategory rename and delete. Locks matching internal
+// catalog products (`SELECT ... FOR UPDATE`) so concurrent document-item inserts that
+// FK-reference those rows wait until this transaction commits or rolls back, then counts
+// links across quote/offer/order/invoice item tables. Must be called inside
+// `withDbTransaction` — the row locks are released on commit/rollback.
 export const checkProductsLinkedToTransactions = async (
   category: string,
   type: string,
@@ -929,12 +934,14 @@ export const checkProductsLinkedToTransactions = async (
     sql` UNION ALL `,
   );
 
+  // MATERIALIZED keeps the FOR UPDATE side effect (PG 12+ may otherwise inline the CTE).
   const rows = await executeRows<{ total: string | number | null }>(
     exec,
-    sql`WITH matched AS (
+    sql`WITH matched AS MATERIALIZED (
           SELECT id FROM products
           WHERE category = ${category} AND type = ${type} AND supplier_id IS NULL
                 ${subcategoryClause}
+          FOR UPDATE
         )
         SELECT COALESCE(SUM(c), 0)::bigint AS total FROM (${linkCountSubqueries}) sub`,
   );

--- a/server/routes/products.ts
+++ b/server/routes/products.ts
@@ -696,47 +696,44 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       const isRename = newName !== current.name;
-      const [expectedCostUnit, nameTaken, linkedCheck] = await Promise.all([
+      const [expectedCostUnit, nameTaken] = await Promise.all([
         productsRepo.getCostUnitForType(current.type),
         isRename
           ? productsRepo.existsInternalCategoryByNameType(newName, current.type, idResult.value)
           : Promise.resolve(false),
-        isRename
-          ? productsRepo.checkProductsLinkedToTransactions(current.name, current.type, undefined)
-          : Promise.resolve({ linked: false, count: 0 }),
       ]);
       if (nameTaken) {
         return badRequest(reply, INTERNAL_CATEGORY_NAME_CONFLICT_MESSAGE);
       }
-      if (linkedCheck.linked) {
-        return replyError(request, reply, {
-          statusCode: 409,
-          message: 'Cannot rename category',
-          action: 'product_category.update.conflict',
-          entityType: 'product_category',
-          entityId: idResult.value,
-          details: {
-            targetLabel: current.name,
-            secondaryLabel: 'linked_to_transactions',
-            counts: { products: linkedCheck.count },
-          },
-          extraBody: {
-            message: `Category "${current.name}" has ${linkedCheck.count} product(s) linked to transactions. Rename would affect historical records.`,
-            linkedCount: linkedCheck.count,
-          },
-        });
-      }
 
-      let updated: productsRepo.InternalCategoryRow | null;
+      // Linked-transaction check + rename must share one transaction and lock matched
+      // product rows so a concurrent document line cannot attach between check and mutate.
+      type CategoryUpdateOutcome =
+        | { ok: true; row: productsRepo.InternalCategoryRow }
+        | { ok: false; reason: 'not_found' }
+        | { ok: false; reason: 'linked'; linkedCount: number };
+
+      let outcome: CategoryUpdateOutcome;
       try {
-        updated = await withDbTransaction(async (tx) => {
+        outcome = await withDbTransaction(async (tx): Promise<CategoryUpdateOutcome> => {
+          if (isRename) {
+            const linkedCheck = await productsRepo.checkProductsLinkedToTransactions(
+              current.name,
+              current.type,
+              undefined,
+              tx,
+            );
+            if (linkedCheck.linked) {
+              return { ok: false, reason: 'linked', linkedCount: linkedCheck.count };
+            }
+          }
           const row = await productsRepo.updateInternalCategoryFields(
             idResult.value,
             newName,
             expectedCostUnit,
             tx,
           );
-          if (!row) return null;
+          if (!row) return { ok: false, reason: 'not_found' };
           if (isRename) {
             await productsRepo.propagateCategoryNameToProducts(
               current.name,
@@ -746,7 +743,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
               tx,
             );
           }
-          return row;
+          return { ok: true, row };
         });
       } catch (error) {
         if (isInternalCategoryNameConflict(error)) {
@@ -755,7 +752,26 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         throw error;
       }
 
-      if (!updated) {
+      if (!outcome.ok && outcome.reason === 'linked') {
+        return replyError(request, reply, {
+          statusCode: 409,
+          message: 'Cannot rename category',
+          action: 'product_category.update.conflict',
+          entityType: 'product_category',
+          entityId: idResult.value,
+          details: {
+            targetLabel: current.name,
+            secondaryLabel: 'linked_to_transactions',
+            counts: { products: outcome.linkedCount },
+          },
+          extraBody: {
+            message: `Category "${current.name}" has ${outcome.linkedCount} product(s) linked to transactions. Rename would affect historical records.`,
+            linkedCount: outcome.linkedCount,
+          },
+        });
+      }
+
+      if (!outcome.ok) {
         return replyError(request, reply, {
           statusCode: 404,
           message: 'Category not found',
@@ -764,6 +780,8 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           entityId: idResult.value,
         });
       }
+
+      const updated = outcome.row;
 
       await logAudit({
         request,
@@ -822,27 +840,43 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
       const { name, type } = category;
 
-      const linkedCheck = await productsRepo.checkProductsLinkedToTransactions(
-        name,
-        type,
-        undefined,
-      );
-      if (linkedCheck.linked) {
+      type CategoryDeleteOutcome =
+        | { ok: true }
+        | { ok: false; reason: 'linked'; linkedCount: number };
+
+      const outcome = await withDbTransaction(async (tx): Promise<CategoryDeleteOutcome> => {
+        const linkedCheck = await productsRepo.checkProductsLinkedToTransactions(
+          name,
+          type,
+          undefined,
+          tx,
+        );
+        if (linkedCheck.linked) {
+          return { ok: false, reason: 'linked', linkedCount: linkedCheck.count };
+        }
+        await productsRepo.clearProductsCategoryAndDeleteInternalCategory(
+          name,
+          type,
+          idResult.value,
+          tx,
+        );
+        return { ok: true };
+      });
+
+      if (!outcome.ok) {
         return replyError(request, reply, {
           statusCode: 409,
-          message: `Cannot delete category "${name}" because ${linkedCheck.count} product(s) are linked to offers, orders, or invoices`,
+          message: `Cannot delete category "${name}" because ${outcome.linkedCount} product(s) are linked to offers, orders, or invoices`,
           action: 'product_category.delete.conflict',
           entityType: 'product_category',
           entityId: idResult.value,
           details: {
             targetLabel: name,
             secondaryLabel: 'linked_to_transactions',
-            counts: { products: linkedCheck.count },
+            counts: { products: outcome.linkedCount },
           },
         });
       }
-
-      await productsRepo.clearProductsCategoryAndDeleteInternalCategory(name, type, idResult.value);
 
       await logAudit({
         request,
@@ -1065,12 +1099,41 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       // Block rename when products are already linked - preserves historical references.
-      const linkedCheck = await productsRepo.checkProductsLinkedToTransactions(
-        categoryResult.value,
-        typeResult.value,
-        oldNameResult.value,
-      );
-      if (linkedCheck.linked) {
+      // Check + rename share one transaction and lock matched product rows so a concurrent
+      // document line cannot attach between the gate and the mutation.
+      type SubcategoryRenameOutcome =
+        | { ok: true; subId: string }
+        | { ok: false; reason: 'not_found' }
+        | { ok: false; reason: 'linked'; linkedCount: number };
+
+      const outcome = await withDbTransaction(async (tx): Promise<SubcategoryRenameOutcome> => {
+        const linkedCheck = await productsRepo.checkProductsLinkedToTransactions(
+          categoryResult.value,
+          typeResult.value,
+          oldNameResult.value,
+          tx,
+        );
+        if (linkedCheck.linked) {
+          return { ok: false, reason: 'linked', linkedCount: linkedCheck.count };
+        }
+        const sub = await productsRepo.updateInternalSubcategoryName(
+          categoryId,
+          oldNameResult.value,
+          newNameResult.value,
+          tx,
+        );
+        if (!sub) return { ok: false, reason: 'not_found' };
+        await productsRepo.propagateSubcategoryNameToProducts(
+          oldNameResult.value,
+          newNameResult.value,
+          typeResult.value,
+          categoryResult.value,
+          tx,
+        );
+        return { ok: true, subId: sub.id };
+      });
+
+      if (!outcome.ok && outcome.reason === 'linked') {
         return replyError(request, reply, {
           statusCode: 409,
           message: 'Cannot rename subcategory',
@@ -1080,34 +1143,16 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           details: {
             targetLabel: oldNameResult.value,
             secondaryLabel: 'linked_to_transactions',
-            counts: { products: linkedCheck.count },
+            counts: { products: outcome.linkedCount },
           },
           extraBody: {
-            message: `Subcategory "${oldNameResult.value}" has ${linkedCheck.count} product(s) linked to transactions. Rename would affect historical records.`,
-            linkedCount: linkedCheck.count,
+            message: `Subcategory "${oldNameResult.value}" has ${outcome.linkedCount} product(s) linked to transactions. Rename would affect historical records.`,
+            linkedCount: outcome.linkedCount,
           },
         });
       }
 
-      const result = await withDbTransaction(async (tx) => {
-        const sub = await productsRepo.updateInternalSubcategoryName(
-          categoryId,
-          oldNameResult.value,
-          newNameResult.value,
-          tx,
-        );
-        if (!sub) return null;
-        await productsRepo.propagateSubcategoryNameToProducts(
-          oldNameResult.value,
-          newNameResult.value,
-          typeResult.value,
-          categoryResult.value,
-          tx,
-        );
-        return { subId: sub.id };
-      });
-
-      if (!result) {
+      if (!outcome.ok) {
         return replyError(request, reply, {
           statusCode: 404,
           message: 'Subcategory not found',
@@ -1121,7 +1166,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         request,
         action: 'internal_subcategory.renamed',
         entityType: 'internal_product_subcategory',
-        entityId: result.subId,
+        entityId: outcome.subId,
         details: {
           targetLabel: newNameResult.value,
           secondaryLabel: `From: ${oldNameResult.value}`,
@@ -1201,33 +1246,48 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         });
       }
 
-      const linkedCheck = await productsRepo.checkProductsLinkedToTransactions(
-        categoryResult.value,
-        typeResult.value,
-        nameResult.value,
-      );
-      if (linkedCheck.linked) {
+      type SubcategoryDeleteOutcome =
+        | { ok: true; subId: string }
+        | { ok: false; reason: 'not_found' }
+        | { ok: false; reason: 'linked'; linkedCount: number };
+
+      const outcome = await withDbTransaction(async (tx): Promise<SubcategoryDeleteOutcome> => {
+        const linkedCheck = await productsRepo.checkProductsLinkedToTransactions(
+          categoryResult.value,
+          typeResult.value,
+          nameResult.value,
+          tx,
+        );
+        if (linkedCheck.linked) {
+          return { ok: false, reason: 'linked', linkedCount: linkedCheck.count };
+        }
+        const subDeleted = await productsRepo.deleteInternalSubcategoryAndClearProducts(
+          categoryId,
+          nameResult.value,
+          typeResult.value,
+          categoryResult.value,
+          tx,
+        );
+        if (!subDeleted) return { ok: false, reason: 'not_found' };
+        return { ok: true, subId: subDeleted.id };
+      });
+
+      if (!outcome.ok && outcome.reason === 'linked') {
         return replyError(request, reply, {
           statusCode: 409,
-          message: `Cannot delete subcategory "${nameResult.value}" because ${linkedCheck.count} product(s) are linked to offers, orders, or invoices`,
+          message: `Cannot delete subcategory "${nameResult.value}" because ${outcome.linkedCount} product(s) are linked to offers, orders, or invoices`,
           action: 'product_subcategory.delete.conflict',
           entityType: 'product_subcategory',
           entityId: nameResult.value,
           details: {
             targetLabel: nameResult.value,
             secondaryLabel: 'linked_to_transactions',
-            counts: { products: linkedCheck.count },
+            counts: { products: outcome.linkedCount },
           },
         });
       }
 
-      const subDeleted = await productsRepo.deleteInternalSubcategoryAndClearProducts(
-        categoryId,
-        nameResult.value,
-        typeResult.value,
-        categoryResult.value,
-      );
-      if (!subDeleted) {
+      if (!outcome.ok) {
         return replyError(request, reply, {
           statusCode: 404,
           message: 'Subcategory not found',
@@ -1241,7 +1301,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         request,
         action: 'internal_subcategory.deleted',
         entityType: 'internal_product_subcategory',
-        entityId: subDeleted.id,
+        entityId: outcome.subId,
         details: {
           targetLabel: nameResult.value,
           secondaryLabel: categoryResult.value,

--- a/server/test/repositories/productsRepo.test.ts
+++ b/server/test/repositories/productsRepo.test.ts
@@ -929,7 +929,9 @@ describe('checkProductsLinkedToTransactions', () => {
     expect(linkSql).toContain('supplier_sale_items');
     expect(linkSql).toContain('supplier_invoice_items');
     // Product ids never leave Postgres - the matched-ids CTE feeds all 7 subqueries directly.
-    expect(linkSql).toMatch(/with\s+matched\s+as/i);
+    expect(linkSql).toMatch(/with\s+matched\s+as\s+materialized/i);
+    // FOR UPDATE serializes concurrent document-item inserts that FK-reference matched products.
+    expect(linkSql).toMatch(/for\s+update/i);
     expect(exec.calls[0].params).toEqual(['cat-a', 'good']);
   });
 });

--- a/server/test/routes/products.test.ts
+++ b/server/test/routes/products.test.ts
@@ -23,6 +23,7 @@ import {
 } from '../helpers/authMiddlewareMock.ts';
 import { buildRouteTestApp } from '../helpers/buildRouteTestApp.ts';
 import { signToken } from '../helpers/jwt.ts';
+import { TX_SENTINEL } from '../helpers/txSentinel.ts';
 import { makeWithDbTransactionMock } from '../helpers/withDbTransactionMock.ts';
 
 const usersRepoSnap = { ...realUsersRepo };
@@ -70,6 +71,7 @@ const updateInternalCategoryFieldsMock = mock();
 const propagateCategoryNameToProductsMock = mock();
 const clearProductsCategoryByNameMock = mock();
 const deleteInternalCategoryByIdMock = mock();
+const clearProductsCategoryAndDeleteInternalCategoryMock = mock();
 const countProductsForCategoryMock = mock();
 
 const listInternalSubcategoriesByTypeMock = mock();
@@ -135,6 +137,8 @@ beforeAll(async () => {
     propagateCategoryNameToProducts: propagateCategoryNameToProductsMock,
     clearProductsCategoryByName: clearProductsCategoryByNameMock,
     deleteInternalCategoryById: deleteInternalCategoryByIdMock,
+    clearProductsCategoryAndDeleteInternalCategory:
+      clearProductsCategoryAndDeleteInternalCategoryMock,
     countProductsForCategory: countProductsForCategoryMock,
     listInternalSubcategoriesByType: listInternalSubcategoriesByTypeMock,
     existsInternalSubcategoryByNameInCategory: existsInternalSubcategoryByNameInCategoryMock,
@@ -264,6 +268,7 @@ const allMocks = [
   propagateCategoryNameToProductsMock,
   clearProductsCategoryByNameMock,
   deleteInternalCategoryByIdMock,
+  clearProductsCategoryAndDeleteInternalCategoryMock,
   countProductsForCategoryMock,
   listInternalSubcategoriesByTypeMock,
   existsInternalSubcategoryByNameInCategoryMock,
@@ -823,6 +828,16 @@ describe('PUT /api/products/internal-categories/:id', () => {
     });
 
     expect(res.statusCode).toBe(200);
+    // TOCTOU: linked check must run inside the same transaction as the rename.
+    expect(checkProductsLinkedToTransactionsMock).toHaveBeenCalledWith(
+      'Electronics',
+      'goods',
+      undefined,
+      TX_SENTINEL,
+    );
+    expect(updateInternalCategoryFieldsMock.mock.calls[0]?.[3]).toBe(TX_SENTINEL);
+    expect(propagateCategoryNameToProductsMock.mock.calls[0]?.[4]).toBe(TX_SENTINEL);
+    expect(withDbTransactionMock).toHaveBeenCalled();
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'internal_category.updated' }),
     );
@@ -856,6 +871,14 @@ describe('PUT /api/products/internal-categories/:id', () => {
 
     expect(res.statusCode).toBe(409);
     expect(JSON.parse(res.body).error).toMatch(/Cannot rename category/);
+    expect(checkProductsLinkedToTransactionsMock).toHaveBeenCalledWith(
+      'Electronics',
+      'goods',
+      undefined,
+      TX_SENTINEL,
+    );
+    expect(updateInternalCategoryFieldsMock).not.toHaveBeenCalled();
+    expect(propagateCategoryNameToProductsMock).not.toHaveBeenCalled();
   });
 
   test('400 when a concurrent case-insensitive duplicate wins the rename race', async () => {
@@ -888,8 +911,7 @@ describe('PUT /api/products/internal-categories/:id', () => {
 describe('DELETE /api/products/internal-categories/:id', () => {
   test('204 deletes category', async () => {
     findInternalCategoryByIdMock.mockResolvedValue({ ...SAMPLE_CATEGORY });
-    clearProductsCategoryByNameMock.mockResolvedValue(undefined);
-    deleteInternalCategoryByIdMock.mockResolvedValue(undefined);
+    clearProductsCategoryAndDeleteInternalCategoryMock.mockResolvedValue(true);
 
     const res = await testApp.inject({
       method: 'DELETE',
@@ -898,6 +920,19 @@ describe('DELETE /api/products/internal-categories/:id', () => {
     });
 
     expect(res.statusCode).toBe(204);
+    expect(checkProductsLinkedToTransactionsMock).toHaveBeenCalledWith(
+      'Electronics',
+      'goods',
+      undefined,
+      TX_SENTINEL,
+    );
+    expect(clearProductsCategoryAndDeleteInternalCategoryMock).toHaveBeenCalledWith(
+      'Electronics',
+      'goods',
+      'ipc-1',
+      TX_SENTINEL,
+    );
+    expect(withDbTransactionMock).toHaveBeenCalled();
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'internal_category.deleted' }),
     );
@@ -926,6 +961,13 @@ describe('DELETE /api/products/internal-categories/:id', () => {
     });
 
     expect(res.statusCode).toBe(409);
+    expect(checkProductsLinkedToTransactionsMock).toHaveBeenCalledWith(
+      'Electronics',
+      'goods',
+      undefined,
+      TX_SENTINEL,
+    );
+    expect(clearProductsCategoryAndDeleteInternalCategoryMock).not.toHaveBeenCalled();
   });
 });
 
@@ -1025,6 +1067,15 @@ describe('PUT /api/products/internal-subcategories/:name', () => {
     });
 
     expect(res.statusCode).toBe(200);
+    expect(checkProductsLinkedToTransactionsMock).toHaveBeenCalledWith(
+      'Electronics',
+      'goods',
+      'Old',
+      TX_SENTINEL,
+    );
+    expect(updateInternalSubcategoryNameMock.mock.calls[0]?.[3]).toBe(TX_SENTINEL);
+    expect(propagateSubcategoryNameToProductsMock.mock.calls[0]?.[4]).toBe(TX_SENTINEL);
+    expect(withDbTransactionMock).toHaveBeenCalled();
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'internal_subcategory.renamed' }),
     );
@@ -1069,6 +1120,13 @@ describe('PUT /api/products/internal-subcategories/:name', () => {
     });
 
     expect(res.statusCode).toBe(409);
+    expect(checkProductsLinkedToTransactionsMock).toHaveBeenCalledWith(
+      'Electronics',
+      'goods',
+      'Old',
+      TX_SENTINEL,
+    );
+    expect(updateInternalSubcategoryNameMock).not.toHaveBeenCalled();
   });
 });
 
@@ -1084,12 +1142,20 @@ describe('DELETE /api/products/internal-subcategories/:name', () => {
     });
 
     expect(res.statusCode).toBe(204);
+    expect(checkProductsLinkedToTransactionsMock).toHaveBeenCalledWith(
+      'Electronics',
+      'goods',
+      'Sub',
+      TX_SENTINEL,
+    );
     expect(deleteInternalSubcategoryAndClearProductsMock).toHaveBeenCalledWith(
       'ipc-1',
       'Sub',
       'goods',
       'Electronics',
+      TX_SENTINEL,
     );
+    expect(withDbTransactionMock).toHaveBeenCalled();
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'internal_subcategory.deleted' }),
     );
@@ -1132,6 +1198,13 @@ describe('DELETE /api/products/internal-subcategories/:name', () => {
     });
 
     expect(res.statusCode).toBe(409);
+    expect(checkProductsLinkedToTransactionsMock).toHaveBeenCalledWith(
+      'Electronics',
+      'goods',
+      'Sub',
+      TX_SENTINEL,
+    );
+    expect(deleteInternalSubcategoryAndClearProductsMock).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- Closes a TOCTOU race where category/subcategory rename or delete could clear or rewrite product categorization after a concurrent document line linked a matching product.
- Linked-transaction checks now take `SELECT … FOR UPDATE` on matched catalog products inside the same `withDbTransaction` as the mutation.

## Changes
- `checkProductsLinkedToTransactions` uses a `MATERIALIZED` CTE with `FOR UPDATE`.
- Category rename/delete and subcategory rename/delete run the gate and mutation atomically.
- Route and repo unit tests assert the check runs with the transaction executor.

## Testing
- `bun test ./test/repositories/productsRepo.test.ts ./test/routes/products.test.ts` (from `server/`) — 140 pass

## Risks / Rollout
- Low. Behavior for uncontended requests is unchanged (same 409/204/200 outcomes). Contended document-line inserts referencing matched products may wait briefly on row locks until the catalog transaction commits.

## Issues
Issue: Not linked (DeepSec finding `praetor-other-race-condition-ad4e211623`)