### PR TITLE
tasks(bug): lock project on edit to match API

### DIFF
--- a/components/projects/TaskFormModal.tsx
+++ b/components/projects/TaskFormModal.tsx
@@ -459,6 +459,9 @@ const TaskFormModalSession: React.FC<TaskFormModalSessionProps> = ({
 
   const canSubmit = mode === 'edit' ? canUpdate : canCreate;
   const isEditing = mode === 'edit' && Boolean(editingTask);
+  // Task updates do not persist projectId server-side; keep the selector locked in edit mode
+  // so the UI cannot offer a silent no-op move.
+  const isProjectLocked = projectLocked || isEditing;
 
   const requestClose = useCallback(() => {
     if (isSubmitting) return;
@@ -484,7 +487,6 @@ const TaskFormModalSession: React.FC<TaskFormModalSessionProps> = ({
       if (isEditing && editingTask) {
         await onUpdate(editingTask.id, {
           name,
-          projectId,
           description,
           isDisabled: tempIsDisabled,
           ...details,
@@ -539,20 +541,20 @@ const TaskFormModalSession: React.FC<TaskFormModalSessionProps> = ({
                   options={projectSelectOptions}
                   value={projectId}
                   onChange={(val) => {
-                    if (projectLocked) return;
+                    if (isProjectLocked) return;
                     const nextProjectId = val as string;
                     const nextProject = projects.find((item) => item.id === nextProjectId);
                     dispatch({
                       type: 'selectProject',
                       projectId: nextProjectId,
-                      billing: isEditing ? undefined : deriveBillingFromProject(nextProject),
+                      billing: deriveBillingFromProject(nextProject),
                     });
                   }}
                   label={t('tasks.project')}
                   required
                   placeholder={t('common:labels.selectOption')}
                   searchable={true}
-                  disabled={projectLocked}
+                  disabled={isProjectLocked}
                   buttonClassName="h-9"
                 />
 

--- a/test/components/projects/TaskFormModal.projectLock.test.tsx
+++ b/test/components/projects/TaskFormModal.projectLock.test.tsx
@@ -43,7 +43,7 @@ describe('<TaskFormModal /> project lock (deepsec logic-bug-9a7143142c)', () => 
   });
 
   test('edit submit omits projectId from the update payload', async () => {
-    const onUpdate = mock(async () => {});
+    const onUpdate = mock(async (_id: string, _updates: Partial<ProjectTask>) => {});
     render(
       <TaskFormModal
         isOpen
@@ -65,7 +65,8 @@ describe('<TaskFormModal /> project lock (deepsec logic-bug-9a7143142c)', () => 
     fireEvent.click(screen.getByRole('button', { name: 'projects.saveChanges' }));
 
     await waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(1));
-    const [, updates] = onUpdate.mock.calls[0] as [string, Partial<ProjectTask>];
+    expect(onUpdate.mock.calls[0]?.[0]).toBe('t-1');
+    const updates = onUpdate.mock.calls[0]?.[1];
     expect(updates).toMatchObject({ name: 'Renamed task' });
     expect(updates).not.toHaveProperty('projectId');
   });

--- a/test/components/projects/TaskFormModal.projectLock.test.tsx
+++ b/test/components/projects/TaskFormModal.projectLock.test.tsx
@@ -1,0 +1,91 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import type { Client, Project, ProjectTask } from '../../../types';
+import { installI18nMock } from '../../helpers/i18n';
+import { render } from '../../helpers/render';
+
+installI18nMock();
+
+const TaskFormModal = (await import('../../../components/projects/TaskFormModal')).default;
+
+const clients: Client[] = [{ id: 'c-1', name: 'Client One' }];
+const projects: Project[] = [
+  { id: 'p-1', name: 'Project One', clientId: 'c-1' },
+  { id: 'p-2', name: 'Project Two', clientId: 'c-1' },
+];
+const editingTask: ProjectTask = {
+  id: 't-1',
+  name: 'Existing task',
+  projectId: 'p-1',
+  description: 'Desc',
+};
+
+const permissions = { canCreate: true, canUpdate: true, canDelete: true };
+
+describe('<TaskFormModal /> project lock (deepsec logic-bug-9a7143142c)', () => {
+  test('edit mode disables the project selector even when projectLocked is omitted', () => {
+    render(
+      <TaskFormModal
+        isOpen
+        onClose={() => {}}
+        mode="edit"
+        editingTask={editingTask}
+        projects={projects}
+        clients={clients}
+        currency="€"
+        permissions={permissions}
+        onAdd={mock(async () => editingTask)}
+        onUpdate={mock(async () => {})}
+      />,
+    );
+
+    expect(document.getElementById('task-project')).toBeDisabled();
+  });
+
+  test('edit submit omits projectId from the update payload', async () => {
+    const onUpdate = mock(async () => {});
+    render(
+      <TaskFormModal
+        isOpen
+        onClose={() => {}}
+        mode="edit"
+        editingTask={editingTask}
+        projects={projects}
+        clients={clients}
+        currency="€"
+        permissions={permissions}
+        onAdd={mock(async () => editingTask)}
+        onUpdate={onUpdate}
+      />,
+    );
+
+    fireEvent.change(document.getElementById('task-name') as HTMLInputElement, {
+      target: { value: 'Renamed task' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: 'projects.saveChanges' }));
+
+    await waitFor(() => expect(onUpdate).toHaveBeenCalledTimes(1));
+    const [, updates] = onUpdate.mock.calls[0] as [string, Partial<ProjectTask>];
+    expect(updates).toMatchObject({ name: 'Renamed task' });
+    expect(updates).not.toHaveProperty('projectId');
+  });
+
+  test('add mode keeps the project selector enabled when projectLocked is false', () => {
+    render(
+      <TaskFormModal
+        isOpen
+        onClose={() => {}}
+        mode="add"
+        projects={projects}
+        clients={clients}
+        currency="€"
+        permissions={permissions}
+        initialProjectId="p-1"
+        onAdd={mock(async () => editingTask)}
+        onUpdate={mock(async () => {})}
+      />,
+    );
+
+    expect(document.getElementById('task-project')).not.toBeDisabled();
+  });
+});


### PR DESCRIPTION
## Summary
- Locks the task form project selector in edit mode so users cannot select a project change the backend never persists.
- Omits `projectId` from edit-mode update payloads to match `taskUpdateBodySchema` / `TaskUpdate`.
- Adds regression tests for locked edit UI, omitted update field, and unlocked add mode.

## Changes
- `components/projects/TaskFormModal.tsx`: `isProjectLocked = projectLocked || isEditing`; drop `projectId` from `onUpdate`.
- `test/components/projects/TaskFormModal.projectLock.test.tsx`: RTL coverage for the correctness bug.

## Testing
- `bun test test/components/projects/TaskFormModal.projectLock.test.tsx`
- `bun test test/components/projects/TaskFormModal.test.ts`
- `bun run test:react-doctor` (score unchanged at 75/100)

## Risks / Rollout
- Low. Aligns UI with existing API behavior; no schema or data migration.
- Docs: unchanged (no documented task-move flow; this removes a non-functional control).

## Issues
Issue: Not linked (DeepSec finding `praetor-other-logic-bug-9a7143142c`)
