### PR TITLE
deploy(fix): align compose env with runtime needs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3,6 +3,11 @@
 # Replace with your server's public IP or domain name
 SERVER_IP=localhost
 
+# Runtime mode for the backend container. Defaults to production (matches the image).
+# Demo seeding is refused when NODE_ENV=production. For a Docker demo stack set e.g.
+# NODE_ENV=development together with DEMO_SEEDING=true and a unique DEMO_USER_PASSWORD.
+NODE_ENV=production
+
 # Database Credentials
 # Fresh PostgreSQL 18 installs only. This compose file is not an in-place upgrade path for
 # an existing PostgreSQL 17 volume.
@@ -24,10 +29,10 @@ ENCRYPTION_KEY=change-me-long-random-encryption-key
 TRUST_PROXY=1
 
 # Optional public backend origin used to build OIDC/SAML callback URLs when the
-# backend sits behind a proxy with a different external URL.
+# backend sits behind a proxy with a different external URL. Forwarded to the backend.
 # SSO_CALLBACK_BASE_URL=https://praetor.example.com
 
-# Logging (backend)
+# Logging (backend). Forwarded to the backend container.
 # LOG_LEVEL supports: trace, debug, info, warn, error, fatal
 LOG_LEVEL=info
 # Pretty logs are enabled by default outside production; set explicitly if needed.
@@ -36,7 +41,7 @@ LOG_LEVEL=info
 # Optional demo refresh on backend startup.
 # When true, the backend provisions the demo manager/user credentials plus the canonical
 # demo business dataset. Intended for demo/test Docker stacks and reused volumes.
-# Refused outright when NODE_ENV=production.
+# Requires NODE_ENV other than production (see NODE_ENV above).
 DEMO_SEEDING=false
 # Required whenever demo seeding runs. Use a unique value; the published legacy default is rejected.
 # Generate with: openssl rand -base64 24
@@ -47,3 +52,13 @@ DEMO_USER_PASSWORD=
 # to create the account when this is blank or set to a published legacy default.
 # Generate with: openssl rand -base64 24
 ADMIN_DEFAULT_PASSWORD=
+
+# Optional: PostgreSQL TLS (forwarded to the backend). Leave unset for the bundled
+# Postgres container, which has no TLS.
+# - `disable` (or unset): no TLS.
+# - `true` / `require`: encrypted; CA and hostname validated.
+# - `verify-ca`:   encrypted; CA validated; hostname NOT checked.
+# - `verify-full`: encrypted; CA validated; hostname must match.
+# Enabled modes use DB_SSL_CA (inline PEM) or DB_SSL_CA_FILE (path).
+# DB_SSL=verify-full
+# DB_SSL_CA_FILE=/run/secrets/pg-ca.pem

--- a/README.md
+++ b/README.md
@@ -70,7 +70,12 @@ official PG18 container layout. Do not point this compose file at an existing Po
 data volume.
 
 The compose setup defaults backend `TRUST_PROXY=1` for the bundled Caddy -> API hop.
-Set `DEMO_SEEDING=true` and a unique `DEMO_USER_PASSWORD` in `.env` when you want the stack to provision the canonical demo users and demo business data. The demo refresh fails before cleaning or reseeding demo data when the password is blank or matches the published legacy default, and it is refused outright when `NODE_ENV=production`.
+Set `DEMO_SEEDING=true`, a unique `DEMO_USER_PASSWORD`, and `NODE_ENV` to a non-production
+value (for example `development`) in `.env` when you want the stack to provision the
+canonical demo users and demo business data. The backend image defaults to
+`NODE_ENV=production`; demo seeding is refused in that mode. The demo refresh also fails
+before cleaning or reseeding demo data when the password is blank or matches the published
+legacy default.
 That refresh flow is intended for demo and test stacks, owns the canonical demo namespace,
 refreshes compatibility clients/projects/tasks, deletes financial documents and dependent
 resales backed by demo products, and resets the seeded demo users' assignments, notifications, and time entries so

--- a/deploy/.env.customer.example
+++ b/deploy/.env.customer.example
@@ -6,6 +6,10 @@
 PRAETOR_IMAGE_PREFIX=ghcr.io/xbounceit
 PRAETOR_VERSION=v0.6.2
 
