### PR TITLE
server(bug): validate supplier invoice status before write

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -54733,7 +54733,14 @@
                         "format": "date"
                       },
                       "status": {
-                        "type": "string"
+                        "type": "string",
+                        "enum": [
+                          "draft",
+                          "sent",
+                          "paid",
+                          "overdue",
+                          "cancelled"
+                        ]
                       },
                       "subtotal": {
                         "type": "number"
@@ -55025,7 +55032,14 @@
                     "format": "date"
                   },
                   "status": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                      "draft",
+                      "sent",
+                      "paid",
+                      "overdue",
+                      "cancelled"
+                    ]
                   },
                   "subtotal": {
                     "type": "number"
@@ -55132,7 +55146,14 @@
                       "format": "date"
                     },
                     "status": {
-                      "type": "string"
+                      "type": "string",
+                      "enum": [
+                        "draft",
+                        "sent",
+                        "paid",
+                        "overdue",
+                        "cancelled"
+                      ]
                     },
                     "subtotal": {
                       "type": "number"
@@ -55399,7 +55420,14 @@
                     "format": "date"
                   },
                   "status": {
-                    "type": "string"
+                    "type": "string",
+                    "enum": [
+                      "draft",
+                      "sent",
+                      "paid",
+                      "overdue",
+                      "cancelled"
+                    ]
                   },
                   "subtotal": {
                     "type": "number"
@@ -55509,7 +55537,14 @@
                       "format": "date"
                     },
                     "status": {
-                      "type": "string"
+                      "type": "string",
+                      "enum": [
+                        "draft",
+                        "sent",
+                        "paid",
+                        "overdue",
+                        "cancelled"
+                      ]
                     },
                     "subtotal": {
                       "type": "number"

--- a/server/routes/supplier-invoices.ts
+++ b/server/routes/supplier-invoices.ts
@@ -33,6 +33,7 @@ import {
   optionalDateString,
   optionalDurationMonths,
   optionalDurationUnit,
+  optionalEnum,
   optionalLocalizedNonNegativeNumber,
   optionalNonEmptyString,
   parseDateString,
@@ -40,6 +41,8 @@ import {
   parseLocalizedPositiveNumber,
   requireNonEmptyString,
 } from '../utils/validation.ts';
+
+const SUPPLIER_INVOICE_STATUSES = ['draft', 'sent', 'paid', 'overdue', 'cancelled'] as const;
 
 const AMOUNT_PAID_EXCEEDS_TOTAL_ERROR = 'amountPaid cannot exceed total';
 const PAID_INVOICE_UNDERPAID_ERROR = 'amountPaid must be at least total when status is paid';
@@ -122,7 +125,7 @@ const invoiceSchema = {
     supplierName: { type: 'string' },
     issueDate: { type: 'string', format: 'date' },
     dueDate: { type: 'string', format: 'date' },
-    status: { type: 'string' },
+    status: { type: 'string', enum: [...SUPPLIER_INVOICE_STATUSES] },
     subtotal: { type: 'number' },
     total: { type: 'number' },
     amountPaid: { type: 'number' },
@@ -181,7 +184,7 @@ const createBodySchema = {
     supplierName: { type: 'string' },
     issueDate: { type: 'string', format: 'date' },
     dueDate: { type: 'string', format: 'date' },
-    status: { type: 'string' },
+    status: { type: 'string', enum: [...SUPPLIER_INVOICE_STATUSES] },
     subtotal: { type: 'number' },
     total: { type: 'number' },
     amountPaid: { type: 'number' },
@@ -199,7 +202,7 @@ const updateBodySchema = {
     supplierName: { type: 'string' },
     issueDate: { type: 'string', format: 'date' },
     dueDate: { type: 'string', format: 'date' },
-    status: { type: 'string' },
+    status: { type: 'string', enum: [...SUPPLIER_INVOICE_STATUSES] },
     subtotal: { type: 'number' },
     total: { type: 'number' },
     amountPaid: { type: 'number' },
@@ -400,10 +403,12 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       if (!totalResult.ok) return badRequest(reply, totalResult.message);
       const amountPaidResult = optionalLocalizedNonNegativeNumber(amountPaid, 'amountPaid');
       if (!amountPaidResult.ok) return badRequest(reply, amountPaidResult.message);
+      const statusResult = optionalEnum(status, SUPPLIER_INVOICE_STATUSES, 'status');
+      if (!statusResult.ok) return badRequest(reply, statusResult.message);
       const subtotalValue = roundCurrency(subtotalResult.value ?? 0);
       const totalValue = roundCurrency(totalResult.value ?? 0);
       const amountPaidValue = roundCurrency(amountPaidResult.value ?? 0);
-      const statusValue = typeof status === 'string' && status.length > 0 ? status : 'draft';
+      const statusValue = statusResult.value ?? 'draft';
 
       if (amountPaidValue > totalValue) {
         return badRequest(reply, AMOUNT_PAID_EXCEEDS_TOTAL_ERROR);
@@ -742,7 +747,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
           patch.amountPaid = roundCurrency(amountPaidResult.value);
       }
 
-      if (typeof status === 'string') patch.status = status;
+      const statusResult = optionalEnum(status, SUPPLIER_INVOICE_STATUSES, 'status');
+      if (!statusResult.ok) return badRequest(reply, statusResult.message);
+      if (statusResult.value !== null) patch.status = statusResult.value;
       if (typeof notes === 'string') patch.notes = notes;
 
       let normalizedItems: supplierInvoicesRepo.NewSupplierInvoiceItem[] | null = null;
@@ -899,7 +906,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
       }
 
       const { invoice: updated, items: resultItems, previousStatus } = transactionResult;
-      const didStatusChange = typeof status === 'string' && previousStatus !== updated.status;
+      const didStatusChange = statusResult.value !== null && previousStatus !== updated.status;
       await logAudit({
         request,
         action: 'supplier_invoice.updated',

--- a/server/test/routes/supplier-invoices.test.ts
+++ b/server/test/routes/supplier-invoices.test.ts
@@ -702,6 +702,18 @@ describe('POST /api/supplier-invoices', () => {
     expect(createMock).not.toHaveBeenCalled();
   });
 
+  test('400 rejects an invalid status instead of reaching the database CHECK', async () => {
+    const res = await testApp.inject({
+      method: 'POST',
+      url: '/api/supplier-invoices',
+      headers: authHeader(),
+      payload: { ...validBody, status: 'void' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(createMock).not.toHaveBeenCalled();
+  });
+
   test('404 linkedSaleId points to missing source order', async () => {
     findOrderByIdMock.mockResolvedValue(null);
     findInvoiceForLinkedSaleMock.mockResolvedValue(null);
@@ -851,6 +863,18 @@ describe('PUT /api/supplier-invoices/:id', () => {
     expect(logAuditMock).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'supplier_invoice.updated' }),
     );
+  });
+
+  test('400 rejects an invalid status instead of reaching the database CHECK', async () => {
+    const res = await testApp.inject({
+      method: 'PUT',
+      url: '/api/supplier-invoices/SINV-2025-0001',
+      headers: authHeader(),
+      payload: { status: 'void' },
+    });
+
+    expect(res.statusCode).toBe(400);
+    expect(updateMock).not.toHaveBeenCalled();
   });
 
   test('200 update with new items uses replaceItems', async () => {


### PR DESCRIPTION
## Summary
- Validates supplier invoice `status` against the allowed draft/sent/paid/overdue/cancelled set on create and update, matching the supplier-orders pattern.
- Returns a clean 400 for invalid values instead of letting the PostgreSQL CHECK constraint surface as an unhandled 500.
- Documents the enum in OpenAPI request/response schemas.

## Changes
- Adds `SUPPLIER_INVOICE_STATUSES` plus `optionalEnum` checks in `server/routes/supplier-invoices.ts`.
- Constrains Fastify JSON schemas for create/update/response status fields.
- Adds regression tests for invalid status on POST and PUT.
- Updates `docs/api/openapi.json` status enums for supplier invoices.

## Testing
- `bun test ./test/routes/supplier-invoices.test.ts` (62 pass)

## Risks / Rollout
- Low risk. Behavior change only for previously invalid status strings that already could not persist under the DB CHECK.
- Valid statuses and happy-path flows are unchanged.

## Issues
Issue: Not linked (DeepSec finding `praetor-other-validation-bug-bcde6ed369`)
