### PR TITLE
tables(feature): add clear filters action

### DIFF
--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -20,6 +20,7 @@ import {
   ArrowDown,
   ArrowUp,
   ArrowUpDown,
+  FilterX,
   GripVertical,
   Lightbulb,
   ZoomIn,
@@ -1947,6 +1948,11 @@ const useStandardTableController = <T extends object>({
     [columnFilters, setCurrentPage, storageIdentity],
   );
 
+  const clearAllFilters = useCallback(() => {
+    onColumnFiltersChange([]);
+    setFilterSearchByColumnId({});
+  }, [onColumnFiltersChange, setFilterSearchByColumnId]);
+
   const onPaginationChange = useCallback(
     (updater: Updater<PaginationState>) => {
       const next = functionalUpdate(updater, pagination);
@@ -2753,6 +2759,8 @@ const useStandardTableController = <T extends object>({
     shouldRenderTable,
     processedRows,
     handleExportToCsv,
+    hasActiveFilters: columnFilters.length > 0,
+    clearAllFilters,
     showSaveColumnLayoutTip,
     isViewCreationDisabled,
     stepFontSize,
@@ -2906,6 +2914,8 @@ const StandardTableToolbar = <T extends object>({
     showSaveColumnLayoutTip,
     isViewCreationDisabled,
     setModalState,
+    hasActiveFilters,
+    clearAllFilters,
     stepFontSize,
     fontSize,
     isExporting,
@@ -2923,6 +2933,14 @@ const StandardTableToolbar = <T extends object>({
           disabled={isViewCreationDisabled}
           active
           text={t('table.saveColumnOrder')}
+        />
+      )}
+      {hasActiveFilters && (
+        <StandardTableToolbarButton
+          label={t('table.clearFilters')}
+          icon={<FilterX className="size-3.5" aria-hidden="true" />}
+          onClick={clearAllFilters}
+          text={t('table.clearFilters')}
         />
       )}
       <StandardTableToolbarButton

--- a/components/shared/StandardTable.tsx
+++ b/components/shared/StandardTable.tsx
@@ -1891,6 +1891,7 @@ const useStandardTableController = <T extends object>({
     () => Object.entries(filterState).map(([id, value]) => ({ id, value })),
     [filterState],
   );
+  const hasActiveFilters = Object.values(filterState).some((values) => values.length > 0);
 
   const pagination = useMemo<PaginationState>(
     () => ({ pageIndex: currentPage - 1, pageSize: rowsPerPage }),
@@ -2759,7 +2760,7 @@ const useStandardTableController = <T extends object>({
     shouldRenderTable,
     processedRows,
     handleExportToCsv,
-    hasActiveFilters: columnFilters.length > 0,
+    hasActiveFilters,
     clearAllFilters,
     showSaveColumnLayoutTip,
     isViewCreationDisabled,

--- a/locales/en/common.json
+++ b/locales/en/common.json
@@ -252,6 +252,7 @@
     "selectAll": "Select All",
     "noResults": "No results found",
     "clearFilter": "Clear Filter",
+    "clearFilters": "Clear filters",
     "increaseFont": "Increase font size",
     "decreaseFont": "Decrease font size",
     "columnSettings": "Column settings",

--- a/locales/it/common.json
+++ b/locales/it/common.json
@@ -252,6 +252,7 @@
     "selectAll": "Seleziona Tutto",
     "noResults": "Nessun risultato",
     "clearFilter": "Pulisci Filtri",
+    "clearFilters": "Pulisci filtri",
     "increaseFont": "Aumenta dimensione testo",
     "decreaseFont": "Riduci dimensione testo",
     "columnSettings": "Impostazioni colonne",

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -1212,6 +1212,28 @@ describe('<StandardTable />', () => {
     expect(tbody.textContent).toContain('Charlie');
   });
 
+  test('shows a clear-filters toolbar button only while filters are active', async () => {
+    const { container } = render(
+      <StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />,
+    );
+
+    expect(screen.queryByRole('button', { name: 'table.clearFilters' })).toBeNull();
+
+    const nameFilterUser = await selectFilterValue('Name', 'Alice');
+    await nameFilterUser.keyboard('{Escape}');
+    const ageFilterUser = await selectFilterValue('Age', '30');
+    await ageFilterUser.keyboard('{Escape}');
+    const clearFiltersButton = screen.getByRole('button', { name: 'table.clearFilters' });
+    const tbody = container.querySelector('tbody') as HTMLElement;
+    expect(tbody.textContent).not.toContain('Bob');
+
+    await act(async () => fireEvent.click(clearFiltersButton));
+
+    expect(tbody.textContent).toContain('Bob');
+    expect(tbody.textContent).toContain('Charlie');
+    expect(screen.queryByRole('button', { name: 'table.clearFilters' })).toBeNull();
+  });
+
   test('header filter menu uses shadcn border tokens and searches filter options', async () => {
     render(<StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />);
     const user = await openHeaderFilter('Name');

--- a/test/components/StandardTable.test.tsx
+++ b/test/components/StandardTable.test.tsx
@@ -1214,7 +1214,12 @@ describe('<StandardTable />', () => {
 
   test('shows a clear-filters toolbar button only while filters are active', async () => {
     const { container } = render(
-      <StandardTable<Row> title="People" data={sampleRows} columns={sampleColumns} />,
+      <StandardTable<Row>
+        title="People"
+        data={sampleRows}
+        columns={sampleColumns}
+        initialFilterState={{ name: [] }}
+      />,
     );
 
     expect(screen.queryByRole('button', { name: 'table.clearFilters' })).toBeNull();


### PR DESCRIPTION
## Summary
- Adds a contextual clear-filters action to the shared StandardTable toolbar.
- Lets users remove every active column filter with one click.

## Changes
- Shows the action only while one or more column filters are active.
- Clears all filters, resets pagination to the first page, and removes transient filter searches.
- Adds Italian and English translations.
- Adds regression coverage for clearing filters across multiple columns.

## Testing
- `bun test test/components/StandardTable.test.tsx` (98 passed)
- `bun run i18n:check`
- `bun run typecheck`
- `bun x biome check components/shared/StandardTable.tsx test/components/StandardTable.test.tsx locales/en/common.json locales/it/common.json`
- `bun run test:react-doctor` (79/100, unchanged; 2 pre-existing errors)

## Risks / Rollout
- Low risk. The change is limited to client-side shared-table filter controls.
- No database, API, permission, configuration, or deployment-order changes.
- User documentation was reviewed and remains unchanged because the action is contextual and self-explanatory.
- The repository-wide `bun run lint` remains affected by pre-existing CRLF formatting diagnostics in unrelated files; i18n, typecheck, and changed-file Biome checks pass.

## Issues
Issue: Not linked