+# Runtime mode for the backend container. Keep production for customer deployments.
+# Demo seeding is refused when NODE_ENV=production.
+NODE_ENV=production
+
 # Public frontend origin used by backend CORS
 # Use your real URL in production (example: https://erp.example.com)
 FRONTEND_URL=http://localhost:3000
@@ -34,6 +38,16 @@ ADMIN_DEFAULT_PASSWORD=
 # `1` matches the built-in frontend proxy -> backend hop in this deployment.
 TRUST_PROXY=1
 
+# Logging (backend). Forwarded to the backend container.
+# LOG_LEVEL supports: trace, debug, info, warn, error, fatal
+LOG_LEVEL=info
+# Pretty logs are disabled by default in production; set explicitly if needed.
+# LOG_PRETTY=true
+
+# Optional public backend origin for OIDC/SAML callbacks when it differs from FRONTEND_URL.
+# Forwarded to the backend. Leave unset to use FRONTEND_URL.
+# SSO_CALLBACK_BASE_URL=https://erp.example.com
+
 # Optional demo data. Keep false for production; it is refused outright when NODE_ENV=production.
 # When enabled, set a unique demo password; Praetor rejects blank values and published legacy
 # defaults before refreshing demo data.
@@ -41,7 +55,7 @@ DEMO_SEEDING=false
 # Generate with: openssl rand -base64 24
 DEMO_USER_PASSWORD=
 
-# Optional: PostgreSQL TLS
+# Optional: PostgreSQL TLS (forwarded to the backend).
 # `node-postgres` does not honor PGSSLMODE, so SSL is configured here.
 # - `disable` (or unset): no TLS. Use for the bundled Postgres container.
 # - `true` / `require`: encrypted; CA and hostname validated.

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -20,6 +20,11 @@ Set at least:
 - `FRONTEND_URL`
 - `ADMIN_DEFAULT_PASSWORD` for a fresh installation
 
+Keep `NODE_ENV=production` (the compose default) for customer deployments. Optional backend
+env vars forwarded from `.env` include `LOG_LEVEL`, `LOG_PRETTY`, `SSO_CALLBACK_BASE_URL`,
+`DB_SSL`, `DB_SSL_CA`, and `DB_SSL_CA_FILE`. Leave `DEMO_SEEDING=false`; demo seeding is
+refused when `NODE_ENV=production`.
+
 Generate a unique `POSTGRES_PASSWORD`; do not leave the published example placeholder in place.
 The backend always requires an explicit database password and, outside explicit local
 development or test runtimes, refuses to start with a known default.

--- a/deploy/docker-compose.customer.yml
+++ b/deploy/docker-compose.customer.yml
@@ -23,6 +23,7 @@ services:
     container_name: praetor-backend
     environment:
       PORT: 3001
+      NODE_ENV: ${NODE_ENV:-production}
       DB_HOST: postgres
       DB_PORT: 5432
       DB_NAME: ${POSTGRES_DB:?POSTGRES_DB is required}
@@ -35,6 +36,12 @@ services:
       DEMO_SEEDING: ${DEMO_SEEDING:-false}
       DEMO_USER_PASSWORD: '${DEMO_USER_PASSWORD:-}'
       FRONTEND_URL: ${FRONTEND_URL:?FRONTEND_URL is required}
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      LOG_PRETTY: '${LOG_PRETTY:-}'
+      SSO_CALLBACK_BASE_URL: '${SSO_CALLBACK_BASE_URL:-}'
+      DB_SSL: '${DB_SSL:-}'
+      DB_SSL_CA: '${DB_SSL_CA:-}'
+      DB_SSL_CA_FILE: '${DB_SSL_CA_FILE:-}'
     volumes:
       - ssl_certs:/app/certs
       - uploads_data:/app/uploads

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -42,6 +42,7 @@ services:
     environment:
       <<: *backend-db-env
       PORT: 3001
+      NODE_ENV: ${NODE_ENV:-production}
       JWT_SECRET: ${JWT_SECRET:?JWT_SECRET is required}
       ENCRYPTION_KEY: ${ENCRYPTION_KEY:?ENCRYPTION_KEY is required}
       ADMIN_DEFAULT_PASSWORD: '${ADMIN_DEFAULT_PASSWORD:-}'
