### PR TITLE
app(chore): bump version to 0.13.0

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Praetor API",
     "description": "Praetor API documentation",
-    "version": "0.12.0"
+    "version": "0.13.0"
   },
   "components": {
     "securitySchemes": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praetor",
   "private": true,
-  "version": "0.12.0",
+  "version": "0.13.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praetor-server",
-  "version": "0.12.0",
+  "version": "0.13.0",
   "description": "Praetor API Server",
   "main": "index.ts",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bumps the application version from 0.12.0 to 0.13.0 for the next minor release.

## Changes
- Update package.json and server/package.json version fields.
- Update the OpenAPI spec info.version in docs/api/openapi.json.

## Testing
- Not run (version metadata only).

## Risks / Rollout
- Low risk. No runtime or schema changes.

## Issues
Not linked

Made with [Cursor](https://cursor.com)