### PR TITLE
fix(tasks): chunk hours batch requests above 200 projects

### DIFF
--- a/services/api/tasks.ts
+++ b/services/api/tasks.ts
@@ -77,9 +77,7 @@ export const tasksApi = {
     if (projectIds.length === 0) return {};
 
     const chunks = chunkProjectIds(projectIds, HOURS_BATCH_MAX_PROJECT_IDS);
-    const settled = await Promise.allSettled(
-      chunks.map((chunk) => fetchHoursChunk(chunk, signal)),
-    );
+    const settled = await Promise.allSettled(chunks.map((chunk) => fetchHoursChunk(chunk, signal)));
 
     const merged: Record<string, Record<string, number>> = {};
     let successCount = 0;

--- a/services/api/tasks.ts
+++ b/services/api/tasks.ts
@@ -2,6 +2,23 @@ import type { ProjectTask } from '../../types';
 import { fetchApi } from './client';
 import { normalizeTask } from './normalizers';
 
+/** Must stay in sync with `GET /tasks/hours/batch` (`projectIds cannot exceed 200 IDs`). */
+export const HOURS_BATCH_MAX_PROJECT_IDS = 200;
+
+const chunkProjectIds = (projectIds: string[], size: number): string[][] => {
+  const chunks: string[][] = [];
+  for (let i = 0; i < projectIds.length; i += size) {
+    chunks.push(projectIds.slice(i, i + size));
+  }
+  return chunks;
+};
+
+const fetchHoursChunk = (projectIds: string[], signal?: AbortSignal) =>
+  fetchApi<Record<string, Record<string, number>>>(
+    `/tasks/hours/batch?projectIds=${projectIds.map(encodeURIComponent).join(',')}`,
+    { signal },
+  );
+
 export const tasksApi = {
   list: (): Promise<ProjectTask[]> =>
     fetchApi<ProjectTask[]>('/tasks').then((tasks) => tasks.map(normalizeTask)),
@@ -48,14 +65,51 @@ export const tasksApi = {
   getHours: (projectId: string, signal?: AbortSignal): Promise<Record<string, number>> =>
     fetchApi(`/tasks/hours?projectId=${encodeURIComponent(projectId)}`, { signal }),
 
-  /** Per-project maps of totals keyed by stable task id (not task name). */
-  getHoursForProjects: (
+  /**
+   * Per-project maps of totals keyed by stable task id (not task name).
+   * Automatically chunks requests to stay within the backend's 200-ID batch limit.
+   * On partial chunk failure, merges successful chunks and only throws when every chunk fails.
+   */
+  getHoursForProjects: async (
     projectIds: string[],
     signal?: AbortSignal,
-  ): Promise<Record<string, Record<string, number>>> =>
-    fetchApi(`/tasks/hours/batch?projectIds=${projectIds.map(encodeURIComponent).join(',')}`, {
-      signal,
-    }),
+  ): Promise<Record<string, Record<string, number>>> => {
+    if (projectIds.length === 0) return {};
+
+    const chunks = chunkProjectIds(projectIds, HOURS_BATCH_MAX_PROJECT_IDS);
+    const settled = await Promise.allSettled(
+      chunks.map((chunk) => fetchHoursChunk(chunk, signal)),
+    );
+
+    const merged: Record<string, Record<string, number>> = {};
+    let successCount = 0;
+    let firstError: unknown;
+
+    for (const result of settled) {
+      if (result.status === 'fulfilled') {
+        successCount += 1;
+        Object.assign(merged, result.value);
+        continue;
+      }
+      if (signal?.aborted) throw result.reason;
+      firstError ??= result.reason;
+    }
+
+    if (successCount === 0) {
+      throw firstError instanceof Error
+        ? firstError
+        : new Error('Failed to load task hours for projects');
+    }
+
+    if (firstError) {
+      console.warn(
+        'Partial failure loading task hours; returning data from successful batches only',
+        firstError,
+      );
+    }
+
+    return merged;
+  },
 
   getUsers: (id: string, signal?: AbortSignal): Promise<string[]> =>
     fetchApi(`/tasks/${id}/users`, { signal }),

--- a/test/services/tasksApi.test.ts
+++ b/test/services/tasksApi.test.ts
@@ -1,0 +1,137 @@
+import { afterAll, beforeEach, describe, expect, mock, test } from 'bun:test';
+import { buildResponse } from '../helpers/fetchMock';
+
+const respondWith = (body: unknown, status = 200) => buildResponse({ status, json: () => body });
+
+const originalFetch = globalThis.fetch;
+const fetchMock = mock(
+  async (_input: unknown, _init?: unknown): Promise<unknown> => respondWith({}),
+);
+globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+const { HOURS_BATCH_MAX_PROJECT_IDS, tasksApi } = await import('../../services/api/tasks');
+
+beforeEach(() => {
+  fetchMock.mockReset();
+  fetchMock.mockImplementation(async () => respondWith({}));
+});
+
+afterAll(() => {
+  globalThis.fetch = originalFetch;
+});
+
+const projectIds = (count: number) => Array.from({ length: count }, (_, i) => `p-${i + 1}`);
+
+const idsFromUrl = (url: string): string[] => {
+  const match = String(url).match(/projectIds=([^&]*)/);
+  if (!match?.[1]) return [];
+  return match[1].split(',').map(decodeURIComponent).filter(Boolean);
+};
+
+describe('tasksApi.getHoursForProjects', () => {
+  test('returns {} without calling the API when projectIds is empty', async () => {
+    const result = await tasksApi.getHoursForProjects([]);
+
+    expect(result).toEqual({});
+    expect(fetchMock.mock.calls).toHaveLength(0);
+  });
+
+  test('issues a single batch request when project count is within the limit', async () => {
+    const ids = projectIds(3);
+    fetchMock.mockImplementation(async (input) => {
+      const requested = idsFromUrl(String(input));
+      return respondWith({
+        [requested[0]]: { t1: 1 },
+        [requested[1]]: { t2: 2 },
+        [requested[2]]: { t3: 3 },
+      });
+    });
+
+    const result = await tasksApi.getHoursForProjects(ids);
+
+    expect(fetchMock.mock.calls).toHaveLength(1);
+    expect(idsFromUrl(String(fetchMock.mock.calls[0][0]))).toEqual(ids);
+    expect(result).toEqual({
+      'p-1': { t1: 1 },
+      'p-2': { t2: 2 },
+      'p-3': { t3: 3 },
+    });
+  });
+
+  test('chunks requests at the backend limit and merges hour maps', async () => {
+    const ids = projectIds(HOURS_BATCH_MAX_PROJECT_IDS + 50);
+    fetchMock.mockImplementation(async (input) => {
+      const requested = idsFromUrl(String(input));
+      expect(requested.length).toBeLessThanOrEqual(HOURS_BATCH_MAX_PROJECT_IDS);
+      const body: Record<string, Record<string, number>> = {};
+      for (const id of requested) {
+        body[id] = { [`task-${id}`]: 1 };
+      }
+      return respondWith(body);
+    });
+
+    const result = await tasksApi.getHoursForProjects(ids);
+
+    expect(fetchMock.mock.calls).toHaveLength(2);
+    expect(idsFromUrl(String(fetchMock.mock.calls[0][0]))).toHaveLength(
+      HOURS_BATCH_MAX_PROJECT_IDS,
+    );
+    expect(idsFromUrl(String(fetchMock.mock.calls[1][0]))).toHaveLength(50);
+    expect(Object.keys(result)).toHaveLength(ids.length);
+    expect(result['p-1']).toEqual({ 'task-p-1': 1 });
+    expect(result['p-250']).toEqual({ 'task-p-250': 1 });
+  });
+
+  test('returns merged data when some chunks succeed and only warns on partial failure', async () => {
+    const ids = projectIds(HOURS_BATCH_MAX_PROJECT_IDS + 1);
+    const warnSpy = mock(() => {});
+    const originalWarn = console.warn;
+    console.warn = warnSpy as unknown as typeof console.warn;
+
+    try {
+      fetchMock.mockImplementation(async (input) => {
+        const requested = idsFromUrl(String(input));
+        if (requested.length === 1) {
+          return respondWith({ error: 'chunk failed' }, 400);
+        }
+        const body: Record<string, Record<string, number>> = {};
+        for (const id of requested) {
+          body[id] = { ok: 4 };
+        }
+        return respondWith(body);
+      });
+
+      const result = await tasksApi.getHoursForProjects(ids);
+
+      expect(Object.keys(result)).toHaveLength(HOURS_BATCH_MAX_PROJECT_IDS);
+      expect(result['p-1']).toEqual({ ok: 4 });
+      expect(result[`p-${HOURS_BATCH_MAX_PROJECT_IDS + 1}`]).toBeUndefined();
+      expect(warnSpy.mock.calls.length).toBeGreaterThan(0);
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+
+  test('throws when every chunk fails', async () => {
+    const ids = projectIds(HOURS_BATCH_MAX_PROJECT_IDS + 1);
+    fetchMock.mockImplementation(async () => respondWith({ error: 'nope' }, 400));
+
+    await expect(tasksApi.getHoursForProjects(ids)).rejects.toThrow();
+  });
+
+  test('rethrows when the request is aborted', async () => {
+    const ids = projectIds(HOURS_BATCH_MAX_PROJECT_IDS + 1);
+    const controller = new AbortController();
+    controller.abort();
+
+    fetchMock.mockImplementation(async (_input, init) => {
+      const signal = (init as { signal?: AbortSignal } | undefined)?.signal;
+      if (signal?.aborted) {
+        throw new DOMException('The operation was aborted.', 'AbortError');
+      }
+      return respondWith({});
+    });
+
+    await expect(tasksApi.getHoursForProjects(ids, controller.signal)).rejects.toThrow(/aborted/i);
+  });
+});


### PR DESCRIPTION
## Summary
- `tasksApi.getHoursForProjects` now chunks project IDs into batches of ≤200 to match the backend `/tasks/hours/batch` limit.
- Successful chunk maps are merged; the call only throws when every chunk fails (partial failures warn and return available data).
- Fixes DeepSec finding `praetor-other-scalability-bug-87ac1f171b` where TasksView (and ProjectsView) lost all progress cells when >200 projects were visible.

## Changes
- Update `services/api/tasks.ts` with batching, merge, and abort-aware error handling.
- Add `test/services/tasksApi.test.ts` covering empty input, single batch, multi-chunk merge, partial failure, total failure, and abort.

## Testing
- `bun test test/services/tasksApi.test.ts` (6 pass)
- `bun run test:react-doctor` score unchanged at 75/100 (no React component changes)
- Docs: unchanged (internal API client behavior; no user-facing docs impact)

## Risks / Rollout
- Low risk. Callers keep the same API; only request sizing and partial-failure behavior change.
- Partial chunk failures now return partial hour maps with a console warning instead of failing the whole load.

## Issues
Issue: Not linked (DeepSec finding `87ac1f171b`)