@@ -49,6 +50,12 @@ services:
       DEMO_SEEDING: ${DEMO_SEEDING:-false}
       DEMO_USER_PASSWORD: '${DEMO_USER_PASSWORD:-}'
       FRONTEND_URL: http://${SERVER_IP:-localhost}:3000
+      LOG_LEVEL: ${LOG_LEVEL:-info}
+      LOG_PRETTY: '${LOG_PRETTY:-}'
+      SSO_CALLBACK_BASE_URL: '${SSO_CALLBACK_BASE_URL:-}'
+      DB_SSL: '${DB_SSL:-}'
+      DB_SSL_CA: '${DB_SSL_CA:-}'
+      DB_SSL_CA_FILE: '${DB_SSL_CA_FILE:-}'
     volumes:
       - ssl_certs:/app/certs
       - uploads_data:/app/uploads

--- a/docs-site/src/content/docs/en/getting-started.md
+++ b/docs-site/src/content/docs/en/getting-started.md
@@ -13,7 +13,7 @@ Before starting an installation, the operator must generate a unique database pa
 
 For a new installation, the operator must generate a unique password and set it as `ADMIN_DEFAULT_PASSWORD` before first startup. Praetor does not create the `admin` account when the value is blank or matches a previously published default credential. Upgrades do not need the variable when the `admin` account already exists.
 
-When enabling the demo dataset with `DEMO_SEEDING=true`, also set a unique `DEMO_USER_PASSWORD`. The refresh stops before cleaning or reseeding demo data if the value is blank or matches the former public password. Every refresh resets demo accounts to this password without changing the dataset's deterministic identities and relationships.
+When enabling the demo dataset with `DEMO_SEEDING=true`, also set a unique `DEMO_USER_PASSWORD`. In Docker stacks the backend refuses demo seeding when `NODE_ENV=production` (the image default): set a non-production value (for example `development`) together with the other variables. The refresh stops before cleaning or reseeding demo data if the value is blank or matches the former public password. Every refresh resets demo accounts to this password without changing the dataset's deterministic identities and relationships.
 
 If the session stays idle for too long, Praetor asks you to sign in again. This protects open sessions from unauthorized use.
 

--- a/docs-site/src/content/docs/getting-started.md
+++ b/docs-site/src/content/docs/getting-started.md
@@ -13,7 +13,7 @@ Prima di avviare un'installazione, l'operatore deve generare una password databa
 
 In una nuova installazione, l'operatore deve generare una password univoca e impostarla in `ADMIN_DEFAULT_PASSWORD` prima del primo avvio. Praetor non crea l'account `admin` se il valore è vuoto o corrisponde a una credenziale predefinita pubblicata in precedenza. Negli aggiornamenti, la variabile non è necessaria quando l'account `admin` esiste già.
 
