### PR TITLE
timesheets(fix): disable submit until notes are filled

### DIFF
--- a/components/timesheet/DailyView.tsx
+++ b/components/timesheet/DailyView.tsx
@@ -298,6 +298,8 @@ const DailyView: React.FC<DailyViewProps> = ({
   });
 
   const hasValidDuration = parseFloat(duration) > 0;
+  const trimmedNotes = notes.trim();
+  const canSubmit = hasValidDuration && trimmedNotes.length > 0;
 
   if (loadedSelectedDate !== selectedDate) {
     // react-doctor-disable-next-line react-doctor/no-impure-state-updater -- React-supported prop snapshot adjustment; no updater callback is involved.
@@ -311,6 +313,8 @@ const DailyView: React.FC<DailyViewProps> = ({
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    if (!canSubmit) return;
+
     dispatchForm({ type: 'setErrors', errors: {} });
 
     const newErrors: DailyEntryErrors = {};
@@ -321,7 +325,7 @@ const DailyView: React.FC<DailyViewProps> = ({
     if (!selection.taskName) {
       newErrors.task = t('entry.taskRequired');
     }
-    if (!notes.trim()) newErrors.notes = t('entry.notesRequired');
+    if (!trimmedNotes) newErrors.notes = t('entry.notesRequired');
 
     if (makeRecurring && recurrenceEndDate && date && recurrenceEndDate < date) {
       newErrors.recurrenceEndDate = t('entry.endDateAfterStart');
@@ -342,7 +346,7 @@ const DailyView: React.FC<DailyViewProps> = ({
       projectId: selection.projectId,
       projectName: project?.name || 'General',
       task: selection.taskName,
-      notes,
+      notes: trimmedNotes,
       duration: durationVal,
       location: selection.location,
     });
@@ -474,7 +478,7 @@ const DailyView: React.FC<DailyViewProps> = ({
           </Field>
 
           <div className="min-w-0 flex items-end">
-            <Button type="submit" disabled={!hasValidDuration} className="h-10 w-full rounded-lg">
+            <Button type="submit" disabled={!canSubmit} className="h-10 w-full rounded-lg">
               <Save className="size-4" aria-hidden="true" />
               {t('entry.logTime')}
             </Button>

--- a/test/components/timesheet/DailyView.test.tsx
+++ b/test/components/timesheet/DailyView.test.tsx
@@ -237,7 +237,7 @@ describe('<DailyView /> RBAC catalog sync', () => {
     });
   });
 
-  test('keeps note validation reachable once positive hours are entered', async () => {
+  test('disables submit until hours and notes are both filled', async () => {
     const onAdd = mock(() => {});
     const props = {
       onAdd,
@@ -254,26 +254,68 @@ describe('<DailyView /> RBAC catalog sync', () => {
     expect(submitButton).toBeDisabled();
 
     const hoursInput = screen.getByPlaceholderText('0,0');
+    const notesInput = screen.getByPlaceholderText('entry.notesPlaceholder');
+
     fireEvent.change(hoursInput, { target: { value: '1,5' } });
-    expect(submitButton).not.toBeDisabled();
+    expect(submitButton).toBeDisabled();
 
-    fireEvent.click(submitButton);
-    await waitFor(() => {
-      expect(document.body).toHaveTextContent('entry.notesRequired');
-    });
+    fireEvent.change(notesInput, { target: { value: '   ' } });
+    expect(submitButton).toBeDisabled();
+
+    fireEvent.submit(document.querySelector('form')!);
     expect(onAdd).not.toHaveBeenCalled();
-
-    fireEvent.change(screen.getByPlaceholderText('entry.notesPlaceholder'), {
-      target: { value: 'Implemented validation' },
-    });
     expect(document.body).not.toHaveTextContent('entry.notesRequired');
+
+    fireEvent.change(notesInput, { target: { value: 'Implemented validation' } });
     expect(submitButton).not.toBeDisabled();
 
+    fireEvent.change(notesInput, { target: { value: '' } });
+    expect(submitButton).toBeDisabled();
+
+    fireEvent.change(notesInput, { target: { value: 'Implemented validation' } });
     fireEvent.change(hoursInput, { target: { value: '0' } });
     expect(submitButton).toBeDisabled();
 
     fireEvent.change(hoursInput, { target: { value: '' } });
     expect(submitButton).toBeDisabled();
+  });
+
+  test('submits trimmed notes when hours and notes are valid', async () => {
+    const onAdd = mock(() => {});
+
+    render(
+      <DailyView
+        onAdd={onAdd}
+        selectedDate="2026-05-11"
+        permissions={[]}
+        dailyGoal={8}
+        currentDayTotal={0}
+        {...defaultModalProps}
+        {...alphaCatalog}
+      />,
+    );
+
+    await waitFor(() => {
+      expect(document.body).toHaveTextContent('Alpha Task');
+    });
+
+    fireEvent.change(screen.getByPlaceholderText('0,0'), { target: { value: '2' } });
+    fireEvent.change(screen.getByPlaceholderText('entry.notesPlaceholder'), {
+      target: { value: '  API work  ' },
+    });
+    fireEvent.click(screen.getByText('entry.logTime'));
+
+    await waitFor(() => {
+      expect(onAdd).toHaveBeenCalledTimes(1);
+    });
+    const payload = (onAdd as unknown as { mock: { calls: unknown[][] } }).mock.calls[0][0] as {
+      notes: string;
+      duration: number;
+      task: string;
+    };
+    expect(payload.notes).toBe('API work');
+    expect(payload.duration).toBe(2);
+    expect(payload.task).toBe('Alpha Task');
   });
 
   test('hides expired projects without the expired-project override permission', async () => {


### PR DESCRIPTION
## Summary
- Keeps the daily timesheet **Registra Tempo** button disabled until both hours and non-empty notes are present.
- Closes the gap left by #1100, where notes were required but the button stayed active once hours were filled.

## Changes
- Gates `DailyView` submit on trimmed notes as well as positive hours.
- Rejects form submit while the gate is incomplete and persists trimmed notes.
- Updates regression coverage for the disabled-button contract and trimmed-note submit.

## Testing
- `bun test test/components/timesheet/DailyView.test.tsx` — passed (9 tests).

## Risks / Rollout
- Low risk, frontend-only UX change on the daily entry form.
- Notes remain required after #1100; this only prevents clicking submit before notes are filled.
- No migration or API contract change.

## Issues
Follow-up to #1100