### PR TITLE
fix(accounting): bound supplier invoice item listing queries

### DIFF
--- a/server/repositories/supplierInvoicesRepo.ts
+++ b/server/repositories/supplierInvoicesRepo.ts
@@ -1,4 +1,4 @@
-import { and, asc, desc, eq, ne, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, ne, sql } from 'drizzle-orm';
 import { type DbExecutor, db, executeRows, runAtomically } from '../db/drizzle.ts';
 import { supplierInvoiceItems, supplierInvoices } from '../db/schema/supplierInvoices.ts';
 import { requireDateOnly } from '../utils/date.ts';
@@ -40,6 +40,8 @@ export type SupplierInvoiceItem = {
   durationUnit: DurationUnit;
   pricingSemanticsVersion: PricingSemanticsVersion;
 };
+
+export type SupplierInvoiceWithItems = SupplierInvoice & { items: SupplierInvoiceItem[] };
 
 const mapInvoice = (row: typeof supplierInvoices.$inferSelect): SupplierInvoice => ({
   id: row.id,
@@ -90,6 +92,42 @@ export const listAllItems = async (exec: DbExecutor = db): Promise<SupplierInvoi
     .from(supplierInvoiceItems)
     .orderBy(asc(supplierInvoiceItems.createdAt), asc(supplierInvoiceItems.id));
   return rows.map(mapItem);
+};
+
+const listItemsForInvoices = async (
+  invoiceIds: string[],
+  exec: DbExecutor,
+): Promise<SupplierInvoiceItem[]> => {
+  const rows = await exec
+    .select()
+    .from(supplierInvoiceItems)
+    .where(inArray(supplierInvoiceItems.invoiceId, invoiceIds))
+    .orderBy(asc(supplierInvoiceItems.createdAt), asc(supplierInvoiceItems.id));
+  return rows.map(mapItem);
+};
+
+// Loads the capped invoice list, then fetches items only for those invoice ids so list
+// endpoints do not scan/allocate the entire supplier_invoice_items table.
+export const listAllWithItems = async (
+  exec: DbExecutor = db,
+): Promise<SupplierInvoiceWithItems[]> => {
+  const invoiceList = await listAll(exec);
+  if (invoiceList.length === 0) return [];
+
+  const items = await listItemsForInvoices(
+    invoiceList.map((invoice) => invoice.id),
+    exec,
+  );
+  const itemsByInvoice = new Map<string, SupplierInvoiceItem[]>();
+  for (const item of items) {
+    const list = itemsByInvoice.get(item.invoiceId);
+    if (list) list.push(item);
+    else itemsByInvoice.set(item.invoiceId, [item]);
+  }
+  return invoiceList.map((invoice) => ({
+    ...invoice,
+    items: itemsByInvoice.get(invoice.id) ?? [],
+  }));
 };
 
 export const findById = async (

--- a/server/routes/mcp.ts
+++ b/server/routes/mcp.ts
@@ -488,20 +488,14 @@ const buildServer = () => {
 
       const canViewClientInvoices = hasPermission(user, 'accounting.clients_invoices.view');
       const canViewSupplierInvoices = hasPermission(user, 'accounting.supplier_invoices.view');
-      const [clientInvoices, supplierInvoices, supplierInvoiceItems] = await Promise.all([
+      const [clientInvoices, supplierInvoices] = await Promise.all([
         listIfAllowed(canViewClientInvoices, invoicesRepo.listAllWithItems),
-        listIfAllowed(canViewSupplierInvoices, supplierInvoicesRepo.listAll),
-        listIfAllowed(canViewSupplierInvoices, supplierInvoicesRepo.listAllItems),
+        listIfAllowed(canViewSupplierInvoices, supplierInvoicesRepo.listAllWithItems),
       ]);
-
-      const supplierItemsByInvoice = groupBy(supplierInvoiceItems, (item) => item.invoiceId);
 
       return jsonResult({
         clientInvoices,
-        supplierInvoices: supplierInvoices.map((invoice) => ({
-          ...invoice,
-          items: supplierItemsByInvoice.get(invoice.id) ?? [],
-        })),
+        supplierInvoices,
         scope: {
           includesClientInvoices: canViewClientInvoices,
           includesSupplierInvoices: canViewSupplierInvoices,

--- a/server/routes/supplier-invoices.ts
+++ b/server/routes/supplier-invoices.ts
@@ -308,21 +308,7 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
         },
       },
     },
-    async () => {
-      const [invoices, items] = await Promise.all([
-        supplierInvoicesRepo.listAll(),
-        supplierInvoicesRepo.listAllItems(),
-      ]);
-      const itemsByInvoice: Record<string, supplierInvoicesRepo.SupplierInvoiceItem[]> = {};
-      for (const item of items) {
-        if (!itemsByInvoice[item.invoiceId]) itemsByInvoice[item.invoiceId] = [];
-        itemsByInvoice[item.invoiceId].push(item);
-      }
-      return invoices.map((invoice) => ({
-        ...invoice,
-        items: itemsByInvoice[invoice.id] || [],
-      }));
-    },
+    async () => supplierInvoicesRepo.listAllWithItems(),
   );
 
   fastify.post(

--- a/server/test/repositories/supplierInvoicesRepo.test.ts
+++ b/server/test/repositories/supplierInvoicesRepo.test.ts
@@ -100,6 +100,53 @@ describe('listAllItems', () => {
   });
 });
 
+describe('listAllWithItems', () => {
+  test('queries items only for the capped invoice ids with deterministic ordering', async () => {
+    exec.enqueue({
+      rows: [invoiceRow({ 0: 'SINV-2' }), invoiceRow({ 0: 'SINV-1' })],
+    });
+    exec.enqueue({ rows: [] });
+
+    await supplierInvoicesRepo.listAllWithItems(testDb);
+
+    const itemQuery = exec.calls[1];
+    expect(itemQuery.sql.toLowerCase()).toContain('where "supplier_invoice_items"."invoice_id" in');
+    expect(itemQuery.params).toContain('SINV-2');
+    expect(itemQuery.params).toContain('SINV-1');
+    expect(itemQuery.sql.toLowerCase()).toMatch(/order by.*"created_at".*,.*"id"/);
+  });
+
+  test('groups items by invoiceId and preserves invoice order', async () => {
+    exec.enqueue({
+      rows: [invoiceRow({ 0: 'SINV-1' }), invoiceRow({ 0: 'SINV-2' })],
+    });
+    exec.enqueue({
+      rows: [
+        itemRow({ 0: 'i-a', 1: 'SINV-2' }),
+        itemRow({ 0: 'i-b', 1: 'SINV-1' }),
+        itemRow({ 0: 'i-c', 1: 'SINV-1' }),
+      ],
+    });
+    const result = await supplierInvoicesRepo.listAllWithItems(testDb);
+    expect(result.map((i) => i.id)).toEqual(['SINV-1', 'SINV-2']);
+    expect(result[0].items.map((i) => i.id)).toEqual(['i-b', 'i-c']);
+    expect(result[1].items.map((i) => i.id)).toEqual(['i-a']);
+  });
+
+  test('returns empty items array when no items exist', async () => {
+    exec.enqueue({ rows: [invoiceRow()] });
+    exec.enqueue({ rows: [] });
+    const result = await supplierInvoicesRepo.listAllWithItems(testDb);
+    expect(result[0].items).toEqual([]);
+  });
+
+  test('skips the item query when the capped invoice list is empty', async () => {
+    exec.enqueue({ rows: [] });
+    expect(await supplierInvoicesRepo.listAllWithItems(testDb)).toEqual([]);
+    expect(exec.calls).toHaveLength(1);
+  });
+});
+
 describe('findItemsForInvoice', () => {
   test('filters by invoice_id and maps rows', async () => {
     exec.enqueue({ rows: [itemRow()] });

--- a/server/test/routes/mcp.test.ts
+++ b/server/test/routes/mcp.test.ts
@@ -49,8 +49,7 @@ const clientsOrdersListAllItemsMock = mock();
 const invoicesListAllWithItemsMock = mock();
 const suppliersListAllMock = mock();
 const suppliersListOptionsMock = mock();
-const supplierInvoicesListAllMock = mock();
-const supplierInvoicesListAllItemsMock = mock();
+const supplierInvoicesListAllWithItemsMock = mock();
 const supplierOrdersListAllMock = mock();
 const supplierOrdersListAllItemsMock = mock();
 const supplierQuotesListAllMock = mock();
@@ -138,8 +137,7 @@ beforeAll(async () => {
   }));
   mock.module('../../repositories/supplierInvoicesRepo.ts', () => ({
     ...supplierInvoicesRepoSnap,
-    listAll: supplierInvoicesListAllMock,
-    listAllItems: supplierInvoicesListAllItemsMock,
+    listAllWithItems: supplierInvoicesListAllWithItemsMock,
   }));
   mock.module('../../repositories/supplierOrdersRepo.ts', () => ({
     ...supplierOrdersRepoSnap,
@@ -230,8 +228,7 @@ beforeEach(async () => {
     invoicesListAllWithItemsMock,
     suppliersListAllMock,
     suppliersListOptionsMock,
-    supplierInvoicesListAllMock,
-    supplierInvoicesListAllItemsMock,
+    supplierInvoicesListAllWithItemsMock,
     supplierOrdersListAllMock,
     supplierOrdersListAllItemsMock,
     supplierQuotesListAllMock,
@@ -269,8 +266,7 @@ beforeEach(async () => {
   invoicesListAllWithItemsMock.mockResolvedValue([]);
   suppliersListAllMock.mockResolvedValue([]);
   suppliersListOptionsMock.mockResolvedValue([]);
-  supplierInvoicesListAllMock.mockResolvedValue([]);
-  supplierInvoicesListAllItemsMock.mockResolvedValue([]);
+  supplierInvoicesListAllWithItemsMock.mockResolvedValue([]);
   supplierOrdersListAllMock.mockResolvedValue([]);
   supplierOrdersListAllItemsMock.mockResolvedValue([]);
   supplierQuotesListAllMock.mockResolvedValue([]);
@@ -612,8 +608,9 @@ describe('/api/mcp', () => {
     supplierOrdersListAllMock.mockResolvedValue([{ id: 'sord-1', supplierId: 's1' }]);
     supplierOrdersListAllItemsMock.mockResolvedValue([{ id: 'sordi-1', orderId: 'sord-1' }]);
     invoicesListAllWithItemsMock.mockResolvedValue([{ id: 'inv-1', items: [{ id: 'invi-1' }] }]);
-    supplierInvoicesListAllMock.mockResolvedValue([{ id: 'sinv-1', supplierId: 's1' }]);
-    supplierInvoicesListAllItemsMock.mockResolvedValue([{ id: 'sinvi-1', invoiceId: 'sinv-1' }]);
+    supplierInvoicesListAllWithItemsMock.mockResolvedValue([
+      { id: 'sinv-1', supplierId: 's1', items: [{ id: 'sinvi-1', invoiceId: 'sinv-1' }] },
+    ]);
 
     const quotesRes = await rpc({
       jsonrpc: '2.0',

--- a/server/test/routes/supplier-invoices.test.ts
+++ b/server/test/routes/supplier-invoices.test.ts
@@ -33,6 +33,7 @@ const getRolePermissionsMock = mock();
 
 const listAllMock = mock();
 const listAllItemsMock = mock();
+const listAllWithItemsMock = mock();
 const findInvoiceForLinkedSaleMock = mock();
 const maxSequenceForYearMock = mock();
 const createMock = mock();
@@ -76,6 +77,7 @@ beforeAll(async () => {
     ...supplierInvoicesRepoSnap,
     listAll: listAllMock,
     listAllItems: listAllItemsMock,
+    listAllWithItems: listAllWithItemsMock,
     findInvoiceForLinkedSale: findInvoiceForLinkedSaleMock,
     maxSequenceForYear: maxSequenceForYearMock,
     create: createMock,
@@ -192,6 +194,7 @@ const allMocks = [
   getRolePermissionsMock,
   listAllMock,
   listAllItemsMock,
+  listAllWithItemsMock,
   findInvoiceForLinkedSaleMock,
   maxSequenceForYearMock,
   createMock,
@@ -241,8 +244,7 @@ const authHeader = () => ({ authorization: `Bearer ${signToken({ userId: 'u1' })
 
 describe('GET /api/supplier-invoices', () => {
   test('200 returns list with grouped items', async () => {
-    listAllMock.mockResolvedValue([SAMPLE_INVOICE]);
-    listAllItemsMock.mockResolvedValue([SAMPLE_ITEM]);
+    listAllWithItemsMock.mockResolvedValue([{ ...SAMPLE_INVOICE, items: [SAMPLE_ITEM] }]);
 
     const res = await testApp.inject({
       method: 'GET',
@@ -255,11 +257,13 @@ describe('GET /api/supplier-invoices', () => {
     expect(body).toHaveLength(1);
     expect(body[0].id).toBe('SINV-2025-0001');
     expect(body[0].items).toHaveLength(1);
+    expect(listAllWithItemsMock).toHaveBeenCalledTimes(1);
+    expect(listAllMock).not.toHaveBeenCalled();
+    expect(listAllItemsMock).not.toHaveBeenCalled();
   });
 
   test('200 invoice without items has empty array', async () => {
-    listAllMock.mockResolvedValue([SAMPLE_INVOICE]);
-    listAllItemsMock.mockResolvedValue([]);
+    listAllWithItemsMock.mockResolvedValue([{ ...SAMPLE_INVOICE, items: [] }]);
 
     const res = await testApp.inject({
       method: 'GET',


### PR DESCRIPTION
## Summary
- Stops GET `/api/supplier-invoices` and MCP `praetor_list_invoices` from loading every `supplier_invoice_items` row.
- Adds `supplierInvoicesRepo.listAllWithItems`, matching the existing client-invoices pattern: load the capped invoice list, then fetch items only for those invoice ids.
- Adds repository and route/MCP regression coverage for the bounded query and grouping behavior.

## Changes
- `server/repositories/supplierInvoicesRepo.ts`: `listItemsForInvoices` + `listAllWithItems`
- `server/routes/supplier-invoices.ts` and `server/routes/mcp.ts`: use `listAllWithItems`
- Focused unit tests for repo, route, and MCP list paths

## Testing
- `bun test ./test/repositories/supplierInvoicesRepo.test.ts ./test/routes/supplier-invoices.test.ts ./test/routes/mcp.test.ts` (with `NODE_ENV=test`)
- 3 consecutive clean iterative review/simplify passes (reuse, efficiency, quality/bugs)
- Docs unchanged: response shape and API contract are the same

## Risks / Rollout
- Low risk. Behavior preserved for returned invoices; only reduces DB/memory work for historical items outside the invoice list cap.

## Issues
Issue: Not linked (DeepSec finding `praetor-other-unbounded-query-17e6941308`)