### PR TITLE
auth(ldap): fix atomic auto-provision role assignment

### DIFF
--- a/server/services/external-auth.ts
+++ b/server/services/external-auth.ts
@@ -162,9 +162,6 @@ const writeExternalRoleIdsTx = async (
   await userAssignmentsRepo.syncTopManagerAssignmentsForUser(userId, tx);
 };
 
-const writeExternalRoleIds = (userId: string, roleIds: string[]): Promise<void> =>
-  withDbTransaction((tx) => writeExternalRoleIdsTx(userId, roleIds, tx));
-
 const syncExternalProfileTx = async (
   userId: string,
   input: Pick<ResolveExternalIdentityInput, 'name' | 'email'>,
@@ -189,9 +186,13 @@ const syncExternalProfileTx = async (
 const applyExternalRoleIdsForUser = async (
   userId: string,
   roleIds: string[],
+  exec: DbExecutor = db,
 ): Promise<string[]> => {
   const mappedRoleIds = await filterExistingRoleIds(roleIds);
-  await writeExternalRoleIds(userId, mappedRoleIds);
+  // runAtomically reuses the caller's transaction when one is passed (so LDAP auto-provision
+  // can create the user, settings row, and user_roles assignment atomically), or opens its own
+  // when called standalone — `exec` defaults to `db`, so existing callers are unaffected.
+  await runAtomically(exec, (tx) => writeExternalRoleIdsTx(userId, mappedRoleIds, tx));
   return mappedRoleIds;
 };
 
@@ -199,8 +200,9 @@ export const applyExternalRolesForUser = (
   userId: string,
   groups: string[],
   mappings: ExternalRoleMapping[],
+  exec: DbExecutor = db,
 ): Promise<string[]> =>
-  applyExternalRoleIdsForUser(userId, mapExternalGroupsToRoleIds(groups, mappings));
+  applyExternalRoleIdsForUser(userId, mapExternalGroupsToRoleIds(groups, mappings), exec);
 
 // True when the user's external groups produce zero usable roles AND the admin has at
 // least one role mapping configured — i.e., the admin's stated intent is "users should

--- a/server/services/ldap.ts
+++ b/server/services/ldap.ts
@@ -277,6 +277,60 @@ const syncDirectoryProfileTx = async (
 const syncDirectoryProfile = (userId: string, profile: DirectoryProfile): Promise<void> =>
   withDbTransaction((tx) => syncDirectoryProfileTx(userId, profile, tx));
 
+// LDAP auto-provision must create the users row, settings row, and user_roles assignment in
+// one transaction. createUser alone does not write user_roles; a crash/error between that
+// insert and applyExternalRolesForUser would leave a stranded LDAP user that later logins
+// intentionally skip (bootstrap-only role mapping) and that auth middleware rejects via
+// user_roles membership checks.
+type NewLdapUserProvision = {
+  id: string;
+  name: string;
+  firstName?: string | null;
+  lastName?: string | null;
+  username: string;
+  primaryRole: string;
+  email?: string | null;
+  groups: string[];
+  roleMappings: ExternalRoleMapping[];
+};
+
+const provisionNewLdapUser = async (input: NewLdapUserProvision): Promise<void> => {
+  await withDbTransaction(async (tx) => {
+    await usersRepo.createUser(
+      {
+        id: input.id,
+        name: input.name,
+        firstName: input.firstName?.trim() || null,
+        lastName: input.lastName?.trim() || null,
+        username: input.username,
+        passwordHash: usersRepo.EXTERNAL_PLACEHOLDER_PASSWORD_HASH,
+        role: input.primaryRole,
+        avatarInitials: computeAvatarInitials(input.name),
+        authMethod: 'ldap',
+        authProviderId: null,
+      },
+      tx,
+    );
+    await settingsRepo.upsertForUser(
+      input.id,
+      {
+        fullName: input.name,
+        email: input.email?.trim() || '',
+        language: null,
+      },
+      tx,
+    );
+    await applyExternalRolesForUser(input.id, input.groups, input.roleMappings, tx);
+  });
+};
+
+// Repair path for LDAP users stranded without a user_roles row (e.g. historical crash between
+// createUser and role write). ON CONFLICT DO NOTHING keeps this a no-op when membership already
+// exists, so every existing-user login/sync can cheaply enforce the invariant without clobbering
+// additional admin-assigned roles.
+const ensurePrimaryRoleMembership = (userId: string, primaryRoleId: string): Promise<void> =>
+  usersRepo.addUserRole(userId, primaryRoleId);
+
 const isUniqueViolationError = (err: unknown): boolean => {
   if (!err || typeof err !== 'object') return false;
   const code = (err as { code?: unknown }).code;
@@ -504,6 +558,9 @@ class LDAPService {
           result.groups,
         );
       }
+      // Repair stranded users that have users.role but no matching user_roles row (e.g.
+      // historical non-atomic auto-provision). Does not replace or remove other roles.
+      await ensurePrimaryRoleMembership(existingByCanonical.id, existingByCanonical.role);
       await syncDirectoryProfile(existingByCanonical.id, {
         name: result.displayName,
         firstName: result.firstName,
@@ -544,17 +601,16 @@ class LDAPService {
     const primaryRole = filteredRoleIds[0];
 
     try {
-      await usersRepo.createUser({
+      await provisionNewLdapUser({
         id,
         name,
-        firstName: result.firstName?.trim() || null,
-        lastName: result.lastName?.trim() || null,
+        firstName: result.firstName,
+        lastName: result.lastName,
         username: canonicalUsername,
-        passwordHash: usersRepo.EXTERNAL_PLACEHOLDER_PASSWORD_HASH,
-        role: primaryRole,
-        avatarInitials: computeAvatarInitials(name),
-        authMethod: 'ldap',
-        authProviderId: null,
+        primaryRole,
+        email: result.email,
+        groups: result.groups,
+        roleMappings,
       });
     } catch (err) {
       if (isUniqueViolationError(err)) {
@@ -570,6 +626,7 @@ class LDAPService {
           // is acceptable; the bootstrap-only invariant only forbids re-applying mapping
           // for users that already existed BEFORE this provisioning request started.
           await applyExternalRolesForUserIfMatched(racedUser.id, result.groups, roleMappings);
+          await ensurePrimaryRoleMembership(racedUser.id, racedUser.role);
           await syncDirectoryProfile(racedUser.id, {
             name: result.displayName,
             firstName: result.firstName,
@@ -592,12 +649,6 @@ class LDAPService {
       throw err;
     }
 
-    await settingsRepo.upsertForUser(id, {
-      fullName: name,
-      email: result.email?.trim() || '',
-      language: null,
-    });
-    await applyExternalRolesForUser(id, result.groups, roleMappings);
     return { authenticated: true, userId: id, created: true, canonicalUsername };
   }
 
@@ -891,6 +942,7 @@ class LDAPService {
               'LDAP sync skipped role-mapping diagnostic for user: group search failed',
             );
             // Still refresh the display name — that bit doesn't depend on group state.
+            await ensurePrimaryRoleMembership(existing.id, existing.role);
             await syncDirectoryProfile(existing.id, {
               name: profile.name,
               firstName: profile.firstName,
@@ -902,6 +954,7 @@ class LDAPService {
           }
           // Refresh by id so pre-migration mixed-case usernames and provider email claims
           // both land on the already matched row.
+          await ensurePrimaryRoleMembership(existing.id, existing.role);
           await syncDirectoryProfile(existing.id, {
             name: profile.name,
             firstName: profile.firstName,
@@ -941,26 +994,17 @@ class LDAPService {
           }
           const roleIds = mapExternalGroupsToRoleIds(groups, roleMappings);
           const id = generatePrefixedId('u');
-          await usersRepo.createUser({
+          await provisionNewLdapUser({
             id,
             name,
-            firstName: profile.firstName?.trim() || null,
-            lastName: profile.lastName?.trim() || null,
+            firstName: profile.firstName,
+            lastName: profile.lastName,
             username,
-            passwordHash: usersRepo.EXTERNAL_PLACEHOLDER_PASSWORD_HASH,
-            role: roleIds[0],
-            avatarInitials: computeAvatarInitials(name),
-            authMethod: 'ldap',
-            authProviderId: null,
+            primaryRole: roleIds[0],
+            email,
+            groups,
+            roleMappings,
           });
-          await Promise.all([
-            settingsRepo.upsertForUser(id, {
-              fullName: name,
-              email: email?.trim() || '',
-              language: null,
-            }),
-            applyExternalRolesForUser(id, groups, roleMappings),
-          ]);
           createdCount++;
         }
       }

--- a/server/services/ldap.ts
+++ b/server/services/ldap.ts
@@ -274,9 +274,6 @@ const syncDirectoryProfileTx = async (
   );
 };
 
-const syncDirectoryProfile = (userId: string, profile: DirectoryProfile): Promise<void> =>
-  withDbTransaction((tx) => syncDirectoryProfileTx(userId, profile, tx));
-
 // LDAP auto-provision must create the users row, settings row, and user_roles assignment in
 // one transaction. createUser alone does not write user_roles; a crash/error between that
 // insert and applyExternalRolesForUser would leave a stranded LDAP user that later logins
@@ -327,9 +324,18 @@ const provisionNewLdapUser = async (input: NewLdapUserProvision): Promise<void> 
 // Repair path for LDAP users stranded without a user_roles row (e.g. historical crash between
 // createUser and role write). ON CONFLICT DO NOTHING keeps this a no-op when membership already
 // exists, so every existing-user login/sync can cheaply enforce the invariant without clobbering
-// additional admin-assigned roles.
-const ensurePrimaryRoleMembership = (userId: string, primaryRoleId: string): Promise<void> =>
-  usersRepo.addUserRole(userId, primaryRoleId);
+// additional admin-assigned roles. Bundled with directory-profile refresh in one transaction so
+// a mid-flight failure does not leave the profile updated while the role repair is skipped.
+const refreshExistingLdapUser = async (
+  userId: string,
+  primaryRoleId: string,
+  profile: DirectoryProfile,
+): Promise<void> => {
+  await withDbTransaction(async (tx) => {
+    await usersRepo.addUserRole(userId, primaryRoleId, tx);
+    await syncDirectoryProfileTx(userId, profile, tx);
+  });
+};
 
 const isUniqueViolationError = (err: unknown): boolean => {
   if (!err || typeof err !== 'object') return false;
@@ -560,8 +566,7 @@ class LDAPService {
       }
       // Repair stranded users that have users.role but no matching user_roles row (e.g.
       // historical non-atomic auto-provision). Does not replace or remove other roles.
-      await ensurePrimaryRoleMembership(existingByCanonical.id, existingByCanonical.role);
-      await syncDirectoryProfile(existingByCanonical.id, {
+      await refreshExistingLdapUser(existingByCanonical.id, existingByCanonical.role, {
         name: result.displayName,
         firstName: result.firstName,
         lastName: result.lastName,
@@ -626,8 +631,7 @@ class LDAPService {
           // is acceptable; the bootstrap-only invariant only forbids re-applying mapping
           // for users that already existed BEFORE this provisioning request started.
           await applyExternalRolesForUserIfMatched(racedUser.id, result.groups, roleMappings);
-          await ensurePrimaryRoleMembership(racedUser.id, racedUser.role);
-          await syncDirectoryProfile(racedUser.id, {
+          await refreshExistingLdapUser(racedUser.id, racedUser.role, {
             name: result.displayName,
             firstName: result.firstName,
             lastName: result.lastName,
@@ -942,8 +946,7 @@ class LDAPService {
               'LDAP sync skipped role-mapping diagnostic for user: group search failed',
             );
             // Still refresh the display name — that bit doesn't depend on group state.
-            await ensurePrimaryRoleMembership(existing.id, existing.role);
-            await syncDirectoryProfile(existing.id, {
+            await refreshExistingLdapUser(existing.id, existing.role, {
               name: profile.name,
               firstName: profile.firstName,
               lastName: profile.lastName,
@@ -954,8 +957,7 @@ class LDAPService {
           }
           // Refresh by id so pre-migration mixed-case usernames and provider email claims
           // both land on the already matched row.
-          await ensurePrimaryRoleMembership(existing.id, existing.role);
-          await syncDirectoryProfile(existing.id, {
+          await refreshExistingLdapUser(existing.id, existing.role, {
             name: profile.name,
             firstName: profile.firstName,
             lastName: profile.lastName,

--- a/server/test/integration/ldap-sync.integration.test.ts
+++ b/server/test/integration/ldap-sync.integration.test.ts
@@ -115,7 +115,7 @@ describe.skipIf(SHOULD_SKIP)('LDAP integration: syncUsers()', () => {
     const result = await ldapService.syncUsers();
 
     expect(result).toEqual({ synced: 1, created: 1 });
-    expect(addUserRoleMock).toHaveBeenCalledWith('u1', 'user');
+    expect(addUserRoleMock).toHaveBeenCalledWith('u1', 'user', expect.anything());
     expect(updateDirectoryProfileMock).toHaveBeenCalledTimes(1);
     expect(updateDirectoryProfileMock).toHaveBeenCalledWith(
       'u1',

--- a/server/test/integration/ldap-sync.integration.test.ts
+++ b/server/test/integration/ldap-sync.integration.test.ts
@@ -28,6 +28,7 @@ describe.skipIf(SHOULD_SKIP)('LDAP integration: syncUsers()', () => {
   const updateDirectoryProfileMock = mock();
   const settingsUpsertForUserMock = mock();
   const createUserMock = mock();
+  const addUserRoleMock = mock();
   const { withDbTransactionMock, resetWithDbTransactionMock } = makeWithDbTransactionMock();
 
   let ldapService: LdapServiceShape;
@@ -51,6 +52,7 @@ describe.skipIf(SHOULD_SKIP)('LDAP integration: syncUsers()', () => {
       updateNameByUsername: updateNameByUsernameMock,
       updateDirectoryProfile: updateDirectoryProfileMock,
       createUser: createUserMock,
+      addUserRole: addUserRoleMock,
     }));
     ldapService = (await import('../../services/ldap.ts')).default as unknown as LdapServiceShape;
   });
@@ -70,9 +72,11 @@ describe.skipIf(SHOULD_SKIP)('LDAP integration: syncUsers()', () => {
     updateDirectoryProfileMock.mockReset();
     settingsUpsertForUserMock.mockReset();
     createUserMock.mockReset();
+    addUserRoleMock.mockReset();
 
     ldapRepoGetMock.mockResolvedValue(buildTestConfig({ autoProvisionAll: true }));
     findLoginUserByNormalizedUsernameMock.mockResolvedValue(null);
+    addUserRoleMock.mockResolvedValue(undefined);
     ldapService.invalidateConfig();
   });
 
@@ -103,12 +107,15 @@ describe.skipIf(SHOULD_SKIP)('LDAP integration: syncUsers()', () => {
 
   test('existing user: refreshes provider profile instead of createUser', async () => {
     findLoginUserByNormalizedUsernameMock.mockImplementation(async (username: string) =>
-      username === 'alice' ? { id: 'u1', username, name: 'Old Name' } : null,
+      username === 'alice'
+        ? { id: 'u1', username, name: 'Old Name', role: 'user', authMethod: 'ldap' }
+        : null,
     );
 
     const result = await ldapService.syncUsers();
 
     expect(result).toEqual({ synced: 1, created: 1 });
+    expect(addUserRoleMock).toHaveBeenCalledWith('u1', 'user');
     expect(updateDirectoryProfileMock).toHaveBeenCalledTimes(1);
     expect(updateDirectoryProfileMock).toHaveBeenCalledWith(
       'u1',

--- a/server/test/services/ldap.test.ts
+++ b/server/test/services/ldap.test.ts
@@ -1933,7 +1933,7 @@ describe('authenticateAndProvision', () => {
       created: false,
       canonicalUsername: 'alice',
     });
-    expect(addUserRoleMock).toHaveBeenCalledWith(LDAP_LOGIN_USER.id, 'manager');
+    expect(addUserRoleMock).toHaveBeenCalledWith(LDAP_LOGIN_USER.id, 'manager', TX_SENTINEL);
     expect(applyExternalRolesForUserMock).not.toHaveBeenCalled();
   });
 
@@ -1990,7 +1990,7 @@ describe('authenticateAndProvision', () => {
 
     await ldapService.syncUsers();
 
-    expect(addUserRoleMock).toHaveBeenCalledWith(LDAP_LOGIN_USER.id, 'manager');
+    expect(addUserRoleMock).toHaveBeenCalledWith(LDAP_LOGIN_USER.id, 'manager', TX_SENTINEL);
     expect(applyExternalRolesForUserMock).not.toHaveBeenCalled();
   });
 

--- a/server/test/services/ldap.test.ts
+++ b/server/test/services/ldap.test.ts
@@ -19,6 +19,7 @@ import ldapService from '../../services/ldap.ts';
 import * as realInitials from '../../utils/initials.ts';
 import * as realLogger from '../../utils/logger.ts';
 import * as realOrderIds from '../../utils/order-ids.ts';
+import { TX_SENTINEL } from '../helpers/txSentinel.ts';
 import { makeWithDbTransactionMock } from '../helpers/withDbTransactionMock.ts';
 
 // Snapshot real exports BEFORE the beforeAll fires (mock.module inside beforeAll is not hoisted).
@@ -38,6 +39,7 @@ const updateNameByUsernameMock = mock();
 const updateDirectoryProfileMock = mock();
 const settingsUpsertForUserMock = mock();
 const createUserMock = mock();
+const addUserRoleMock = mock();
 const applyExternalRolesForUserMock = mock();
 const applyExternalRolesForUserIfMatchedMock = mock();
 const externalGroupsYieldNoKnownRoleMock = mock();
@@ -164,6 +166,7 @@ beforeAll(() => {
     updateNameByUsername: updateNameByUsernameMock,
     updateDirectoryProfile: updateDirectoryProfileMock,
     createUser: createUserMock,
+    addUserRole: addUserRoleMock,
   }));
   mock.module('../../services/external-auth.ts', () => ({
     ...externalAuthSnapshot,
@@ -251,6 +254,7 @@ beforeEach(() => {
   updateDirectoryProfileMock.mockReset();
   settingsUpsertForUserMock.mockReset();
   createUserMock.mockReset();
+  addUserRoleMock.mockReset();
   applyExternalRolesForUserMock.mockReset();
   applyExternalRolesForUserIfMatchedMock.mockReset();
   externalGroupsYieldNoKnownRoleMock.mockReset();
@@ -266,6 +270,7 @@ beforeEach(() => {
   ldapRepoGetMock.mockResolvedValue(ENABLED_LDAP_CONFIG);
   applyExternalRolesForUserMock.mockResolvedValue(['user']);
   applyExternalRolesForUserIfMatchedMock.mockResolvedValue({ applied: false, roleIds: [] });
+  addUserRoleMock.mockResolvedValue(undefined);
   nextFixture = {};
   lastClientStats = null;
 });
@@ -968,6 +973,7 @@ describe('attribute mapping (name / surname / email)', () => {
     expect(result).toMatchObject({ authenticated: true, created: true });
     expect(createUserMock).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'Erin Stone', firstName: 'Erin', lastName: 'Stone' }),
+      TX_SENTINEL,
     );
   });
 
@@ -1152,18 +1158,21 @@ describe('syncUsers', () => {
     };
     findLoginUserByNormalizedUsernameMock.mockResolvedValue(null);
     const result = await ldapService.syncUsers();
-    expect(createUserMock).toHaveBeenCalledWith({
-      id: 'u_test_id',
-      name: 'Carol',
-      firstName: null,
-      lastName: null,
-      username: 'carol',
-      passwordHash: realUsersRepo.LDAP_PLACEHOLDER_PASSWORD_HASH,
-      role: 'user',
-      avatarInitials: 'CA',
-      authMethod: 'ldap',
-      authProviderId: null,
-    });
+    expect(createUserMock).toHaveBeenCalledWith(
+      {
+        id: 'u_test_id',
+        name: 'Carol',
+        firstName: null,
+        lastName: null,
+        username: 'carol',
+        passwordHash: realUsersRepo.LDAP_PLACEHOLDER_PASSWORD_HASH,
+        role: 'user',
+        avatarInitials: 'CA',
+        authMethod: 'ldap',
+        authProviderId: null,
+      },
+      TX_SENTINEL,
+    );
     expect(result).toEqual({ synced: 0, created: 1 });
   });
 
@@ -1186,6 +1195,7 @@ describe('syncUsers', () => {
     const result = await ldapService.syncUsers();
     expect(createUserMock).toHaveBeenCalledWith(
       expect.objectContaining({ username: 'carol', name: 'Carol Display' }),
+      TX_SENTINEL,
     );
     expect(result).toEqual({ synced: 0, created: 1 });
   });
@@ -1212,6 +1222,7 @@ describe('syncUsers', () => {
     await ldapService.syncUsers();
     expect(createUserMock).toHaveBeenCalledWith(
       expect.objectContaining({ username: 'dave', name: 'Dave Display' }),
+      TX_SENTINEL,
     );
   });
 
@@ -1815,19 +1826,172 @@ describe('authenticateAndProvision', () => {
       created: true,
       canonicalUsername: 'alice',
     });
-    expect(createUserMock).toHaveBeenCalledWith({
-      id: 'u_test_id',
-      name: 'Alice Real',
-      firstName: null,
-      lastName: null,
-      username: 'alice',
-      passwordHash: realUsersRepo.EXTERNAL_PLACEHOLDER_PASSWORD_HASH,
-      role: 'user',
-      avatarInitials: 'AL',
-      authMethod: 'ldap',
-      authProviderId: null,
+    expect(createUserMock).toHaveBeenCalledWith(
+      {
+        id: 'u_test_id',
+        name: 'Alice Real',
+        firstName: null,
+        lastName: null,
+        username: 'alice',
+        passwordHash: realUsersRepo.EXTERNAL_PLACEHOLDER_PASSWORD_HASH,
+        role: 'user',
+        avatarInitials: 'AL',
+        authMethod: 'ldap',
+        authProviderId: null,
+      },
+      TX_SENTINEL,
+    );
+    expect(applyExternalRolesForUserMock).toHaveBeenCalledWith('u_test_id', [], [], TX_SENTINEL);
+  });
+
+  test('auto-provision creates user, settings, and roles inside one transaction', async () => {
+    nextFixture = {
+      bindResponses: [null, null],
+      searchResponses: [
+        {
+          entries: [
+            {
+              objectName: 'uid=alice,dc=test,dc=com',
+              object: { uid: 'alice', cn: 'Alice', mail: 'alice@example.com' },
+            },
+          ],
+          status: 0,
+        },
+        { entries: [], status: 0 },
+      ],
+    };
+    findLoginUserByNormalizedUsernameMock.mockResolvedValue(null);
+
+    const result = await ldapService.authenticateAndProvision('alice', 'pw');
+
+    expect(result).toEqual({
+      authenticated: true,
+      userId: 'u_test_id',
+      created: true,
+      canonicalUsername: 'alice',
     });
-    expect(applyExternalRolesForUserMock).toHaveBeenCalledWith('u_test_id', [], []);
+    expect(withDbTransactionMock).toHaveBeenCalled();
+    expect(createUserMock).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'u_test_id', username: 'alice' }),
+      TX_SENTINEL,
+    );
+    expect(settingsUpsertForUserMock).toHaveBeenCalledWith(
+      'u_test_id',
+      { fullName: 'Alice', email: 'alice@example.com', language: null },
+      TX_SENTINEL,
+    );
+    expect(applyExternalRolesForUserMock).toHaveBeenCalledWith('u_test_id', [], [], TX_SENTINEL);
+    expect(createUserMock.mock.calls.every((call) => call[1] === TX_SENTINEL)).toBe(true);
+  });
+
+  test('rolls back auto-provision when role write fails inside the transaction', async () => {
+    nextFixture = {
+      bindResponses: [null, null],
+      searchResponses: [
+        {
+          entries: [
+            { objectName: 'uid=alice,dc=test,dc=com', object: { uid: 'alice', cn: 'Alice' } },
+          ],
+          status: 0,
+        },
+        { entries: [], status: 0 },
+      ],
+    };
+    findLoginUserByNormalizedUsernameMock.mockResolvedValue(null);
+    applyExternalRolesForUserMock.mockRejectedValueOnce(new Error('role write failed'));
+
+    await expect(ldapService.authenticateAndProvision('alice', 'pw')).rejects.toThrow(
+      'role write failed',
+    );
+    expect(createUserMock).toHaveBeenCalled();
+    expect(applyExternalRolesForUserMock).toHaveBeenCalled();
+  });
+
+  test('existing LDAP login repairs missing primary user_roles membership', async () => {
+    nextFixture = {
+      bindResponses: [null, null],
+      searchResponses: [
+        {
+          entries: [
+            { objectName: 'uid=alice,dc=test,dc=com', object: { uid: 'alice', cn: 'Alice' } },
+          ],
+          status: 0,
+        },
+        { entries: [], status: 0 },
+      ],
+    };
+    findLoginUserByNormalizedUsernameMock.mockResolvedValue({
+      ...LDAP_LOGIN_USER,
+      role: 'manager',
+    });
+
+    const result = await ldapService.authenticateAndProvision('alice', 'pw');
+
+    expect(result).toEqual({
+      authenticated: true,
+      userId: LDAP_LOGIN_USER.id,
+      created: false,
+      canonicalUsername: 'alice',
+    });
+    expect(addUserRoleMock).toHaveBeenCalledWith(LDAP_LOGIN_USER.id, 'manager');
+    expect(applyExternalRolesForUserMock).not.toHaveBeenCalled();
+  });
+
+  test('sync auto-provision creates user, settings, and roles inside one transaction', async () => {
+    nextFixture = {
+      bindResponses: [null],
+      searchResponses: [
+        {
+          entries: [
+            {
+              objectName: 'uid=alice,dc=test,dc=com',
+              object: { uid: 'alice', cn: 'Alice', mail: 'alice@example.com' },
+            },
+          ],
+          status: 0,
+        },
+        { entries: [], status: 0 },
+      ],
+    };
+    findLoginUserByNormalizedUsernameMock.mockResolvedValue(null);
+
+    const result = await ldapService.syncUsers();
+
+    expect(result).toEqual({ synced: 0, created: 1 });
+    expect(createUserMock).toHaveBeenCalledWith(
+      expect.objectContaining({ username: 'alice' }),
+      TX_SENTINEL,
+    );
+    expect(settingsUpsertForUserMock).toHaveBeenCalledWith(
+      'u_test_id',
+      { fullName: 'Alice', email: 'alice@example.com', language: null },
+      TX_SENTINEL,
+    );
+    expect(applyExternalRolesForUserMock).toHaveBeenCalledWith('u_test_id', [], [], TX_SENTINEL);
+  });
+
+  test('sync repairs missing primary user_roles membership for existing users', async () => {
+    findLoginUserByNormalizedUsernameMock.mockResolvedValue({
+      ...LDAP_LOGIN_USER,
+      role: 'manager',
+    });
+    nextFixture = {
+      bindResponses: [null],
+      searchResponses: [
+        {
+          entries: [
+            { objectName: 'uid=alice,dc=test,dc=com', object: { uid: 'alice', cn: 'Alice' } },
+          ],
+          status: 0,
+        },
+        { entries: [], status: 0 },
+      ],
+    };
+
+    await ldapService.syncUsers();
+
+    expect(addUserRoleMock).toHaveBeenCalledWith(LDAP_LOGIN_USER.id, 'manager');
+    expect(applyExternalRolesForUserMock).not.toHaveBeenCalled();
   });
 
   test('falls back to sAMAccountName when uid is missing (AD)', async () => {
@@ -1852,6 +2016,7 @@ describe('authenticateAndProvision', () => {
     expect(result.canonicalUsername).toBe('carol');
     expect(createUserMock).toHaveBeenCalledWith(
       expect.objectContaining({ username: 'carol', name: 'Carol' }),
+      TX_SENTINEL,
     );
   });
 
@@ -1878,6 +2043,7 @@ describe('authenticateAndProvision', () => {
     expect(result.canonicalUsername).toBe('jdoe');
     expect(createUserMock).toHaveBeenCalledWith(
       expect.objectContaining({ username: 'jdoe', name: 'John Doe' }),
+      TX_SENTINEL,
     );
   });
 
@@ -1903,7 +2069,10 @@ describe('authenticateAndProvision', () => {
 
     expect(result.canonicalUsername).toBe('jdoe');
     expect(findLoginUserByNormalizedUsernameMock).toHaveBeenCalledWith('jdoe');
-    expect(createUserMock).toHaveBeenCalledWith(expect.objectContaining({ username: 'jdoe' }));
+    expect(createUserMock).toHaveBeenCalledWith(
+      expect.objectContaining({ username: 'jdoe' }),
+      TX_SENTINEL,
+    );
   });
 
   test('reuses an existing LDAP-bound user under the canonical username (no creation)', async () => {
@@ -2273,6 +2442,7 @@ describe('authenticateAndProvision', () => {
     await ldapService.authenticateAndProvision('dave', 'pw');
     expect(createUserMock).toHaveBeenCalledWith(
       expect.objectContaining({ name: 'Dave Display', username: 'dave' }),
+      TX_SENTINEL,
     );
   });
 
@@ -2338,6 +2508,9 @@ describe('authenticateAndProvision', () => {
 
     // filterExistingRoleIds must be called with the unfiltered mapped IDs before createUser fires
     expect(filterExistingRoleIdsMock).toHaveBeenCalledWith(['role-deleted-12345']);
-    expect(createUserMock).toHaveBeenCalledWith(expect.objectContaining({ role: 'user' }));
+    expect(createUserMock).toHaveBeenCalledWith(
+      expect.objectContaining({ role: 'user' }),
+      TX_SENTINEL,
+    );
   });
 });


### PR DESCRIPTION
## Summary
- LDAP login and sync auto-provision now create the user, settings row, and `user_roles` assignment in a single database transaction.
- Existing LDAP users get a cheap primary-role membership repair (`ON CONFLICT DO NOTHING`) bundled with directory profile refresh, so historically stranded accounts recover on next login/sync.
- `applyExternalRolesForUser` accepts an optional executor so callers can compose it atomically via `runAtomically`.

## Changes
- `server/services/ldap.ts`: `provisionNewLdapUser` + `refreshExistingLdapUser` helpers for login and sync paths.
- `server/services/external-auth.ts`: thread `DbExecutor` through `applyExternalRolesForUser`.
- Unit/integration coverage for atomic provision, rollback on role-write failure, and stranded-role repair.

## Testing
- `bun test ./test/services/ldap.test.ts ./test/services/external-auth.test.ts` (121 pass)

## Risks / Rollout
- Low. New users become fully provisioned atomically; existing users only gain a missing primary `user_roles` row when absent. Bootstrap-only role mapping for existing users is unchanged.

## Issues
Issue: Not linked (DeepSec finding `praetor-other-atomicity-bug-692a8f9d86`)