-Se abiliti il dataset dimostrativo con `DEMO_SEEDING=true`, imposta anche una password univoca in `DEMO_USER_PASSWORD`. Il refresh si interrompe prima di pulire o riseminare i dati demo se il valore è vuoto o corrisponde alla vecchia password pubblica. Ogni refresh reimposta gli account demo a questa password senza cambiare le identità e le relazioni deterministiche del dataset.
+Se abiliti il dataset dimostrativo con `DEMO_SEEDING=true`, imposta anche una password univoca in `DEMO_USER_PASSWORD`. Negli stack Docker il backend rifiuta il seed demo quando `NODE_ENV=production` (il default dell'immagine): imposta un valore diverso da `production` (ad esempio `development`) insieme alle altre variabili. Il refresh si interrompe prima di pulire o riseminare i dati demo se il valore è vuoto o corrisponde alla vecchia password pubblica. Ogni refresh reimposta gli account demo a questa password senza cambiare le identità e le relazioni deterministiche del dataset.
 
 Se la sessione resta inattiva troppo a lungo, Praetor richiede un nuovo accesso. Questa protezione evita che una sessione lasciata aperta venga usata da altri.
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -1,6 +1,7 @@
 # Local Development Configuration
 # Used when running 'npm run dev' or 'node index.ts' directly in the server directory.
 # These values OVERRIDE the docker-compose defaults for local testing.
+NODE_ENV=development
 PORT=3001
 FRONTEND_URL=http://localhost:5173
 # Public base URL the IdP will redirect back to (e.g. https://praetor.example.com).

--- a/server/test/utils/bootstrapAdminDeployment.test.ts
+++ b/server/test/utils/bootstrapAdminDeployment.test.ts
@@ -92,6 +92,38 @@ describe('deployment password configuration', () => {
     expect(readRepositoryFile(path)).toMatch(/DEMO_USER_PASSWORD:\s+'\$\{DEMO_USER_PASSWORD:-\}'/);
   });
 
+  test.each([
+    'docker-compose.yml',
+    'deploy/docker-compose.customer.yml',
+  ])('%s forwards NODE_ENV with a production default', (path) => {
+    expect(readRepositoryFile(path)).toContain('NODE_ENV: ${NODE_ENV:-production}');
+  });
+
+  test.each([
+    'docker-compose.yml',
+    'deploy/docker-compose.customer.yml',
+  ])('%s forwards logging, SSO callback, and DB SSL env to the backend', (path) => {
+    const source = readRepositoryFile(path);
+
+    expect(source).toContain('LOG_LEVEL: ${LOG_LEVEL:-info}');
+    expect(source).toMatch(/LOG_PRETTY:\s+'\$\{LOG_PRETTY:-\}'/);
+    expect(source).toMatch(/SSO_CALLBACK_BASE_URL:\s+'\$\{SSO_CALLBACK_BASE_URL:-\}'/);
+    expect(source).toMatch(/DB_SSL:\s+'\$\{DB_SSL:-\}'/);
+    expect(source).toMatch(/DB_SSL_CA:\s+'\$\{DB_SSL_CA:-\}'/);
+    expect(source).toMatch(/DB_SSL_CA_FILE:\s+'\$\{DB_SSL_CA_FILE:-\}'/);
+  });
+
+  test.each([
+    ['.env.example', 'production'],
+    ['deploy/.env.customer.example', 'production'],
+    ['server/.env.example', 'development'],
+  ])('%s sets NODE_ENV=%s', (path, expected) => {
+    const source = readRepositoryFile(path);
+    const configuredValue = source.match(/^NODE_ENV=(.*)$/m)?.[1].trim();
+
+    expect(configuredValue).toBe(expected);
+  });
+
   test('committed frontend docs do not advertise the removed password fallback', () => {
     const source = readRepositoryFile('docs/frontend/index.html');
 
@@ -108,6 +140,7 @@ describe('deployment password configuration', () => {
 
     expect(readme).toContain('For this direct-server command');
     expect(readme).toContain('`server/.env`');
+    expect(readme).toContain('NODE_ENV');
     expect(frontendDocs).toContain('For this direct-server command');
     expect(frontendDocs).toContain('<code>server/.env</code>');
   });


### PR DESCRIPTION
## Summary
- Forward documented but previously unwired backend env vars from Compose `.env` into the backend container.
- Make `NODE_ENV` overridable (default `production`) so Docker demo seeding can work when operators opt in.

## Changes
- Wire `NODE_ENV`, `LOG_LEVEL`, `LOG_PRETTY`, `SSO_CALLBACK_BASE_URL`, and `DB_SSL*` in `docker-compose.yml` and `deploy/docker-compose.customer.yml`.
- Align `.env.example`, `deploy/.env.customer.example`, and `server/.env.example` with the forwarded contract.
- Document the non-production `NODE_ENV` requirement for Docker demo seeding in README, deploy README, and getting-started docs (IT/EN).
- Extend deployment config tests to assert Compose forwarding and `NODE_ENV` defaults.

## Testing
- `cd server; bun test test/utils/bootstrapAdminDeployment.test.ts` (25 pass)
- Not run: full `bun run test`, Docker stack CI job

## Risks / Rollout
- Low. Production customer default remains `NODE_ENV=production` with `DEMO_SEEDING=false`.
- Operators who set optional env in `.env` expecting no effect will now see those values reach the backend (intended).
- Empty optional vars are forwarded as empty strings; runtime already treats blank as unset for these keys.

## Issues
Issue: Not linked