### PR TITLE
hr(fix): align employee table row height

### DIFF
--- a/components/HR/ExternalEmployeesView.tsx
+++ b/components/HR/ExternalEmployeesView.tsx
@@ -156,7 +156,7 @@ const ExternalEmployeesTable: React.FC<ExternalEmployeesTableProps> = ({
         accessorKey: 'name',
         cell: ({ row }) => (
           <div className="flex items-center gap-3">
-            <div className="size-9 rounded-full bg-amber-100 text-amber-700 flex items-center justify-center font-bold text-xs">
+            <div className="size-6 rounded-full bg-amber-100 text-amber-700 flex items-center justify-center font-bold text-xs">
               {row.avatarInitials}
             </div>
             <span className="font-semibold text-foreground">{row.name}</span>

--- a/components/HR/InternalEmployeesView.tsx
+++ b/components/HR/InternalEmployeesView.tsx
@@ -156,7 +156,7 @@ const InternalEmployeesTable: React.FC<InternalEmployeesTableProps> = ({
         accessorKey: 'name',
         cell: ({ row }) => (
           <div className="flex items-center gap-3">
-            <div className="size-9 rounded-full bg-praetor/10 text-praetor flex items-center justify-center font-bold text-xs">
+            <div className="size-6 rounded-full bg-praetor/10 text-praetor flex items-center justify-center font-bold text-xs">
               {row.avatarInitials}
             </div>
             <span className="font-semibold text-foreground">{row.name}</span>

--- a/test/components/hr/ExternalEmployeesView.rowClick.test.tsx
+++ b/test/components/hr/ExternalEmployeesView.rowClick.test.tsx
@@ -102,6 +102,7 @@ describe('<ExternalEmployeesView /> row click', () => {
     expect(cellTexts).toContain('+39 02 9876');
     expect(cellTexts).toContain('Paola Manager');
     expect(cellTexts).not.toContain('mario.contractor@example.com+39 02 9876');
+    expect(within(row).getByText('MR')).toHaveClass('size-6');
   });
 
   test('clicking a row opens the edit modal populated for that employee', () => {

--- a/test/components/hr/InternalEmployeesView.rowClick.test.tsx
+++ b/test/components/hr/InternalEmployeesView.rowClick.test.tsx
@@ -106,6 +106,7 @@ describe('<InternalEmployeesView /> row click', () => {
     expect(cellTexts).toContain('+39 02 1234');
     expect(cellTexts).toContain('Paola Manager');
     expect(cellTexts).not.toContain('mario@example.com+39 02 1234');
+    expect(within(row).getByText('MR')).toHaveClass('size-6');
   });
 
   test('clicking a row opens the edit modal populated for that employee', () => {


### PR DESCRIPTION
## Summary
- Aligns internal and external employee table rows with the height used by quote tables.
- Keeps employee initials visible while preventing the avatar from increasing row height.

## Changes
- Reduces employee table avatars from `size-9` to `size-6` in both HR views.
- Adds regression assertions for the compact avatar size in the internal and external employee view tests.
- Documentation unchanged because this is a visual consistency fix with no workflow or API impact.

## Testing
- `bun test test/components/hr/InternalEmployeesView.rowClick.test.tsx test/components/hr/ExternalEmployeesView.rowClick.test.tsx` — 26 passed
- `bun x tsc -p tsconfig.json` — passed
- `bun run test:react-doctor` — score unchanged at 79/100; reports 2 pre-existing unrelated findings
- `bun run typecheck` — backend portion could not complete because backend dependencies are unavailable in this worktree

## Risks / Rollout
- Low risk. The change is limited to avatar sizing in two table cells and has no data, API, permission, migration, or configuration impact.

## Issues
Issue: Not linked