### PR TITLE
ui(fix): align offer success toast with app theme

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -134,6 +134,7 @@ import type {
   WorkUnit,
 } from './types';
 import { clearAuthScopedState } from './utils/authScopedState';
+import { ensureClientOfferAvailable } from './utils/clientOfferNavigation';
 import { formatDateOnlyForLocale, getLocalDateString } from './utils/date';
 import { getTechnicalDocsViewFromPathname } from './utils/docsRoutes';
 import { formatDocumentCode } from './utils/document-code';
@@ -1835,15 +1836,35 @@ const useAppContentController = () => {
         classNames: offerCreatedToastClassNames,
         action: resolveOfferCreatedToastAction(canViewClientOffers, {
           label: tApp('sales:clientQuotes.viewOffer'),
-          onClick: () => {
-            setClientQuoteFilterId(null);
-            setClientOfferFilterId(offer.id);
-            setActiveView('sales/client-offers');
+          onClick: async () => {
+            try {
+              setClientOffers(
+                await ensureClientOfferAvailable(
+                  offer.id,
+                  clientOffersRef.current,
+                  api.clientOffers.list,
+                ),
+              );
+              setClientQuoteFilterId(null);
+              setClientOfferFilterId(offer.id);
+              setActiveView('sales/client-offers');
+            } catch (err) {
+              console.error('Failed to load created client offer:', err);
+              toastError(tApp('sales:clientOffers.failedToLoad'));
+            }
           },
         }),
       });
     },
