### PR TITLE
tables(fix): align StandardTable row avatars to employee density

### DIFF
--- a/components/HR/ExternalEmployeesView.tsx
+++ b/components/HR/ExternalEmployeesView.tsx
@@ -27,6 +27,7 @@ import {
 } from '../shared/ModalLayout';
 import StandardTable, { type Column } from '../shared/StandardTable';
 import StatusBadge from '../shared/StatusBadge';
+import { TABLE_ROW_AVATAR_CLASSNAME } from '../shared/tableControlStyles';
 import EmployeeAssignmentsModal from './EmployeeAssignmentsModal';
 import EmployeeHrFields from './EmployeeHrFields';
 import {
@@ -156,7 +157,7 @@ const ExternalEmployeesTable: React.FC<ExternalEmployeesTableProps> = ({
         accessorKey: 'name',
         cell: ({ row }) => (
           <div className="flex items-center gap-3">
-            <div className="size-6 rounded-full bg-amber-100 text-amber-700 flex items-center justify-center font-bold text-xs">
+            <div className={`${TABLE_ROW_AVATAR_CLASSNAME} bg-amber-100 text-amber-700`}>
               {row.avatarInitials}
             </div>
             <span className="font-semibold text-foreground">{row.name}</span>
@@ -198,15 +199,15 @@ const ExternalEmployeesTable: React.FC<ExternalEmployeesTableProps> = ({
         id: 'roleTitle',
         accessorFn: (row) => row.jobTitle || '',
         cell: ({ row }) => (
-          <div className="flex min-w-36 flex-col gap-0.5 text-sm">
+          <div className="flex min-w-36 items-center gap-1.5 text-sm">
             <OptionalText
               value={row.jobTitle}
               fallback={notSetLabel}
               className="font-medium text-foreground"
             />
             {row.contractType && (
-              <span className="text-xs text-muted-foreground">
-                {t(`employeeProfile.contractTypes.${row.contractType}`)}
+              <span className="truncate text-xs text-muted-foreground">
+                · {t(`employeeProfile.contractTypes.${row.contractType}`)}
               </span>
             )}
           </div>

--- a/components/HR/InternalEmployeesView.tsx
+++ b/components/HR/InternalEmployeesView.tsx
@@ -27,6 +27,7 @@ import {
 } from '../shared/ModalLayout';
 import StandardTable, { type Column } from '../shared/StandardTable';
 import StatusBadge from '../shared/StatusBadge';
+import { TABLE_ROW_AVATAR_CLASSNAME } from '../shared/tableControlStyles';
 import EmployeeAssignmentsModal from './EmployeeAssignmentsModal';
 import EmployeeHrFields from './EmployeeHrFields';
 import {
@@ -156,7 +157,7 @@ const InternalEmployeesTable: React.FC<InternalEmployeesTableProps> = ({
         accessorKey: 'name',
         cell: ({ row }) => (
           <div className="flex items-center gap-3">
-            <div className="size-6 rounded-full bg-praetor/10 text-praetor flex items-center justify-center font-bold text-xs">
+            <div className={`${TABLE_ROW_AVATAR_CLASSNAME} bg-praetor/10 text-praetor`}>
               {row.avatarInitials}
             </div>
             <span className="font-semibold text-foreground">{row.name}</span>

--- a/components/administration/UserManagement.tsx
+++ b/components/administration/UserManagement.tsx
@@ -49,6 +49,7 @@ import Modal from '../shared/Modal';
 import SelectControl from '../shared/SelectControl';
 import StandardTable, { type Column } from '../shared/StandardTable';
 import StatusBadge, { type StatusType } from '../shared/StatusBadge';
+import { TABLE_ROW_AVATAR_CLASSNAME } from '../shared/tableControlStyles';
 
 const isSsoAuthMethod = (authMethod: UserAuthMethod): authMethod is 'oidc' | 'saml' =>
   authMethod === 'oidc' || authMethod === 'saml';
@@ -1040,7 +1041,7 @@ const useUserManagementController = ({
       accessorKey: 'name',
       cell: ({ row }) => (
         <div className="flex items-center gap-3">
-          <div className="size-8 rounded-full bg-zinc-100 text-praetor flex items-center justify-center text-xs font-bold">
+          <div className={`${TABLE_ROW_AVATAR_CLASSNAME} bg-zinc-100 text-praetor`}>
             {row.avatarInitials}
           </div>
           <span className="font-bold text-zinc-800">{row.name}</span>

--- a/components/shared/tableControlStyles.ts
+++ b/components/shared/tableControlStyles.ts
@@ -5,3 +5,7 @@ export const TABLE_CONTROL_BUTTON_CLASSNAME =
 // Semantic actions (delete = destructive red, mark-as-sent = blue) keep their own colors.
 export const TABLE_ROW_ACTION_BUTTON_CLASSNAME =
   'rounded-lg p-2 text-muted-foreground transition-all hover:bg-muted hover:text-praetor';
+
+/** Initials avatar in StandardTable name cells. Keep size-6 so row height matches HR employees. */
+export const TABLE_ROW_AVATAR_CLASSNAME =
+  'size-6 shrink-0 rounded-full flex items-center justify-center font-bold text-xs';

--- a/test/components/administration/UserManagement.test.tsx
+++ b/test/components/administration/UserManagement.test.tsx
@@ -136,6 +136,7 @@ describe('<UserManagement />', () => {
     renderUserManagement();
 
     expect(screen.getByText('Alice Admin')).toBeInTheDocument();
+    expect(screen.getByText('AA')).toHaveClass('size-6');
     expect(screen.getByText('alice.admin')).toBeInTheDocument();
     expect(screen.getByText('alice@example.com')).toBeInTheDocument();
     expect(screen.getByText('manager')).toBeInTheDocument();

--- a/test/components/hr/ExternalEmployeesView.rowClick.test.tsx
+++ b/test/components/hr/ExternalEmployeesView.rowClick.test.tsx
@@ -205,6 +205,10 @@ describe('<ExternalEmployeesView /> row click', () => {
       within(row).queryByText('employeeProfile.employmentStatuses.active'),
     ).not.toBeInTheDocument();
     expect(within(row).getAllByText('employeeProfile.notSet').length).toBeGreaterThanOrEqual(4);
+    const contractType = within(row).getByText(/employeeProfile\.contractTypes\.contractor/);
+    expect(contractType).toHaveTextContent('·');
+    expect(contractType.parentElement).toHaveClass('items-center');
+    expect(contractType.parentElement).not.toHaveClass('flex-col');
 
     fireEvent.click(row);
 


### PR DESCRIPTION
﻿## Summary
- Aligns StandardTable name-cell avatars to the compact `size-6` density used on internal employees.
- Keeps external employee job title and contract type on one row so list height matches other StandardTable views.

## Changes
- Adds shared `TABLE_ROW_AVATAR_CLASSNAME` and applies it in HR employee tables and User Management.
- Flattens the external employees job-title cell from a two-line stack to a single-line layout.
- Adds regression coverage for avatar size and the single-line contract-type layout.

## Testing
- `bun test test/components/hr/InternalEmployeesView.rowClick.test.tsx test/components/hr/ExternalEmployeesView.rowClick.test.tsx test/components/administration/UserManagement.test.tsx` — 53 passed
- `bun run test:react-doctor` — score unchanged at 79/100
- Documentation unchanged (visual consistency only; no workflow or API impact)

## Risks / Rollout
- Low risk. Visual-only change limited to table cell content sizing; no API, permission, migration, or config impact.

## Issues
Issue: Not linked
