### PR TITLE
offers(bug): allow clearing nullable deliveryDate on update

### DIFF
--- a/server/repositories/clientOffersRepo.ts
+++ b/server/repositories/clientOffersRepo.ts
@@ -413,9 +413,7 @@ export const update = async (
       status: sql`COALESCE(${patch.status ?? null}, ${customerOffers.status})`,
       // Direct write (not COALESCE) so an explicit null clears the date; `undefined` keeps it.
       deliveryDate:
-        patch.deliveryDate === undefined
-          ? sql`${customerOffers.deliveryDate}`
-          : patch.deliveryDate,
+        patch.deliveryDate === undefined ? sql`${customerOffers.deliveryDate}` : patch.deliveryDate,
       expirationDate: sql`COALESCE(${patch.expirationDate ?? null}::date, ${customerOffers.expirationDate})`,
       notes: sql`COALESCE(${patch.notes ?? null}, ${customerOffers.notes})`,
       updatedAt: sql`CURRENT_TIMESTAMP`,

--- a/server/repositories/clientOffersRepo.ts
+++ b/server/repositories/clientOffersRepo.ts
@@ -411,7 +411,11 @@ export const update = async (
       discount: sql`COALESCE(${numericForDb(patch.discount) ?? null}::numeric, ${customerOffers.discount})`,
       discountType: sql`COALESCE(${patch.discountType ?? null}, ${customerOffers.discountType})`,
       status: sql`COALESCE(${patch.status ?? null}, ${customerOffers.status})`,
-      deliveryDate: sql`COALESCE(${patch.deliveryDate ?? null}::date, ${customerOffers.deliveryDate})`,
+      // Direct write (not COALESCE) so an explicit null clears the date; `undefined` keeps it.
+      deliveryDate:
+        patch.deliveryDate === undefined
+          ? sql`${customerOffers.deliveryDate}`
+          : patch.deliveryDate,
       expirationDate: sql`COALESCE(${patch.expirationDate ?? null}::date, ${customerOffers.expirationDate})`,
       notes: sql`COALESCE(${patch.notes ?? null}, ${customerOffers.notes})`,
       updatedAt: sql`CURRENT_TIMESTAMP`,

--- a/server/routes/client-offers.ts
+++ b/server/routes/client-offers.ts
@@ -1456,6 +1456,13 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
             !lockedOffer.deliveryDate &&
             !deliveryDateValue;
           const automaticDeliveryDate = shouldStampDeliveryDate ? todayLocalDateOnly() : undefined;
+          // When the client omits deliveryDate, leave it undefined so the repo keeps the column.
+          // When it sends null, still allow the draft→sent auto-stamp (same as create); otherwise
+          // write the explicit null so COALESCE can no longer trap clears on ordinary updates.
+          const resolvedDeliveryDate =
+            deliveryDate !== undefined
+              ? ((deliveryDateValue as string | null) ?? automaticDeliveryDate ?? null)
+              : automaticDeliveryDate;
           const supplierRevisionStates = revisionIntent
             ? await lockSupplierRevisionStates(
                 await sourcedSupplierQuoteIds(
@@ -1491,10 +1498,9 @@ export default async function (fastify: FastifyInstance, _opts: unknown) {
                     discount: (discountValue as number | null | undefined) ?? null,
                     discountType: discountTypeValue ?? null,
                     status: targetStatus,
-                    deliveryDate:
-                      (deliveryDateValue as string | null | undefined) ??
-                      automaticDeliveryDate ??
-                      null,
+                    ...(resolvedDeliveryDate !== undefined
+                      ? { deliveryDate: resolvedDeliveryDate }
+                      : {}),
                     expirationDate: (expirationDateValue as string | null | undefined) ?? null,
                     notes: (notes as string | null | undefined) ?? null,
                   },

--- a/server/test/repositories/clientOffersRepo.test.ts
+++ b/server/test/repositories/clientOffersRepo.test.ts
@@ -248,7 +248,7 @@ describe('create', () => {
 });
 
 describe('update', () => {
-  test('binds 9 patch values via COALESCE, WHERE id last - no id in SET', async () => {
+  test('binds patch values via COALESCE, WHERE id last - no id in SET', async () => {
     exec.enqueue({ rows: [offerRow()] });
     await clientOffersRepo.update('co-1', { status: 'accepted' }, testDb);
     const sql = exec.calls[0].sql;
@@ -257,10 +257,28 @@ describe('update', () => {
     expect(sql).toContain('CURRENT_TIMESTAMP');
     // The SET clause must NOT touch the primary key column (issue #621).
     expect(sql).not.toMatch(/set[^"]*"id"\s*=/i);
-    expect(sql).toContain('"id" = $10');
-    expect(exec.calls[0].params).toHaveLength(10);
+    // Omitted deliveryDate keeps the column (no bound param); 8 COALESCE/direct args + WHERE id.
+    expect(sql).toContain('"id" = $9');
+    expect(exec.calls[0].params).toHaveLength(9);
     expect(exec.calls[0].params[5]).toBe('accepted'); // status
-    expect(exec.calls[0].params[9]).toBe('co-1'); // where id
+    expect(exec.calls[0].params[8]).toBe('co-1'); // where id
+  });
+
+  test('clears deliveryDate when the patch explicitly supplies null', async () => {
+    exec.enqueue({ rows: [offerRow()] });
+    await clientOffersRepo.update('co-1', { deliveryDate: null }, testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    expect(sql).not.toMatch(/"delivery_date"\s*=\s*coalesce/);
+    expect(exec.calls[0].params).toContain(null);
+    expect(exec.calls[0].params).toContain('co-1');
+  });
+
+  test('keeps deliveryDate when the patch omits it', async () => {
+    exec.enqueue({ rows: [offerRow()] });
+    await clientOffersRepo.update('co-1', { status: 'sent' }, testDb);
+    const sql = exec.calls[0].sql.toLowerCase();
+    const setClause = sql.slice(sql.indexOf(' set ') + 5, sql.indexOf(' where '));
+    expect(setClause).toMatch(/"delivery_date"\s*=\s*"customer_offers"\."delivery_date"/);
   });
 
   test('returns null when no row updated', async () => {

--- a/server/test/routes/client-offers.test.ts
+++ b/server/test/routes/client-offers.test.ts
@@ -683,6 +683,48 @@ describe('client-offer transactional update guards', () => {
   });
 });
 
+describe('PUT /api/sales/client-offers/:id deliveryDate clear', () => {
+  test('200 clears deliveryDate when the body explicitly sends null', async () => {
+    coFindExistingMock.mockResolvedValue(gate({ deliveryDate: '2026-05-14' }));
+    coUpdateMock.mockResolvedValue(updatedOffer({ deliveryDate: null }));
+
+    const res = await putOffer({ deliveryDate: null });
+
+    expect(res.statusCode).toBe(200);
+    expect(coUpdateMock).toHaveBeenCalledWith(
+      'off-1',
+      expect.objectContaining({ deliveryDate: null }),
+      expect.anything(),
+    );
+  });
+
+  test('omits deliveryDate from the patch when the body does not send it', async () => {
+    coFindExistingMock.mockResolvedValue(gate({ deliveryDate: '2026-05-14' }));
+    coUpdateMock.mockResolvedValue(updatedOffer({ notes: 'edited', deliveryDate: '2026-05-14' }));
+
+    const res = await putOffer({ notes: 'edited' });
+
+    expect(res.statusCode).toBe(200);
+    const patch = coUpdateMock.mock.calls[0]?.[1] as Record<string, unknown>;
+    expect(patch).not.toHaveProperty('deliveryDate');
+  });
+
+  test('draft→sent still auto-stamps today when deliveryDate is explicitly null', async () => {
+    coFindExistingMock.mockResolvedValue(gate({ status: 'draft', deliveryDate: null }));
+    coLockExistingByIdMock.mockResolvedValue(gate({ status: 'draft', deliveryDate: null }));
+    coUpdateMock.mockResolvedValue(updatedOffer({ status: 'sent' }));
+
+    const res = await putOffer({ status: 'sent', deliveryDate: null });
+
+    expect(res.statusCode).toBe(200);
+    expect(coUpdateMock).toHaveBeenCalledWith(
+      'off-1',
+      expect.objectContaining({ status: 'sent', deliveryDate: expect.any(String) }),
+      expect.anything(),
+    );
+  });
+});
+
 describe('PUT /api/sales/client-offers/:id expired rules (issue #779)', () => {
   test('200 extends an expired sent offer via its expiration date and derives effectiveStatus', async () => {
     coFindExistingMock.mockResolvedValue(gate({ status: 'sent', expirationDate: '2000-01-01' }));


### PR DESCRIPTION
## Summary
- Fixes client offer updates so an explicit `deliveryDate: null` clears the stored date instead of being trapped by `COALESCE`.
- Route patches omit `deliveryDate` when unset (keep existing) while preserving draft→sent auto-stamping.

## Changes
- `clientOffersRepo.update` writes `deliveryDate` directly when present (`undefined` keeps the column).
- Update route resolves omit vs clear vs auto-stamp without collapsing null through `??`.
- Adds repo and route regression tests for clear, omit, and send-stamp behavior.

## Testing
- `bun test ./test/repositories/clientOffersRepo.test.ts ./test/routes/client-offers.test.ts ./test/routes/client-offers-versions.test.ts` (141 pass)
- `bun run test:react-doctor` score unchanged at 75/100

## Risks / Rollout
- Low risk. Scoped to client-offer update nullability; draft→sent auto-stamp behavior preserved.

## Issues
Issue: Not linked (DeepSec finding `praetor-other-logic-bug-650d7bd7e9`)