-    [canViewClientOffers, setActiveView, setClientQuoteFilterId, setClientOfferFilterId, tApp],
+    [
+      canViewClientOffers,
+      clientOffersRef,
+      setActiveView,
+      setClientOffers,
+      setClientQuoteFilterId,
+      setClientOfferFilterId,
+      tApp,
+    ],
   );
 
   const notifyClientOrderCreated = useCallback(

--- a/App.tsx
+++ b/App.tsx
@@ -69,6 +69,7 @@ import RilView from './components/timesheet/RilView';
 import WeeklyView from './components/timesheet/WeeklyView';
 import UserSettings, { type UserSettingsTab } from './components/UserSettings';
 import { Toaster } from './components/ui/sonner';
+import { neutralSuccessToastClassNames } from './components/ui/sonner-presets';
 import WorkUnitsView from './components/WorkUnitsView';
 import { CurrentUserIdProvider } from './contexts/CurrentUserContext';
 import { makeClientHandlers } from './hooks/handlers/clientHandlers';
@@ -1823,6 +1824,7 @@ const useAppContentController = () => {
     (offer: Pick<ClientOffer, 'id' | 'revisionCode'>) => {
       toast.success(tApp('sales:clientQuotes.offerCreatedToast'), {
         description: formatDocumentCode(offer.id, offer.revisionCode),
+        classNames: neutralSuccessToastClassNames,
         action: {
           label: tApp('sales:clientQuotes.viewOffer'),
           onClick: () => {

--- a/App.tsx
+++ b/App.tsx
@@ -69,7 +69,11 @@ import RilView from './components/timesheet/RilView';
 import WeeklyView from './components/timesheet/WeeklyView';
 import UserSettings, { type UserSettingsTab } from './components/UserSettings';
 import { Toaster } from './components/ui/sonner';
-import { appToasterProps, offerCreatedToastClassNames } from './components/ui/sonner-presets';
+import {
+  appToasterProps,
+  offerCreatedToastClassNames,
+  resolveOfferCreatedToastAction,
+} from './components/ui/sonner-presets';
 import WorkUnitsView from './components/WorkUnitsView';
 import { CurrentUserIdProvider } from './contexts/CurrentUserContext';
 import { makeClientHandlers } from './hooks/handlers/clientHandlers';
@@ -1820,22 +1824,26 @@ const useAppContentController = () => {
     [switchRole],
   );
 
+  const canViewClientOffers = Boolean(
+    currentUser &&
+      hasPermission(currentUser.permissions, VIEW_PERMISSION_MAP['sales/client-offers']),
+  );
   const notifyClientOfferCreated = useCallback(
     (offer: Pick<ClientOffer, 'id' | 'revisionCode'>) => {
       toast.success(tApp('sales:clientQuotes.offerCreatedToast'), {
         description: formatDocumentCode(offer.id, offer.revisionCode),
         classNames: offerCreatedToastClassNames,
-        action: {
+        action: resolveOfferCreatedToastAction(canViewClientOffers, {
           label: tApp('sales:clientQuotes.viewOffer'),
           onClick: () => {
             setClientQuoteFilterId(null);
             setClientOfferFilterId(offer.id);
             setActiveView('sales/client-offers');
           },
-        },
+        }),
       });
     },
-    [setActiveView, setClientQuoteFilterId, setClientOfferFilterId, tApp],
+    [canViewClientOffers, setActiveView, setClientQuoteFilterId, setClientOfferFilterId, tApp],
   );
 
   const notifyClientOrderCreated = useCallback(

--- a/App.tsx
+++ b/App.tsx
@@ -69,7 +69,7 @@ import RilView from './components/timesheet/RilView';
 import WeeklyView from './components/timesheet/WeeklyView';
 import UserSettings, { type UserSettingsTab } from './components/UserSettings';
 import { Toaster } from './components/ui/sonner';
-import { neutralSuccessToastClassNames } from './components/ui/sonner-presets';
+import { offerCreatedToastClassNames } from './components/ui/sonner-presets';
 import WorkUnitsView from './components/WorkUnitsView';
 import { CurrentUserIdProvider } from './contexts/CurrentUserContext';
 import { makeClientHandlers } from './hooks/handlers/clientHandlers';
@@ -1824,7 +1824,7 @@ const useAppContentController = () => {
     (offer: Pick<ClientOffer, 'id' | 'revisionCode'>) => {
       toast.success(tApp('sales:clientQuotes.offerCreatedToast'), {
         description: formatDocumentCode(offer.id, offer.revisionCode),
-        classNames: neutralSuccessToastClassNames,
+        classNames: offerCreatedToastClassNames,
         action: {
           label: tApp('sales:clientQuotes.viewOffer'),
           onClick: () => {

--- a/App.tsx
+++ b/App.tsx
@@ -69,7 +69,7 @@ import RilView from './components/timesheet/RilView';
 import WeeklyView from './components/timesheet/WeeklyView';
 import UserSettings, { type UserSettingsTab } from './components/UserSettings';
 import { Toaster } from './components/ui/sonner';
-import { offerCreatedToastClassNames } from './components/ui/sonner-presets';
+import { appToasterProps, offerCreatedToastClassNames } from './components/ui/sonner-presets';
 import WorkUnitsView from './components/WorkUnitsView';
 import { CurrentUserIdProvider } from './contexts/CurrentUserContext';
 import { makeClientHandlers } from './hooks/handlers/clientHandlers';
@@ -4909,7 +4909,7 @@ const App: React.FC = () => (
       <AppContent />
     </ErrorBoundary>
     {/* Outside the boundary so toasts keep rendering if the boundary trips. */}
-    <Toaster richColors closeButton position="top-center" />
+    <Toaster {...appToasterProps} />
   </>
 );
 

--- a/App.tsx
+++ b/App.tsx
@@ -4909,7 +4909,7 @@ const App: React.FC = () => (
       <AppContent />
     </ErrorBoundary>
     {/* Outside the boundary so toasts keep rendering if the boundary trips. */}
-    <Toaster richColors closeButton position="top-right" />
+    <Toaster richColors closeButton position="top-center" />
   </>
 );
 

--- a/components/ui/sonner-presets.ts
+++ b/components/ui/sonner-presets.ts
@@ -12,6 +12,11 @@ export const appToasterProps = {
   position: 'top-center',
 } satisfies Pick<ToasterProps, 'richColors' | 'closeButton' | 'position'>;
 
+export const resolveOfferCreatedToastAction = <T>(
+  canViewClientOffers: boolean,
+  action: T,
+): T | undefined => (canViewClientOffers ? action : undefined);
+
 export const offerCreatedToastClassNames = {
   toast: 'rounded-lg! border-primary! bg-primary! pr-12! text-primary-foreground! shadow-lg',
   description: 'text-primary-foreground/70!',

--- a/components/ui/sonner-presets.ts
+++ b/components/ui/sonner-presets.ts
@@ -1,0 +1,11 @@
+import type { ToastClassnames } from 'sonner';
+
+export const neutralSuccessToastClassNames = {
+  toast: 'border-border! bg-popover! text-popover-foreground! shadow-lg',
+  description: 'text-muted-foreground!',
+  icon: 'text-emerald-600! dark:text-emerald-400!',
+  actionButton:
+    'bg-primary! text-primary-foreground! hover:bg-primary/90! focus-visible:ring-[3px] focus-visible:ring-ring/50',
+  closeButton:
+    'border-border! bg-background! text-muted-foreground! hover:bg-accent! hover:text-accent-foreground! focus-visible:ring-[3px] focus-visible:ring-ring/50',
+} satisfies ToastClassnames;

--- a/components/ui/sonner-presets.ts
+++ b/components/ui/sonner-presets.ts
@@ -1,11 +1,11 @@
 import type { ToastClassnames } from 'sonner';
 
-export const neutralSuccessToastClassNames = {
-  toast: 'rounded-md! border-border! bg-popover! text-popover-foreground! shadow-lg',
-  description: 'text-muted-foreground!',
-  icon: 'text-primary!',
+export const offerCreatedToastClassNames = {
+  toast: 'rounded-lg! border-primary! bg-primary! pr-12! text-primary-foreground! shadow-lg',
+  description: 'text-primary-foreground/70!',
+  icon: 'text-primary-foreground!',
   actionButton:
-    'rounded-md! bg-primary! text-primary-foreground! hover:bg-primary/90! focus-visible:ring-[3px] focus-visible:ring-ring/50',
+    'rounded-md! bg-primary-foreground! text-primary! hover:bg-primary-foreground/90! focus-visible:ring-[3px] focus-visible:ring-primary-foreground/50',
   closeButton:
-    'top-0.5! right-1! left-auto! size-5! transform-none! rounded-md! border-0! bg-transparent! text-muted-foreground! hover:bg-accent! hover:text-accent-foreground! focus-visible:ring-[3px] focus-visible:ring-ring/50',
+    'top-2! right-2! left-auto! size-6! transform-none! rounded-md! border-0! bg-transparent! text-primary-foreground! hover:bg-primary-foreground/10! focus-visible:ring-[3px] focus-visible:ring-primary-foreground/50 [&_svg]:size-4!',
 } satisfies ToastClassnames;

--- a/components/ui/sonner-presets.ts
+++ b/components/ui/sonner-presets.ts
@@ -1,11 +1,11 @@
 import type { ToastClassnames } from 'sonner';
 
 export const neutralSuccessToastClassNames = {
-  toast: 'border-border! bg-popover! text-popover-foreground! shadow-lg',
+  toast: 'rounded-md! border-border! bg-popover! text-popover-foreground! shadow-lg',
   description: 'text-muted-foreground!',
-  icon: 'text-emerald-600! dark:text-emerald-400!',
+  icon: 'text-primary!',
   actionButton:
-    'bg-primary! text-primary-foreground! hover:bg-primary/90! focus-visible:ring-[3px] focus-visible:ring-ring/50',
+    'rounded-md! bg-primary! text-primary-foreground! hover:bg-primary/90! focus-visible:ring-[3px] focus-visible:ring-ring/50',
   closeButton:
-    'border-border! bg-background! text-muted-foreground! hover:bg-accent! hover:text-accent-foreground! focus-visible:ring-[3px] focus-visible:ring-ring/50',
+    'top-0.5! right-1! left-auto! size-5! transform-none! rounded-md! border-0! bg-transparent! text-muted-foreground! hover:bg-accent! hover:text-accent-foreground! focus-visible:ring-[3px] focus-visible:ring-ring/50',
 } satisfies ToastClassnames;

--- a/components/ui/sonner-presets.ts
+++ b/components/ui/sonner-presets.ts
@@ -1,4 +1,16 @@
-import type { ToastClassnames } from 'sonner';
+import type { ToastClassnames, ToasterProps } from 'sonner';
+import type { ResolvedTheme } from '@/utils/theme';
+
+export const resolveSonnerTheme = (
+  resolvedTheme: ResolvedTheme,
+  theme?: ToasterProps['theme'],
+): ToasterProps['theme'] => theme ?? (resolvedTheme === 'dark' ? 'dark' : 'light');
+
+export const appToasterProps = {
+  richColors: true,
+  closeButton: true,
+  position: 'top-center',
+} satisfies Pick<ToasterProps, 'richColors' | 'closeButton' | 'position'>;
 
 export const offerCreatedToastClassNames = {
   toast: 'rounded-lg! border-primary! bg-primary! pr-12! text-primary-foreground! shadow-lg',

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -5,29 +5,43 @@ import {
   OctagonXIcon,
   TriangleAlertIcon,
 } from 'lucide-react';
+import type * as React from 'react';
 import { Toaster as Sonner, type ToasterProps } from 'sonner';
+import { cn } from '@/lib/utils';
+import { getShadcnThemeClassName, useResolvedShadcnTheme } from './use-shadcn-theme';
 
-const Toaster = ({ ...props }: ToasterProps) => (
-  <Sonner
-    theme="system"
-    className="toaster group"
-    icons={{
-      success: <CircleCheckIcon className="size-4" />,
-      info: <InfoIcon className="size-4" />,
-      warning: <TriangleAlertIcon className="size-4" />,
-      error: <OctagonXIcon className="size-4" />,
-      loading: <Loader2Icon className="size-4 animate-spin" />,
-    }}
-    style={
-      {
-        '--normal-bg': 'var(--popover)',
-        '--normal-text': 'var(--popover-foreground)',
-        '--normal-border': 'var(--border)',
-        '--border-radius': 'var(--radius)',
-      } as React.CSSProperties
-    }
-    {...props}
-  />
-);
+const Toaster = ({ className, theme, ...props }: ToasterProps) => {
+  const resolvedTheme = useResolvedShadcnTheme();
+  const themeClassName = getShadcnThemeClassName(resolvedTheme);
+
+  return (
+    <div
+      data-shadcn-theme-scope=""
+      data-shadcn-theme={resolvedTheme}
+      className={cn('shadcn-theme-bridge', themeClassName)}
+    >
+      <Sonner
+        theme={theme ?? (resolvedTheme === 'dark' ? 'dark' : 'light')}
+        className={cn('toaster group', className)}
+        icons={{
+          success: <CircleCheckIcon className="size-4" />,
+          info: <InfoIcon className="size-4" />,
+          warning: <TriangleAlertIcon className="size-4" />,
+          error: <OctagonXIcon className="size-4" />,
+          loading: <Loader2Icon className="size-4 animate-spin" />,
+        }}
+        style={
+          {
+            '--normal-bg': 'var(--popover)',
+            '--normal-text': 'var(--popover-foreground)',
+            '--normal-border': 'var(--border)',
+            '--border-radius': 'var(--radius)',
+          } as React.CSSProperties
+        }
+        {...props}
+      />
+    </div>
+  );
+};
 
 export { Toaster };

--- a/components/ui/sonner.tsx
+++ b/components/ui/sonner.tsx
@@ -8,6 +8,7 @@ import {
 import type * as React from 'react';
 import { Toaster as Sonner, type ToasterProps } from 'sonner';
 import { cn } from '@/lib/utils';
+import { resolveSonnerTheme } from './sonner-presets';
 import { getShadcnThemeClassName, useResolvedShadcnTheme } from './use-shadcn-theme';
 
 const Toaster = ({ className, theme, ...props }: ToasterProps) => {
@@ -21,7 +22,7 @@ const Toaster = ({ className, theme, ...props }: ToasterProps) => {
       className={cn('shadcn-theme-bridge', themeClassName)}
     >
       <Sonner
-        theme={theme ?? (resolvedTheme === 'dark' ? 'dark' : 'light')}
+        theme={resolveSonnerTheme(resolvedTheme, theme)}
         className={cn('toaster group', className)}
         icons={{
           success: <CircleCheckIcon className="size-4" />,

--- a/hooks/handlers/quoteHandlers.ts
+++ b/hooks/handlers/quoteHandlers.ts
@@ -89,11 +89,16 @@ export const makeQuoteHandlers = (deps: QuoteHandlersDeps) => {
     setInvoices(invoicesData);
   };
 
-  const refreshBestEffort = async (refresh: () => Promise<void>, errorMessage: string) => {
+  const refreshBestEffort = async (
+    refresh: () => Promise<void>,
+    errorMessage: string,
+  ): Promise<boolean> => {
     try {
       await refresh();
+      return true;
     } catch (refreshErr) {
       console.error(errorMessage, refreshErr);
+      return false;
     }
   };
 
@@ -105,8 +110,31 @@ export const makeQuoteHandlers = (deps: QuoteHandlersDeps) => {
   const refreshLinkedSupplierQuotes = () =>
     refreshBestEffort(refreshSupplierQuoteFlow, 'Failed to refresh supplier data:');
 
-  const refreshClientQuoteFlowBestEffort = () =>
-    refreshBestEffort(refreshClientQuoteFlow, 'Failed to refresh client quote data:');
+  const refreshClientOffersBestEffort = async () => {
+    const refreshClientOffers = async () => {
+      const offersData = await api.clientOffers.list();
+      setClientOffers(offersData);
+    };
+    const offersRefreshed = await refreshBestEffort(
+      refreshClientOffers,
+      'Failed to refresh client offers:',
+    );
+    if (!offersRefreshed) {
+      await refreshBestEffort(refreshClientOffers, 'Failed to retry client offers refresh:');
+    }
+  };
+
+  const refreshClientQuoteCachesBestEffort = async () => {
+    await Promise.all([
+      refreshBestEffort(async () => {
+        setQuotes(await api.quotes.list());
+      }, 'Failed to refresh client quotes:'),
+      refreshClientOffersBestEffort(),
+      refreshBestEffort(async () => {
+        setClientsOrders(await api.clientsOrders.list());
+      }, 'Failed to refresh client orders:'),
+    ]);
+  };
 
   const surfaceWarnings = (warnings?: string[]) => {
     for (const warning of warnings ?? []) {
@@ -164,7 +192,7 @@ export const makeQuoteHandlers = (deps: QuoteHandlersDeps) => {
         notifyClientOfferCreated?.(createdOffer);
       }
       await Promise.all([
-        createdOffer ? refreshClientQuoteFlowBestEffort() : refreshClientQuoteFlow(),
+        createdOffer ? refreshClientQuoteCachesBestEffort() : refreshClientQuoteFlow(),
         supplierRefreshNeeded ? refreshLinkedSupplierQuotes() : Promise.resolve(),
       ]);
     } catch (err) {
@@ -176,12 +204,16 @@ export const makeQuoteHandlers = (deps: QuoteHandlersDeps) => {
   const promoteQuoteCandidate = async (quoteId: string, candidateId: string) => {
     try {
       const result = await api.quotes.promote(quoteId, candidateId);
+      setClientOffers((prev) => [
+        result.offer,
+        ...prev.filter((offer) => offer.id !== result.offer.id),
+      ]);
       // Confirm the completed promotion immediately; the follow-up list refreshes can be slow.
       notifyClientOfferCreated?.({
         id: result.offer.id,
         revisionCode: result.offer.revisionCode,
       });
-      await Promise.all([refreshClientQuoteFlowBestEffort(), refreshLinkedSupplierQuotes()]);
+      await Promise.all([refreshClientQuoteCachesBestEffort(), refreshLinkedSupplierQuotes()]);
       return result;
     } catch (err) {
       console.error('Failed to promote quote candidate:', err);

--- a/hooks/handlers/quoteHandlers.ts
+++ b/hooks/handlers/quoteHandlers.ts
@@ -146,20 +146,21 @@ export const makeQuoteHandlers = (deps: QuoteHandlersDeps) => {
       // so a plain edit of an unsourced quote would otherwise refetch needlessly. The two flows
       // set disjoint state, so they run in parallel.
       const supplierRefreshNeeded = wasSourcing || sourcesSupplierQuote(updated);
-      await Promise.all([
-        refreshClientQuoteFlow(),
-        supplierRefreshNeeded ? refreshLinkedSupplierQuotes() : Promise.resolve(),
-      ]);
       if (
         updated.status === 'offer' &&
         previousQuote?.status !== 'offer' &&
         updated.linkedOfferId
       ) {
+        // Confirm the completed mutation immediately; the follow-up list refreshes can be slow.
         notifyClientOfferCreated?.({
           id: updated.linkedOfferId,
           revisionCode: updated.linkedOfferRevisionCode,
         });
       }
+      await Promise.all([
+        refreshClientQuoteFlow(),
+        supplierRefreshNeeded ? refreshLinkedSupplierQuotes() : Promise.resolve(),
+      ]);
     } catch (err) {
       console.error('Failed to update quote:', err);
       throw err;
@@ -169,11 +170,12 @@ export const makeQuoteHandlers = (deps: QuoteHandlersDeps) => {
   const promoteQuoteCandidate = async (quoteId: string, candidateId: string) => {
     try {
       const result = await api.quotes.promote(quoteId, candidateId);
-      await Promise.all([refreshClientQuoteFlow(), refreshLinkedSupplierQuotes()]);
+      // Confirm the completed promotion immediately; the follow-up list refreshes can be slow.
       notifyClientOfferCreated?.({
         id: result.offer.id,
         revisionCode: result.offer.revisionCode,
       });
+      await Promise.all([refreshClientQuoteFlow(), refreshLinkedSupplierQuotes()]);
       return result;
     } catch (err) {
       console.error('Failed to promote quote candidate:', err);

--- a/hooks/handlers/quoteHandlers.ts
+++ b/hooks/handlers/quoteHandlers.ts
@@ -89,18 +89,24 @@ export const makeQuoteHandlers = (deps: QuoteHandlersDeps) => {
     setInvoices(invoicesData);
   };
 
+  const refreshBestEffort = async (refresh: () => Promise<void>, errorMessage: string) => {
+    try {
+      await refresh();
+    } catch (refreshErr) {
+      console.error(errorMessage, refreshErr);
+    }
+  };
+
   // A linked supplier quote derives its visible status / isStatusSynced from its client quote at
   // read time (#779), so creating, changing, or severing that link — or changing the client
   // quote's status — can leave the separately-cached supplier quotes table showing stale
   // unsynced/draft state until a full module reload. Refresh it too, best-effort: a refresh
   // failure must not fail the primary write.
-  const refreshLinkedSupplierQuotes = async () => {
-    try {
-      await refreshSupplierQuoteFlow();
-    } catch (refreshErr) {
-      console.error('Failed to refresh supplier data:', refreshErr);
-    }
-  };
+  const refreshLinkedSupplierQuotes = () =>
+    refreshBestEffort(refreshSupplierQuoteFlow, 'Failed to refresh supplier data:');
+
+  const refreshClientQuoteFlowBestEffort = () =>
+    refreshBestEffort(refreshClientQuoteFlow, 'Failed to refresh client quote data:');
 
   const surfaceWarnings = (warnings?: string[]) => {
     for (const warning of warnings ?? []) {
@@ -146,19 +152,19 @@ export const makeQuoteHandlers = (deps: QuoteHandlersDeps) => {
       // so a plain edit of an unsourced quote would otherwise refetch needlessly. The two flows
       // set disjoint state, so they run in parallel.
       const supplierRefreshNeeded = wasSourcing || sourcesSupplierQuote(updated);
-      if (
-        updated.status === 'offer' &&
-        previousQuote?.status !== 'offer' &&
-        updated.linkedOfferId
-      ) {
+      const createdOffer =
+        updated.status === 'offer' && previousQuote?.status !== 'offer' && updated.linkedOfferId
+          ? {
+              id: updated.linkedOfferId,
+              revisionCode: updated.linkedOfferRevisionCode,
+            }
+          : undefined;
+      if (createdOffer) {
         // Confirm the completed mutation immediately; the follow-up list refreshes can be slow.
-        notifyClientOfferCreated?.({
-          id: updated.linkedOfferId,
-          revisionCode: updated.linkedOfferRevisionCode,
-        });
+        notifyClientOfferCreated?.(createdOffer);
       }
       await Promise.all([
-        refreshClientQuoteFlow(),
+        createdOffer ? refreshClientQuoteFlowBestEffort() : refreshClientQuoteFlow(),
         supplierRefreshNeeded ? refreshLinkedSupplierQuotes() : Promise.resolve(),
       ]);
     } catch (err) {
@@ -175,7 +181,7 @@ export const makeQuoteHandlers = (deps: QuoteHandlersDeps) => {
         id: result.offer.id,
         revisionCode: result.offer.revisionCode,
       });
-      await Promise.all([refreshClientQuoteFlow(), refreshLinkedSupplierQuotes()]);
+      await Promise.all([refreshClientQuoteFlowBestEffort(), refreshLinkedSupplierQuotes()]);
       return result;
     } catch (err) {
       console.error('Failed to promote quote candidate:', err);

--- a/hooks/handlers/quoteHandlers.ts
+++ b/hooks/handlers/quoteHandlers.ts
@@ -204,6 +204,7 @@ export const makeQuoteHandlers = (deps: QuoteHandlersDeps) => {
   const promoteQuoteCandidate = async (quoteId: string, candidateId: string) => {
     try {
       const result = await api.quotes.promote(quoteId, candidateId);
+      setQuotes((prev) => [result.quote, ...prev.filter((quote) => quote.id !== result.quote.id)]);
       setClientOffers((prev) => [
         result.offer,
         ...prev.filter((offer) => offer.id !== result.offer.id),

--- a/hooks/handlers/quoteHandlers.ts
+++ b/hooks/handlers/quoteHandlers.ts
@@ -13,6 +13,11 @@ import { addMonthsToDateOnly, getLocalDateString, isDateOnlyBeforeToday } from '
 import { sourcesSupplierQuote } from '../../utils/supplierLineSync';
 import { toastError } from '../../utils/toast';
 
+const prependById = <T extends { id: string }>(items: T[], item: T): T[] => [
+  item,
+  ...items.filter((current) => current.id !== item.id),
+];
+
 /**
  * Quote handlers read two pieces of shared state — `clientQuoteFilterId` and
  * `clientOfferFilterId` — both before and AFTER awaited network calls.
@@ -188,7 +193,9 @@ export const makeQuoteHandlers = (deps: QuoteHandlersDeps) => {
             }
           : undefined;
       if (createdOffer) {
-        // Confirm the completed mutation immediately; the follow-up list refreshes can be slow.
+        // Reconcile the completed mutation immediately; the follow-up list refreshes can be slow
+        // or fail independently after the server has already created the offer.
+        setQuotes((prev) => prependById(prev, updated));
         notifyClientOfferCreated?.(createdOffer);
       }
       await Promise.all([
@@ -204,11 +211,8 @@ export const makeQuoteHandlers = (deps: QuoteHandlersDeps) => {
   const promoteQuoteCandidate = async (quoteId: string, candidateId: string) => {
     try {
       const result = await api.quotes.promote(quoteId, candidateId);
-      setQuotes((prev) => [result.quote, ...prev.filter((quote) => quote.id !== result.quote.id)]);
-      setClientOffers((prev) => [
-        result.offer,
-        ...prev.filter((offer) => offer.id !== result.offer.id),
-      ]);
+      setQuotes((prev) => prependById(prev, result.quote));
+      setClientOffers((prev) => prependById(prev, result.offer));
       // Confirm the completed promotion immediately; the follow-up list refreshes can be slow.
       notifyClientOfferCreated?.({
         id: result.offer.id,

--- a/locales/en/sales.json
+++ b/locales/en/sales.json
@@ -291,6 +291,7 @@
     "addOffer": "Add offer",
     "failedToSave": "Failed to save the offer. Please retry.",
     "failedToDelete": "Failed to delete the offer. Please retry.",
+    "failedToLoad": "Failed to load the created offer. Please retry.",
     "failedToUpdateStatus": "Failed to update the offer status. Please retry.",
     "sourceQuote": "Source quote",
     "viewQuote": "View quote",

--- a/locales/it/sales.json
+++ b/locales/it/sales.json
@@ -291,6 +291,7 @@
     "addOffer": "Aggiungi offerta",
     "failedToSave": "Impossibile salvare l'offerta. Riprova.",
     "failedToDelete": "Impossibile eliminare l'offerta. Riprova.",
+    "failedToLoad": "Impossibile caricare l'offerta creata. Riprova.",
     "failedToUpdateStatus": "Impossibile aggiornare lo stato dell'offerta. Riprova.",
     "sourceQuote": "Preventivo di origine",
     "viewQuote": "Vedi preventivo",

--- a/test/components/ui/Sonner.test.tsx
+++ b/test/components/ui/Sonner.test.tsx
@@ -2,16 +2,16 @@ import { describe, expect, test } from 'bun:test';
 import { screen } from '@testing-library/react';
 import { toast } from 'sonner';
 import { Toaster } from '../../../components/ui/sonner';
-import { neutralSuccessToastClassNames } from '../../../components/ui/sonner-presets';
+import { offerCreatedToastClassNames } from '../../../components/ui/sonner-presets';
 import { render } from '../../helpers/render';
 
 describe('<Toaster />', () => {
-  test('supports a neutral themed success without disabling rich colors globally', async () => {
+  test('supports a primary themed offer success without disabling rich colors globally', async () => {
     const { container } = render(<Toaster richColors closeButton position="top-center" />);
 
     toast.success('Offer created', {
       description: 'OFF_26_0015',
-      classNames: neutralSuccessToastClassNames,
+      classNames: offerCreatedToastClassNames,
       action: {
         label: 'View offer',
         onClick: () => {},
@@ -27,15 +27,17 @@ describe('<Toaster />', () => {
 
     expect(toaster?.getAttribute('data-x-position')).toBe('center');
     expect(toastElement?.getAttribute('data-rich-colors')).toBe('true');
-    expect(toastElement?.className).toContain('bg-popover!');
-    expect(toastElement?.className).toContain('rounded-md!');
-    expect(description.className).toContain('text-muted-foreground!');
-    expect(action.className).toContain('bg-primary!');
+    expect(toastElement?.className).toContain('bg-primary!');
+    expect(toastElement?.className).toContain('rounded-lg!');
+    expect(description.className).toContain('text-primary-foreground/70!');
+    expect(action.className).toContain('bg-primary-foreground!');
     expect(action.className).toContain('rounded-md!');
-    expect(closeButton.className).toContain('right-1!');
-    expect(closeButton.className).toContain('top-0.5!');
-    expect(closeButton.className).toContain('size-5!');
+    expect(closeButton.className).toContain('right-2!');
+    expect(closeButton.className).toContain('top-2!');
+    expect(closeButton.className).toContain('size-6!');
     expect(closeButton.className).toContain('rounded-md!');
-    expect(successIcon?.className).toContain('text-primary!');
+    expect(closeButton.className).toContain('text-primary-foreground!');
+    expect(closeButton.className).toContain('[&_svg]:size-4!');
+    expect(successIcon?.className).toContain('text-primary-foreground!');
   });
 });

--- a/test/components/ui/Sonner.test.tsx
+++ b/test/components/ui/Sonner.test.tsx
@@ -1,58 +1,36 @@
-import { afterEach, describe, expect, test } from 'bun:test';
-import { screen } from '@testing-library/react';
-import { toast } from 'sonner';
-import { Toaster } from '../../../components/ui/sonner';
-import { offerCreatedToastClassNames } from '../../../components/ui/sonner-presets';
-import { render } from '../../helpers/render';
+import { describe, expect, test } from 'bun:test';
+import {
+  appToasterProps,
+  offerCreatedToastClassNames,
+  resolveSonnerTheme,
+} from '../../../components/ui/sonner-presets';
 
-describe('<Toaster />', () => {
-  afterEach(() => localStorage.removeItem('praetor_theme'));
-
-  test('inherits the selected app theme outside the layout theme scope', async () => {
-    localStorage.setItem('praetor_theme', 'dark');
-
-    const { container } = render(<Toaster />);
-    const themeScope = container.querySelector('[data-shadcn-theme-scope]');
-    toast('Theme probe');
-    const toaster = (await screen.findByText('Theme probe')).closest('[data-sonner-toaster]');
-
-    expect(themeScope?.getAttribute('data-shadcn-theme')).toBe('dark');
-    expect(themeScope?.className).toContain('dark');
-    expect(toaster?.getAttribute('data-sonner-theme')).toBe('dark');
+describe('Sonner configuration', () => {
+  test('maps the selected app theme to Sonner without overriding an explicit theme', () => {
+    expect(resolveSonnerTheme('dark')).toBe('dark');
+    expect(resolveSonnerTheme('light')).toBe('light');
+    expect(resolveSonnerTheme('zebra')).toBe('light');
+    expect(resolveSonnerTheme('praetor')).toBe('light');
+    expect(resolveSonnerTheme('dark', 'system')).toBe('system');
   });
 
-  test('supports a primary themed offer success without disabling rich colors globally', async () => {
-    const { container } = render(<Toaster richColors closeButton position="top-center" />);
-
-    toast.success('Offer created', {
-      description: 'OFF_26_0015',
-      classNames: offerCreatedToastClassNames,
-      action: {
-        label: 'View offer',
-        onClick: () => {},
-      },
+  test('configures centered rich toasts and primary offer styling', () => {
+    expect(appToasterProps).toEqual({
+      richColors: true,
+      closeButton: true,
+      position: 'top-center',
     });
-
-    const description = await screen.findByText('OFF_26_0015');
-    const action = screen.getByRole('button', { name: 'View offer' });
-    const closeButton = screen.getByRole('button', { name: 'Close toast' });
-    const toastElement = description.closest('[data-sonner-toast]');
-    const toaster = container.querySelector('[data-sonner-toaster]');
-    const successIcon = toastElement?.querySelector('[data-icon]');
-
-    expect(toaster?.getAttribute('data-x-position')).toBe('center');
-    expect(toastElement?.getAttribute('data-rich-colors')).toBe('true');
-    expect(toastElement?.className).toContain('bg-primary!');
-    expect(toastElement?.className).toContain('rounded-lg!');
-    expect(description.className).toContain('text-primary-foreground/70!');
-    expect(action.className).toContain('bg-primary-foreground!');
-    expect(action.className).toContain('rounded-md!');
-    expect(closeButton.className).toContain('right-2!');
-    expect(closeButton.className).toContain('top-2!');
-    expect(closeButton.className).toContain('size-6!');
-    expect(closeButton.className).toContain('rounded-md!');
-    expect(closeButton.className).toContain('text-primary-foreground!');
-    expect(closeButton.className).toContain('[&_svg]:size-4!');
-    expect(successIcon?.className).toContain('text-primary-foreground!');
+    expect(offerCreatedToastClassNames.toast).toContain('bg-primary!');
+    expect(offerCreatedToastClassNames.toast).toContain('rounded-lg!');
+    expect(offerCreatedToastClassNames.description).toContain('text-primary-foreground/70!');
+    expect(offerCreatedToastClassNames.actionButton).toContain('bg-primary-foreground!');
+    expect(offerCreatedToastClassNames.actionButton).toContain('rounded-md!');
+    expect(offerCreatedToastClassNames.closeButton).toContain('right-2!');
+    expect(offerCreatedToastClassNames.closeButton).toContain('top-2!');
+    expect(offerCreatedToastClassNames.closeButton).toContain('size-6!');
+    expect(offerCreatedToastClassNames.closeButton).toContain('rounded-md!');
+    expect(offerCreatedToastClassNames.closeButton).toContain('text-primary-foreground!');
+    expect(offerCreatedToastClassNames.closeButton).toContain('[&_svg]:size-4!');
+    expect(offerCreatedToastClassNames.icon).toContain('text-primary-foreground!');
   });
 });

--- a/test/components/ui/Sonner.test.tsx
+++ b/test/components/ui/Sonner.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, test } from 'bun:test';
+import { afterEach, describe, expect, test } from 'bun:test';
 import { screen } from '@testing-library/react';
 import { toast } from 'sonner';
 import { Toaster } from '../../../components/ui/sonner';
@@ -6,6 +6,21 @@ import { offerCreatedToastClassNames } from '../../../components/ui/sonner-prese
 import { render } from '../../helpers/render';
 
 describe('<Toaster />', () => {
+  afterEach(() => localStorage.removeItem('praetor_theme'));
+
+  test('inherits the selected app theme outside the layout theme scope', async () => {
+    localStorage.setItem('praetor_theme', 'dark');
+
+    const { container } = render(<Toaster />);
+    const themeScope = container.querySelector('[data-shadcn-theme-scope]');
+    toast('Theme probe');
+    const toaster = (await screen.findByText('Theme probe')).closest('[data-sonner-toaster]');
+
+    expect(themeScope?.getAttribute('data-shadcn-theme')).toBe('dark');
+    expect(themeScope?.className).toContain('dark');
+    expect(toaster?.getAttribute('data-sonner-theme')).toBe('dark');
+  });
+
   test('supports a primary themed offer success without disabling rich colors globally', async () => {
     const { container } = render(<Toaster richColors closeButton position="top-center" />);
 

--- a/test/components/ui/Sonner.test.tsx
+++ b/test/components/ui/Sonner.test.tsx
@@ -1,0 +1,34 @@
+import { describe, expect, test } from 'bun:test';
+import { screen } from '@testing-library/react';
+import { toast } from 'sonner';
+import { Toaster } from '../../../components/ui/sonner';
+import { neutralSuccessToastClassNames } from '../../../components/ui/sonner-presets';
+import { render } from '../../helpers/render';
+
+describe('<Toaster />', () => {
+  test('supports a neutral themed success without disabling rich colors globally', async () => {
+    render(<Toaster richColors closeButton />);
+
+    toast.success('Offer created', {
+      description: 'OFF_26_0015',
+      classNames: neutralSuccessToastClassNames,
+      action: {
+        label: 'View offer',
+        onClick: () => {},
+      },
+    });
+
+    const description = await screen.findByText('OFF_26_0015');
+    const action = screen.getByRole('button', { name: 'View offer' });
+    const closeButton = screen.getByRole('button', { name: 'Close toast' });
+    const toastElement = description.closest('[data-sonner-toast]');
+    const successIcon = toastElement?.querySelector('[data-icon]');
+
+    expect(toastElement?.getAttribute('data-rich-colors')).toBe('true');
+    expect(toastElement?.className).toContain('bg-popover!');
+    expect(description.className).toContain('text-muted-foreground!');
+    expect(action.className).toContain('bg-primary!');
+    expect(closeButton.className).toContain('bg-background!');
+    expect(successIcon?.className).toContain('text-emerald-600!');
+  });
+});

--- a/test/components/ui/Sonner.test.tsx
+++ b/test/components/ui/Sonner.test.tsx
@@ -7,7 +7,7 @@ import { render } from '../../helpers/render';
 
 describe('<Toaster />', () => {
   test('supports a neutral themed success without disabling rich colors globally', async () => {
-    render(<Toaster richColors closeButton />);
+    const { container } = render(<Toaster richColors closeButton position="top-center" />);
 
     toast.success('Offer created', {
       description: 'OFF_26_0015',
@@ -22,13 +22,20 @@ describe('<Toaster />', () => {
     const action = screen.getByRole('button', { name: 'View offer' });
     const closeButton = screen.getByRole('button', { name: 'Close toast' });
     const toastElement = description.closest('[data-sonner-toast]');
+    const toaster = container.querySelector('[data-sonner-toaster]');
     const successIcon = toastElement?.querySelector('[data-icon]');
 
+    expect(toaster?.getAttribute('data-x-position')).toBe('center');
     expect(toastElement?.getAttribute('data-rich-colors')).toBe('true');
     expect(toastElement?.className).toContain('bg-popover!');
+    expect(toastElement?.className).toContain('rounded-md!');
     expect(description.className).toContain('text-muted-foreground!');
     expect(action.className).toContain('bg-primary!');
-    expect(closeButton.className).toContain('bg-background!');
-    expect(successIcon?.className).toContain('text-emerald-600!');
+    expect(action.className).toContain('rounded-md!');
+    expect(closeButton.className).toContain('right-1!');
+    expect(closeButton.className).toContain('top-0.5!');
+    expect(closeButton.className).toContain('size-5!');
+    expect(closeButton.className).toContain('rounded-md!');
+    expect(successIcon?.className).toContain('text-primary!');
   });
 });

--- a/test/components/ui/Sonner.test.tsx
+++ b/test/components/ui/Sonner.test.tsx
@@ -2,6 +2,7 @@ import { describe, expect, test } from 'bun:test';
 import {
   appToasterProps,
   offerCreatedToastClassNames,
+  resolveOfferCreatedToastAction,
   resolveSonnerTheme,
 } from '../../../components/ui/sonner-presets';
 
@@ -32,5 +33,12 @@ describe('Sonner configuration', () => {
     expect(offerCreatedToastClassNames.closeButton).toContain('text-primary-foreground!');
     expect(offerCreatedToastClassNames.closeButton).toContain('[&_svg]:size-4!');
     expect(offerCreatedToastClassNames.icon).toContain('text-primary-foreground!');
+  });
+
+  test('only exposes the offer action when the user can view client offers', () => {
+    const action = { label: 'View offer', onClick: () => {} };
+
+    expect(resolveOfferCreatedToastAction(true, action)).toBe(action);
+    expect(resolveOfferCreatedToastAction(false, action)).toBeUndefined();
   });
 });

--- a/test/handlers/quoteHandlers.test.ts
+++ b/test/handlers/quoteHandlers.test.ts
@@ -396,6 +396,35 @@ describe('makeQuoteHandlers', () => {
     });
   });
 
+  test('updateQuote notifies before the client flow refetch completes', async () => {
+    let resolveQuotesRefetch: (quotes: unknown[]) => void = () => {};
+    const pendingQuotesRefetch = new Promise<unknown[]>((resolve) => {
+      resolveQuotesRefetch = resolve;
+    });
+    stubQuoteUpdateFlow({
+      status: 'offer',
+      linkedOfferId: 'q1-OF',
+      linkedOfferRevisionCode: 'REV2',
+      items: [],
+    });
+    apiMocks.quotesList.mockImplementation(() => pendingQuotesRefetch);
+    const ctx = buildHandlers({
+      quotes: [{ id: 'q1', status: 'sent', items: [] }],
+    });
+
+    const pendingUpdate = ctx.handlers.updateQuote('q1', { status: 'offer' } as never);
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(ctx.notifyClientOfferCreated).toHaveBeenCalledWith({
+      id: 'q1-OF',
+      revisionCode: 'REV2',
+    });
+
+    resolveQuotesRefetch([]);
+    await pendingUpdate;
+  });
+
   test('deleteQuote refreshes supplier quotes when the deleted quote sourced one', async () => {
     apiMocks.quotesDelete.mockImplementation(() => Promise.resolve());
     const refreshSupplierQuoteFlow = mock(() => Promise.resolve());
@@ -915,6 +944,32 @@ describe('makeQuoteHandlers', () => {
     expect(apiMocks.quotesPromote).toHaveBeenCalledWith('q-1', 'candidate-b');
     expect(ctx.notifyClientOfferCreated).toHaveBeenCalledWith({ id: 'of-1', revisionCode: 'REV1' });
     expect(ctx.refreshSupplierQuoteFlow).toHaveBeenCalled();
+  });
+
+  test('promoteQuoteCandidate notifies before flow refetches complete', async () => {
+    let resolveQuotesRefetch: (quotes: unknown[]) => void = () => {};
+    const pendingQuotesRefetch = new Promise<unknown[]>((resolve) => {
+      resolveQuotesRefetch = resolve;
+    });
+    apiMocks.quotesPromote.mockImplementation(() =>
+      Promise.resolve({ quote: { id: 'q-1' }, offer: { id: 'of-1', revisionCode: 'REV1' } }),
+    );
+    apiMocks.quotesList.mockImplementation(() => pendingQuotesRefetch);
+    apiMocks.clientOffersList.mockImplementation(() => Promise.resolve([{ id: 'of-1' }]));
+    apiMocks.clientsOrdersList.mockImplementation(() => Promise.resolve([]));
+    const ctx = buildHandlers();
+
+    const pendingPromotion = ctx.handlers.promoteQuoteCandidate('q-1', 'candidate-b');
+    await Promise.resolve();
+    await Promise.resolve();
+
+    expect(ctx.notifyClientOfferCreated).toHaveBeenCalledWith({
+      id: 'of-1',
+      revisionCode: 'REV1',
+    });
+
+    resolveQuotesRefetch([]);
+    await pendingPromotion;
   });
 
   test('createClientOfferFromLegacyQuote creates and links the missing first offer', async () => {

--- a/test/handlers/quoteHandlers.test.ts
+++ b/test/handlers/quoteHandlers.test.ts
@@ -94,6 +94,7 @@ type QuoteLike = {
   isExpired?: boolean;
   expirationDate?: string;
   linkedOfferId?: string;
+  linkedOfferRevisionCode?: string | null;
   linkedSupplierQuoteId?: string | null;
   candidates?: Array<{
     id: string;
@@ -393,7 +394,10 @@ describe('makeQuoteHandlers', () => {
       items: [],
     });
     const ctx = buildHandlers({
-      quotes: [{ id: 'q1', status: 'sent', items: [] }],
+      quotes: [
+        { id: 'q1', status: 'sent', items: [] },
+        { id: 'q-existing', status: 'draft' },
+      ],
     });
 
     await ctx.handlers.updateQuote('q1', { status: 'offer' } as never);
@@ -442,7 +446,10 @@ describe('makeQuoteHandlers', () => {
       .mockRejectedValueOnce(new Error('offers refresh failed'))
       .mockResolvedValueOnce([{ id: 'q1-OF' }]);
     const ctx = buildHandlers({
-      quotes: [{ id: 'q1', status: 'sent', items: [] }],
+      quotes: [
+        { id: 'q1', status: 'sent', items: [] },
+        { id: 'q-existing', status: 'draft' },
+      ],
     });
     const restore = silenceConsole();
 
@@ -455,6 +462,16 @@ describe('makeQuoteHandlers', () => {
         revisionCode: 'REV2',
       });
       expect(apiMocks.clientOffersList).toHaveBeenCalledTimes(2);
+      expect(ctx.quotes.get()).toEqual([
+        {
+          id: 'q1',
+          status: 'offer',
+          linkedOfferId: 'q1-OF',
+          linkedOfferRevisionCode: 'REV2',
+          items: [],
+        },
+        { id: 'q-existing', status: 'draft' },
+      ]);
       expect(ctx.clientOffers.get()).toEqual([{ id: 'q1-OF' }]);
     } finally {
       restore();

--- a/test/handlers/quoteHandlers.test.ts
+++ b/test/handlers/quoteHandlers.test.ts
@@ -1007,7 +1007,11 @@ describe('makeQuoteHandlers', () => {
 
   test('promoteQuoteCandidate stays successful when the client refetch fails', async () => {
     const result = {
-      quote: { id: 'q-1' },
+      quote: {
+        id: 'q-1',
+        status: 'offer',
+        candidates: [{ id: 'candidate-b', state: 'promoted' }],
+      },
       offer: { id: 'of-1', revisionCode: 'REV1' },
     };
     apiMocks.quotesPromote.mockImplementation(() => Promise.resolve(result));
@@ -1016,12 +1020,23 @@ describe('makeQuoteHandlers', () => {
       Promise.reject(new Error('offers refresh failed')),
     );
     apiMocks.clientsOrdersList.mockImplementation(() => Promise.resolve([]));
-    const ctx = buildHandlers({ clientOffers: [{ id: 'of-existing' }] });
+    const ctx = buildHandlers({
+      quotes: [
+        {
+          id: 'q-1',
+          status: 'sent',
+          candidates: [{ id: 'candidate-b', state: 'pending' }],
+        },
+        { id: 'q-existing', status: 'draft' },
+      ],
+      clientOffers: [{ id: 'of-existing' }],
+    });
     const restore = silenceConsole();
 
     try {
       const promotion = await ctx.handlers.promoteQuoteCandidate('q-1', 'candidate-b');
       expect(promotion.offer.id).toBe('of-1');
+      expect(ctx.quotes.get()).toEqual([result.quote, { id: 'q-existing', status: 'draft' }]);
       expect(ctx.clientOffers.get().map((offer) => offer.id)).toEqual(['of-1', 'of-existing']);
       expect(ctx.notifyClientOfferCreated).toHaveBeenCalledWith({
         id: 'of-1',

--- a/test/handlers/quoteHandlers.test.ts
+++ b/test/handlers/quoteHandlers.test.ts
@@ -133,6 +133,14 @@ const makeStubScalar = <T>(initial: T) => {
   return { setter, get: () => value };
 };
 
+const deferValue = <T>() => {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve;
+  });
+  return { promise, resolve };
+};
+
 const buildHandlers = (overrides: Record<string, unknown> = {}) => {
   const quotes = makeStubSetter<QuoteLike>((overrides.quotes as QuoteLike[] | undefined) ?? []);
   const clientOffers = makeStubSetter<ClientOfferLike>(
@@ -397,17 +405,14 @@ describe('makeQuoteHandlers', () => {
   });
 
   test('updateQuote notifies before the client flow refetch completes', async () => {
-    let resolveQuotesRefetch: (quotes: unknown[]) => void = () => {};
-    const pendingQuotesRefetch = new Promise<unknown[]>((resolve) => {
-      resolveQuotesRefetch = resolve;
-    });
+    const quotesRefetch = deferValue<unknown[]>();
     stubQuoteUpdateFlow({
       status: 'offer',
       linkedOfferId: 'q1-OF',
       linkedOfferRevisionCode: 'REV2',
       items: [],
     });
-    apiMocks.quotesList.mockImplementation(() => pendingQuotesRefetch);
+    apiMocks.quotesList.mockImplementation(() => quotesRefetch.promise);
     const ctx = buildHandlers({
       quotes: [{ id: 'q1', status: 'sent', items: [] }],
     });
@@ -421,8 +426,34 @@ describe('makeQuoteHandlers', () => {
       revisionCode: 'REV2',
     });
 
-    resolveQuotesRefetch([]);
+    quotesRefetch.resolve([]);
     await pendingUpdate;
+  });
+
+  test('updateQuote keeps a created offer successful when the client refetch fails', async () => {
+    stubQuoteUpdateFlow({
+      status: 'offer',
+      linkedOfferId: 'q1-OF',
+      linkedOfferRevisionCode: 'REV2',
+      items: [],
+    });
+    apiMocks.quotesList.mockImplementation(() => Promise.reject(new Error('refresh failed')));
+    const ctx = buildHandlers({
+      quotes: [{ id: 'q1', status: 'sent', items: [] }],
+    });
+    const restore = silenceConsole();
+
+    try {
+      await expect(
+        ctx.handlers.updateQuote('q1', { status: 'offer' } as never),
+      ).resolves.toBeUndefined();
+      expect(ctx.notifyClientOfferCreated).toHaveBeenCalledWith({
+        id: 'q1-OF',
+        revisionCode: 'REV2',
+      });
+    } finally {
+      restore();
+    }
   });
 
   test('deleteQuote refreshes supplier quotes when the deleted quote sourced one', async () => {
@@ -947,14 +978,11 @@ describe('makeQuoteHandlers', () => {
   });
 
   test('promoteQuoteCandidate notifies before flow refetches complete', async () => {
-    let resolveQuotesRefetch: (quotes: unknown[]) => void = () => {};
-    const pendingQuotesRefetch = new Promise<unknown[]>((resolve) => {
-      resolveQuotesRefetch = resolve;
-    });
+    const quotesRefetch = deferValue<unknown[]>();
     apiMocks.quotesPromote.mockImplementation(() =>
       Promise.resolve({ quote: { id: 'q-1' }, offer: { id: 'of-1', revisionCode: 'REV1' } }),
     );
-    apiMocks.quotesList.mockImplementation(() => pendingQuotesRefetch);
+    apiMocks.quotesList.mockImplementation(() => quotesRefetch.promise);
     apiMocks.clientOffersList.mockImplementation(() => Promise.resolve([{ id: 'of-1' }]));
     apiMocks.clientsOrdersList.mockImplementation(() => Promise.resolve([]));
     const ctx = buildHandlers();
@@ -968,8 +996,32 @@ describe('makeQuoteHandlers', () => {
       revisionCode: 'REV1',
     });
 
-    resolveQuotesRefetch([]);
+    quotesRefetch.resolve([]);
     await pendingPromotion;
+  });
+
+  test('promoteQuoteCandidate stays successful when the client refetch fails', async () => {
+    const result = {
+      quote: { id: 'q-1' },
+      offer: { id: 'of-1', revisionCode: 'REV1' },
+    };
+    apiMocks.quotesPromote.mockImplementation(() => Promise.resolve(result));
+    apiMocks.quotesList.mockImplementation(() => Promise.reject(new Error('refresh failed')));
+    apiMocks.clientOffersList.mockImplementation(() => Promise.resolve([{ id: 'of-1' }]));
+    apiMocks.clientsOrdersList.mockImplementation(() => Promise.resolve([]));
+    const ctx = buildHandlers();
+    const restore = silenceConsole();
+
+    try {
+      const promotion = await ctx.handlers.promoteQuoteCandidate('q-1', 'candidate-b');
+      expect(promotion.offer.id).toBe('of-1');
+      expect(ctx.notifyClientOfferCreated).toHaveBeenCalledWith({
+        id: 'of-1',
+        revisionCode: 'REV1',
+      });
+    } finally {
+      restore();
+    }
   });
 
   test('createClientOfferFromLegacyQuote creates and links the missing first offer', async () => {

--- a/test/handlers/quoteHandlers.test.ts
+++ b/test/handlers/quoteHandlers.test.ts
@@ -438,6 +438,9 @@ describe('makeQuoteHandlers', () => {
       items: [],
     });
     apiMocks.quotesList.mockImplementation(() => Promise.reject(new Error('refresh failed')));
+    apiMocks.clientOffersList
+      .mockRejectedValueOnce(new Error('offers refresh failed'))
+      .mockResolvedValueOnce([{ id: 'q1-OF' }]);
     const ctx = buildHandlers({
       quotes: [{ id: 'q1', status: 'sent', items: [] }],
     });
@@ -451,6 +454,8 @@ describe('makeQuoteHandlers', () => {
         id: 'q1-OF',
         revisionCode: 'REV2',
       });
+      expect(apiMocks.clientOffersList).toHaveBeenCalledTimes(2);
+      expect(ctx.clientOffers.get()).toEqual([{ id: 'q1-OF' }]);
     } finally {
       restore();
     }
@@ -1007,14 +1012,17 @@ describe('makeQuoteHandlers', () => {
     };
     apiMocks.quotesPromote.mockImplementation(() => Promise.resolve(result));
     apiMocks.quotesList.mockImplementation(() => Promise.reject(new Error('refresh failed')));
-    apiMocks.clientOffersList.mockImplementation(() => Promise.resolve([{ id: 'of-1' }]));
+    apiMocks.clientOffersList.mockImplementation(() =>
+      Promise.reject(new Error('offers refresh failed')),
+    );
     apiMocks.clientsOrdersList.mockImplementation(() => Promise.resolve([]));
-    const ctx = buildHandlers();
+    const ctx = buildHandlers({ clientOffers: [{ id: 'of-existing' }] });
     const restore = silenceConsole();
 
     try {
       const promotion = await ctx.handlers.promoteQuoteCandidate('q-1', 'candidate-b');
       expect(promotion.offer.id).toBe('of-1');
+      expect(ctx.clientOffers.get().map((offer) => offer.id)).toEqual(['of-1', 'of-existing']);
       expect(ctx.notifyClientOfferCreated).toHaveBeenCalledWith({
         id: 'of-1',
         revisionCode: 'REV1',

--- a/test/utils/clientOfferNavigation.test.ts
+++ b/test/utils/clientOfferNavigation.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, mock, test } from 'bun:test';
+import { ensureClientOfferAvailable } from '../../utils/clientOfferNavigation';
+
+describe('ensureClientOfferAvailable', () => {
+  test('reuses the local cache when it already contains the created offer', async () => {
+    const currentOffers = [{ id: 'offer-1' }];
+    const loadOffers = mock(() => Promise.resolve([{ id: 'offer-1' }]));
+
+    await expect(ensureClientOfferAvailable('offer-1', currentOffers, loadOffers)).resolves.toBe(
+      currentOffers,
+    );
+    expect(loadOffers).not.toHaveBeenCalled();
+  });
+
+  test('reloads a missing created offer before navigation can continue', async () => {
+    const loadedOffers = [{ id: 'offer-1' }, { id: 'offer-2' }];
+
+    await expect(
+      ensureClientOfferAvailable('offer-2', [{ id: 'offer-1' }], () =>
+        Promise.resolve(loadedOffers),
+      ),
+    ).resolves.toBe(loadedOffers);
+  });
+
+  test('rejects when a successful reload still cannot provide the created offer', async () => {
+    await expect(
+      ensureClientOfferAvailable('offer-2', [], () => Promise.resolve([{ id: 'offer-1' }])),
+    ).rejects.toThrow('Created client offer offer-2 is not available');
+  });
+});

--- a/utils/clientOfferNavigation.ts
+++ b/utils/clientOfferNavigation.ts
@@ -1,0 +1,15 @@
+export const ensureClientOfferAvailable = async <T extends { id: string }>(
+  offerId: string,
+  currentOffers: T[],
+  loadOffers: () => Promise<T[]>,
+): Promise<T[]> => {
+  if (currentOffers.some((offer) => offer.id === offerId)) {
+    return currentOffers;
+  }
+
+  const offers = await loadOffers();
+  if (!offers.some((offer) => offer.id === offerId)) {
+    throw new Error(`Created client offer ${offerId} is not available`);
+  }
+  return offers;
+};


### PR DESCRIPTION
## Summary
- Shows the client-offer success toast immediately after the mutation succeeds.
- Matches the shadcn `primary` surface and button radii, with inverse light/dark presentation.
- Centers notifications and uses the same visible close-control sizing as the notification panel.

## Changes
- Uses shadcn theme tokens for the toast, action, icon, and close control.
- Synchronizes Sonner with the selected app theme while keeping the inverse primary appearance.
- Makes post-mutation list refreshes best-effort so a successful conversion is never reported as failed.
- Reconciles returned quotes and offers into local state before fallible refreshes.
- Reloads a missing created offer before the “View offer” action navigates, preventing an empty stale view.
- Hides “View offer” when the current user lacks `sales.client_offers.view`.
- Adds Italian and English feedback when the created offer cannot be loaded.

## Testing
- `bun test test/utils/clientOfferNavigation.test.ts test/components/ui/Sonner.test.tsx test/handlers/quoteHandlers.test.ts` — 55 passed
- `bun run i18n:check`
- `bun run typecheck`
- `bun run build`
- `bunx biome check App.tsx utils/clientOfferNavigation.ts test/utils/clientOfferNavigation.test.ts`
- Visual QA in light and dark themes
- `bun run test:react-doctor` — unchanged at 79/100; two pre-existing findings remain outside this change
- Codex review loop — final review clean; all six prior threads resolved

## Risks / Rollout
- Low risk. The toast remains immediate, while follow-up reads no longer invalidate a completed server mutation.
- The action performs at most one additional offers read when the created offer is absent from local state.
- No database, API, configuration, deployment, or user-documentation changes.

## Issues
Issue: Not linked
