### PR TITLE
ui(fix): unify Sonner toast styling across the app

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -11,7 +11,6 @@ import React, {
   useState,
 } from 'react';
 import { useTranslation } from 'react-i18next';
-import { toast } from 'sonner';
 import { Button } from '@/components/ui/button';
 import { FieldLabel } from '@/components/ui/field';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
@@ -69,11 +68,7 @@ import RilView from './components/timesheet/RilView';
 import WeeklyView from './components/timesheet/WeeklyView';
 import UserSettings, { type UserSettingsTab } from './components/UserSettings';
 import { Toaster } from './components/ui/sonner';
-import {
-  appToasterProps,
-  offerCreatedToastClassNames,
-  resolveOfferCreatedToastAction,
-} from './components/ui/sonner-presets';
+import { appToasterProps, resolveOfferCreatedToastAction } from './components/ui/sonner-presets';
 import WorkUnitsView from './components/WorkUnitsView';
 import { CurrentUserIdProvider } from './contexts/CurrentUserContext';
 import { makeClientHandlers } from './hooks/handlers/clientHandlers';
@@ -1828,9 +1823,8 @@ const useAppContentController = () => {
   );
   const notifyClientOfferCreated = useCallback(
     (offer: Pick<ClientOffer, 'id' | 'revisionCode'>) => {
-      toast.success(tApp('sales:clientQuotes.offerCreatedToast'), {
+      toastSuccess(tApp('sales:clientQuotes.offerCreatedToast'), {
         description: formatDocumentCode(offer.id, offer.revisionCode),
-        classNames: offerCreatedToastClassNames,
         action: resolveOfferCreatedToastAction(canViewClientOffers, {
           label: tApp('sales:clientQuotes.viewOffer'),
           onClick: async () => {
@@ -1866,7 +1860,7 @@ const useAppContentController = () => {
 
   const notifyClientOrderCreated = useCallback(
     (orderId: string) => {
-      toast.success(tApp('accounting:clientsOrders.orderCreatedToast'), {
+      toastSuccess(tApp('accounting:clientsOrders.orderCreatedToast'), {
         description: orderId,
         action: {
           label: tApp('accounting:clientsOrders.viewOrder'),
@@ -1882,7 +1876,7 @@ const useAppContentController = () => {
 
   const notifySupplierOrderCreated = useCallback(
     (order: { id: string; supplierName: string }) => {
-      toast.success(tApp('accounting:supplierOrders.orderCreatedToast'), {
+      toastSuccess(tApp('accounting:supplierOrders.orderCreatedToast'), {
         description: `${order.id} - ${order.supplierName}`,
         action: {
           label: tApp('accounting:supplierOrders.viewOrder'),

--- a/components/administration/SiemLogsTab.tsx
+++ b/components/administration/SiemLogsTab.tsx
@@ -11,7 +11,6 @@ import {
 import type React from 'react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { toast } from 'sonner';
 import {
   logsApi,
   type SiemConfig,
@@ -19,6 +18,7 @@ import {
   type SiemStatus,
 } from '../../services/api/logs';
 import { formatNumber } from '../../utils/numbers';
+import { toastError, toastSuccess } from '../../utils/toast';
 import SecretField from '../shared/SecretField';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
@@ -251,7 +251,7 @@ const SiemLogsTab: React.FC<Props> = ({ canUpdate }) => {
     if (!firstInvalidField) return false;
 
     const message = next[firstInvalidField];
-    if (message) toast.error(message);
+    if (message) toastError(message);
     const selector = FIELD_FOCUS_SELECTORS[firstInvalidField];
     if (selector) {
       window.requestAnimationFrame(() => {
@@ -315,14 +315,14 @@ const SiemLogsTab: React.FC<Props> = ({ canUpdate }) => {
       const next = await logsApi.updateSiemConfig(form);
       applyConfig(next, true);
       refreshStatusBestEffort();
-      toast.success(t('logs.siem.messages.saved'));
+      toastSuccess(t('logs.siem.messages.saved'));
     } catch (error) {
       const errorCode =
         error instanceof Error
           ? ((error as Error & { errorCode?: string }).errorCode ?? error.message)
           : '';
       if (!showServerValidationError(errorCode)) {
-        toast.error(error instanceof Error ? error.message : t('logs.siem.messages.saveFailed'));
+        toastError(error instanceof Error ? error.message : t('logs.siem.messages.saveFailed'));
       }
     } finally {
       setBusy(null);
@@ -337,9 +337,9 @@ const SiemLogsTab: React.FC<Props> = ({ canUpdate }) => {
       const nextConfig = await logsApi.getSiemConfig().catch(() => null);
       if (nextConfig) applyConfig(nextConfig, true);
       refreshStatusBestEffort();
-      if (result.success) toast.success(t('logs.siem.messages.testSucceeded'));
+      if (result.success) toastSuccess(t('logs.siem.messages.testSucceeded'));
       else if (!result.error || !showServerValidationError(result.error)) {
-        toast.error(result.error || t('logs.siem.messages.testFailed'));
+        toastError(result.error || t('logs.siem.messages.testFailed'));
       }
     } catch (error) {
       const errorCode =
@@ -347,7 +347,7 @@ const SiemLogsTab: React.FC<Props> = ({ canUpdate }) => {
           ? ((error as Error & { errorCode?: string }).errorCode ?? error.message)
           : '';
       if (!showServerValidationError(errorCode)) {
-        toast.error(error instanceof Error ? error.message : t('logs.siem.messages.testFailed'));
+        toastError(error instanceof Error ? error.message : t('logs.siem.messages.testFailed'));
       }
     } finally {
       setBusy(null);
@@ -361,9 +361,9 @@ const SiemLogsTab: React.FC<Props> = ({ canUpdate }) => {
       const next = enabled ? await logsApi.enableSiem() : await logsApi.disableSiem();
       applyConfig(next, true);
       refreshStatusBestEffort();
-      toast.success(t(next.enabled ? 'logs.siem.messages.enabled' : 'logs.siem.messages.disabled'));
+      toastSuccess(t(next.enabled ? 'logs.siem.messages.enabled' : 'logs.siem.messages.disabled'));
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : t('logs.siem.messages.toggleFailed'));
+      toastError(error instanceof Error ? error.message : t('logs.siem.messages.toggleFailed'));
     } finally {
       setBusy(null);
     }

--- a/components/reports/AiReportingVisualization.tsx
+++ b/components/reports/AiReportingVisualization.tsx
@@ -9,7 +9,6 @@ import {
 import { memo, useId, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { BarShapeProps } from 'recharts';
-import { toast } from 'sonner';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -51,6 +50,7 @@ import {
 } from '@/components/ui/table';
 import { CopyElementAsPngError, copyElementAsPng } from '@/utils/copyElementAsPng';
 import { formatNumber } from '@/utils/numbers';
+import { toastError, toastSuccess } from '@/utils/toast';
 import {
   CHART_COLORS,
   getBarPointColor,
@@ -373,7 +373,7 @@ const AiReportingVisualizationContent = ({ visualization }: AiReportingVisualiza
     setIsCopyingPng(true);
     try {
       await copyElementAsPng(chartExportRef.current);
-      toast.success(
+      toastSuccess(
         t('aiReporting.visualizationCopiedPng', { defaultValue: 'Chart copied as PNG.' }),
       );
     } catch (error) {
@@ -391,7 +391,7 @@ const AiReportingVisualizationContent = ({ visualization }: AiReportingVisualiza
             'PNG clipboard copy is unavailable in this browser or page context. Use HTTPS and an up-to-date browser.',
         });
       }
-      toast.error(errorMessage);
+      toastError(errorMessage);
     } finally {
       setIsCopyingPng(false);
     }

--- a/components/reports/TimeReportView.tsx
+++ b/components/reports/TimeReportView.tsx
@@ -10,13 +10,13 @@ import {
 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
-import { toast } from 'sonner';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Field, FieldLabel } from '@/components/ui/field';
 import { Input } from '@/components/ui/input';
+import { toastError, toastSuccess, toastWarning } from '@/utils/toast';
 import { timeReportsApi } from '../../services/api/timeReports';
 import { usersApi } from '../../services/api/users';
 import { type SavedViewDto, viewsApi } from '../../services/api/views';
@@ -341,7 +341,7 @@ const TimeReportView = ({
         const message =
           generateError instanceof Error ? generateError.message : t('timeReport.errors.generate');
         setError(message);
-        toast.error(message);
+        toastError(message);
       } finally {
         setIsGenerating(false);
       }
@@ -365,7 +365,7 @@ const TimeReportView = ({
       saved.periodPreset === 'custom' ? null : periodRange(saved.periodPreset, startOfWeek),
     );
     setDefinition(finalized);
-    if (wasSanitized) toast.warning(t('timeReport.favorites.sanitized'));
+    if (wasSanitized) toastWarning(t('timeReport.favorites.sanitized'));
   };
 
   const saveFavorite = async () => {
@@ -381,9 +381,9 @@ const TimeReportView = ({
       });
       setFavoriteName('');
       await loadFavorites();
-      toast.success(t('timeReport.favorites.saved'));
+      toastSuccess(t('timeReport.favorites.saved'));
     } catch (saveError) {
-      toast.error(saveError instanceof Error ? saveError.message : t('timeReport.errors.favorite'));
+      toastError(saveError instanceof Error ? saveError.message : t('timeReport.errors.favorite'));
     } finally {
       setIsSavingFavorite(false);
     }
@@ -397,9 +397,9 @@ const TimeReportView = ({
       if (selectedFavoriteId === favoriteToDelete.id) setSelectedFavoriteId('');
       setFavoriteToDelete(null);
       await loadFavorites();
-      toast.success(t('timeReport.favorites.deleted'));
+      toastSuccess(t('timeReport.favorites.deleted'));
     } catch (deleteError) {
-      toast.error(
+      toastError(
         deleteError instanceof Error ? deleteError.message : t('timeReport.errors.favorite'),
       );
     } finally {
@@ -420,7 +420,7 @@ const TimeReportView = ({
         blob,
       );
     } catch (exportError) {
-      toast.error(
+      toastError(
         exportError instanceof Error ? exportError.message : t('timeReport.errors.export'),
       );
     } finally {
@@ -441,7 +441,7 @@ const TimeReportView = ({
         setEditingCatalogs(catalogs);
         setEditingEntry(entry);
       } catch (catalogError) {
-        toast.error(
+        toastError(
           catalogError instanceof Error
             ? catalogError.message
             : t('timeReport.errors.editCatalogs'),

--- a/components/ui/sonner-presets.ts
+++ b/components/ui/sonner-presets.ts
@@ -53,13 +53,13 @@ export const appSuccessToastClassNames = buildVariantClassNames({
 });
 
 export const appErrorToastClassNames = buildVariantClassNames({
-  surface: 'border-destructive! bg-destructive! text-destructive-foreground!',
-  description: 'text-destructive-foreground/70!',
-  icon: 'text-destructive-foreground!',
+  surface: 'border-toast-destructive! bg-toast-destructive! text-toast-destructive-foreground!',
+  description: 'text-toast-destructive-foreground/70!',
+  icon: 'text-toast-destructive-foreground!',
   actionButton:
-    'rounded-md! bg-destructive-foreground! text-destructive! hover:bg-destructive-foreground/90! focus-visible:ring-[3px] focus-visible:ring-destructive-foreground/50',
+    'rounded-md! bg-toast-destructive-foreground! text-toast-destructive! hover:bg-toast-destructive-foreground/90! focus-visible:ring-[3px] focus-visible:ring-toast-destructive-foreground/50',
   closeTone:
-    'text-destructive-foreground! hover:bg-destructive-foreground/10! focus-visible:ring-destructive-foreground/50',
+    'text-toast-destructive-foreground! hover:bg-toast-destructive-foreground/10! focus-visible:ring-toast-destructive-foreground/50',
 });
 
 export const appWarningToastClassNames = buildVariantClassNames({

--- a/components/ui/sonner-presets.ts
+++ b/components/ui/sonner-presets.ts
@@ -75,31 +75,16 @@ export const appWarningToastClassNames = buildVariantClassNames({
 /** Alias kept for offer-created call sites; identical to `appSuccessToastClassNames`. */
 export const offerCreatedToastClassNames = appSuccessToastClassNames;
 
-const TOAST_CLASSNAME_KEYS = [
-  'toast',
-  'title',
-  'description',
-  'actionButton',
-  'cancelButton',
-  'closeButton',
-  'error',
-  'success',
-  'warning',
-  'info',
-  'loading',
-  'content',
-  'icon',
-] as const satisfies ReadonlyArray<keyof ToastClassnames>;
-
 export const mergeToastClassNames = (
   base: ToastClassnames,
   override?: ToastClassnames,
 ): ToastClassnames => {
   if (!override) return base;
   const merged: ToastClassnames = { ...base };
-  for (const key of TOAST_CLASSNAME_KEYS) {
-    if (!override[key]) continue;
-    merged[key] = [base[key], override[key]].filter(Boolean).join(' ');
+  for (const key of Object.keys(override) as Array<keyof ToastClassnames>) {
+    const overrideValue = override[key];
+    if (!overrideValue) continue;
+    merged[key] = [base[key], overrideValue].filter(Boolean).join(' ');
   }
   return merged;
 };

--- a/components/ui/sonner-presets.ts
+++ b/components/ui/sonner-presets.ts
@@ -63,12 +63,13 @@ export const appErrorToastClassNames = buildVariantClassNames({
 });
 
 export const appWarningToastClassNames = buildVariantClassNames({
-  surface: 'border-amber-600! bg-amber-600! text-white! dark:border-amber-500! dark:bg-amber-500!',
-  description: 'text-white/70!',
-  icon: 'text-white!',
+  surface: 'border-warning! bg-warning! text-warning-foreground!',
+  description: 'text-warning-foreground/70!',
+  icon: 'text-warning-foreground!',
   actionButton:
-    'rounded-md! bg-white! text-amber-700! hover:bg-white/90! focus-visible:ring-[3px] focus-visible:ring-white/50',
-  closeTone: 'text-white! hover:bg-white/10! focus-visible:ring-white/50',
+    'rounded-md! bg-warning-foreground! text-warning! hover:bg-warning-foreground/90! focus-visible:ring-[3px] focus-visible:ring-warning-foreground/50',
+  closeTone:
+    'text-warning-foreground! hover:bg-warning-foreground/10! focus-visible:ring-warning-foreground/50',
 });
 
 /** Alias kept for offer-created call sites; identical to `appSuccessToastClassNames`. */

--- a/components/ui/sonner-presets.ts
+++ b/components/ui/sonner-presets.ts
@@ -17,12 +17,88 @@ export const resolveOfferCreatedToastAction = <T>(
   action: T,
 ): T | undefined => (canViewClientOffers ? action : undefined);
 
-export const offerCreatedToastClassNames = {
-  toast: 'rounded-lg! border-primary! bg-primary! pr-12! text-primary-foreground! shadow-lg',
+const toastLayout = 'rounded-lg! pr-12! shadow-lg';
+const closeButtonLayout =
+  'top-2! right-2! left-auto! size-6! transform-none! rounded-md! border-0! bg-transparent! focus-visible:ring-[3px] [&_svg]:size-4!';
+
+const buildVariantClassNames = ({
+  surface,
+  description,
+  icon,
+  actionButton,
+  closeTone,
+}: {
+  surface: string;
+  description: string;
+  icon: string;
+  actionButton: string;
+  closeTone: string;
+}): ToastClassnames => ({
+  toast: `${toastLayout} ${surface}`,
+  description,
+  icon,
+  actionButton,
+  closeButton: `${closeButtonLayout} ${closeTone}`,
+});
+
+/** Primary-themed success toast — same look as quote→offer conversion. */
+export const appSuccessToastClassNames = buildVariantClassNames({
+  surface: 'border-primary! bg-primary! text-primary-foreground!',
   description: 'text-primary-foreground/70!',
   icon: 'text-primary-foreground!',
   actionButton:
     'rounded-md! bg-primary-foreground! text-primary! hover:bg-primary-foreground/90! focus-visible:ring-[3px] focus-visible:ring-primary-foreground/50',
-  closeButton:
-    'top-2! right-2! left-auto! size-6! transform-none! rounded-md! border-0! bg-transparent! text-primary-foreground! hover:bg-primary-foreground/10! focus-visible:ring-[3px] focus-visible:ring-primary-foreground/50 [&_svg]:size-4!',
-} satisfies ToastClassnames;
+  closeTone:
+    'text-primary-foreground! hover:bg-primary-foreground/10! focus-visible:ring-primary-foreground/50',
+});
+
+export const appErrorToastClassNames = buildVariantClassNames({
+  surface: 'border-destructive! bg-destructive! text-destructive-foreground!',
+  description: 'text-destructive-foreground/70!',
+  icon: 'text-destructive-foreground!',
+  actionButton:
+    'rounded-md! bg-destructive-foreground! text-destructive! hover:bg-destructive-foreground/90! focus-visible:ring-[3px] focus-visible:ring-destructive-foreground/50',
+  closeTone:
+    'text-destructive-foreground! hover:bg-destructive-foreground/10! focus-visible:ring-destructive-foreground/50',
+});
+
+export const appWarningToastClassNames = buildVariantClassNames({
+  surface: 'border-amber-600! bg-amber-600! text-white! dark:border-amber-500! dark:bg-amber-500!',
+  description: 'text-white/70!',
+  icon: 'text-white!',
+  actionButton:
+    'rounded-md! bg-white! text-amber-700! hover:bg-white/90! focus-visible:ring-[3px] focus-visible:ring-white/50',
+  closeTone: 'text-white! hover:bg-white/10! focus-visible:ring-white/50',
+});
+
+/** Alias kept for offer-created call sites; identical to `appSuccessToastClassNames`. */
+export const offerCreatedToastClassNames = appSuccessToastClassNames;
+
+const TOAST_CLASSNAME_KEYS = [
+  'toast',
+  'title',
+  'description',
+  'actionButton',
+  'cancelButton',
+  'closeButton',
+  'error',
+  'success',
+  'warning',
+  'info',
+  'loading',
+  'content',
+  'icon',
+] as const satisfies ReadonlyArray<keyof ToastClassnames>;
+
+export const mergeToastClassNames = (
+  base: ToastClassnames,
+  override?: ToastClassnames,
+): ToastClassnames => {
+  if (!override) return base;
+  const merged: ToastClassnames = { ...base };
+  for (const key of TOAST_CLASSNAME_KEYS) {
+    if (!override[key]) continue;
+    merged[key] = [base[key], override[key]].filter(Boolean).join(' ');
+  }
+  return merged;
+};

--- a/src/index.css
+++ b/src/index.css
@@ -213,9 +213,9 @@ tr[data-standard-table-font-size] [data-slot="button"][data-size="icon-sm"] {
   --muted-foreground: oklch(0.705 0.015 286.067);
   --accent: oklch(0.274 0.006 286.033);
   --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.704 0.191 22.216);
+  --destructive: oklch(0.45 0.18 25);
   --destructive-foreground: oklch(0.985 0 0);
-  --warning: oklch(0.55 0.14 55);
+  --warning: oklch(0.48 0.14 55);
   --warning-foreground: oklch(0.985 0 0);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);

--- a/src/index.css
+++ b/src/index.css
@@ -52,6 +52,7 @@
   --accent: oklch(0.967 0.001 286.375);
   --accent-foreground: oklch(0.21 0.006 285.885);
   --destructive: oklch(0.577 0.245 27.325);
+  --destructive-foreground: oklch(0.985 0 0);
   --border: oklch(0.92 0.004 286.32);
   --input: oklch(0.92 0.004 286.32);
   --ring: oklch(0.705 0.015 286.067);
@@ -211,6 +212,7 @@ tr[data-standard-table-font-size] [data-slot="button"][data-size="icon-sm"] {
   --accent: oklch(0.274 0.006 286.033);
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
+  --destructive-foreground: oklch(0.985 0 0);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.552 0.016 285.938);
@@ -271,6 +273,7 @@ tr[data-standard-table-font-size] [data-slot="button"][data-size="icon-sm"] {
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
@@ -426,6 +429,7 @@ tr[data-standard-table-font-size] [data-slot="button"][data-size="icon-sm"] {
   --color-accent: var(--accent);
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
+  --color-destructive-foreground: var(--destructive-foreground);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);

--- a/src/index.css
+++ b/src/index.css
@@ -53,6 +53,8 @@
   --accent-foreground: oklch(0.21 0.006 285.885);
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(0.985 0 0);
+  --warning: oklch(0.505 0.145 55);
+  --warning-foreground: oklch(0.985 0 0);
   --border: oklch(0.92 0.004 286.32);
   --input: oklch(0.92 0.004 286.32);
   --ring: oklch(0.705 0.015 286.067);
@@ -213,6 +215,8 @@ tr[data-standard-table-font-size] [data-slot="button"][data-size="icon-sm"] {
   --accent-foreground: oklch(0.985 0 0);
   --destructive: oklch(0.704 0.191 22.216);
   --destructive-foreground: oklch(0.985 0 0);
+  --warning: oklch(0.55 0.14 55);
+  --warning-foreground: oklch(0.985 0 0);
   --border: oklch(1 0 0 / 10%);
   --input: oklch(1 0 0 / 15%);
   --ring: oklch(0.552 0.016 285.938);
@@ -274,6 +278,8 @@ tr[data-standard-table-font-size] [data-slot="button"][data-size="icon-sm"] {
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);
@@ -430,6 +436,8 @@ tr[data-standard-table-font-size] [data-slot="button"][data-size="icon-sm"] {
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
+  --color-warning: var(--warning);
+  --color-warning-foreground: var(--warning-foreground);
   --color-border: var(--border);
   --color-input: var(--input);
   --color-ring: var(--ring);

--- a/src/index.css
+++ b/src/index.css
@@ -53,6 +53,8 @@
   --accent-foreground: oklch(0.21 0.006 285.885);
   --destructive: oklch(0.577 0.245 27.325);
   --destructive-foreground: oklch(0.985 0 0);
+  --toast-destructive: oklch(0.45 0.18 25);
+  --toast-destructive-foreground: oklch(0.985 0 0);
   --warning: oklch(0.505 0.145 55);
   --warning-foreground: oklch(0.985 0 0);
   --border: oklch(0.92 0.004 286.32);
@@ -213,8 +215,10 @@ tr[data-standard-table-font-size] [data-slot="button"][data-size="icon-sm"] {
   --muted-foreground: oklch(0.705 0.015 286.067);
   --accent: oklch(0.274 0.006 286.033);
   --accent-foreground: oklch(0.985 0 0);
-  --destructive: oklch(0.45 0.18 25);
+  --destructive: oklch(0.704 0.191 22.216);
   --destructive-foreground: oklch(0.985 0 0);
+  --toast-destructive: oklch(0.45 0.18 25);
+  --toast-destructive-foreground: oklch(0.985 0 0);
   --warning: oklch(0.48 0.14 55);
   --warning-foreground: oklch(0.985 0 0);
   --border: oklch(1 0 0 / 10%);
@@ -278,6 +282,8 @@ tr[data-standard-table-font-size] [data-slot="button"][data-size="icon-sm"] {
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
+  --color-toast-destructive: var(--toast-destructive);
+  --color-toast-destructive-foreground: var(--toast-destructive-foreground);
   --color-warning: var(--warning);
   --color-warning-foreground: var(--warning-foreground);
   --color-border: var(--border);
@@ -436,6 +442,8 @@ tr[data-standard-table-font-size] [data-slot="button"][data-size="icon-sm"] {
   --color-accent-foreground: var(--accent-foreground);
   --color-destructive: var(--destructive);
   --color-destructive-foreground: var(--destructive-foreground);
+  --color-toast-destructive: var(--toast-destructive);
+  --color-toast-destructive-foreground: var(--toast-destructive-foreground);
   --color-warning: var(--warning);
   --color-warning-foreground: var(--warning-foreground);
   --color-border: var(--border);

--- a/test/components/administration/LogsView.test.tsx
+++ b/test/components/administration/LogsView.test.tsx
@@ -12,8 +12,10 @@ const t = (key: string) => key;
 const toastSuccess = mock(() => undefined);
 const toastError = mock(() => undefined);
 
-mock.module('sonner', () => ({
-  toast: { success: toastSuccess, error: toastError },
+mock.module('../../../utils/toast', () => ({
+  toastSuccess,
+  toastError,
+  toastWarning: () => undefined,
 }));
 
 mock.module('react-i18next', () => ({

--- a/test/components/ui/Sonner.test.tsx
+++ b/test/components/ui/Sonner.test.tsx
@@ -37,8 +37,8 @@ describe('Sonner configuration', () => {
   test('defines matching error and warning variants', () => {
     expect(appErrorToastClassNames.toast).toContain('bg-destructive!');
     expect(appErrorToastClassNames.icon).toContain('text-destructive-foreground!');
-    expect(appWarningToastClassNames.toast).toContain('bg-amber-600!');
-    expect(appWarningToastClassNames.closeButton).toContain('text-white!');
+    expect(appWarningToastClassNames.toast).toContain('bg-warning!');
+    expect(appWarningToastClassNames.closeButton).toContain('text-warning-foreground!');
   });
 
   test('merges className overrides without dropping the shared base style', () => {

--- a/test/components/ui/Sonner.test.tsx
+++ b/test/components/ui/Sonner.test.tsx
@@ -57,6 +57,16 @@ describe('Sonner configuration', () => {
     expect(mergeToastClassNames(appSuccessToastClassNames, {})).toEqual(appSuccessToastClassNames);
   });
 
+  test('merges Sonner default and loader className overrides', () => {
+    const merged = mergeToastClassNames(appSuccessToastClassNames, {
+      default: 'extra-default',
+      loader: 'extra-loader',
+    });
+    expect(merged.default).toContain('extra-default');
+    expect(merged.loader).toContain('extra-loader');
+    expect(merged.toast).toBe(appSuccessToastClassNames.toast);
+  });
+
   test('only exposes the offer action when the user can view client offers', () => {
     const action = { label: 'View offer', onClick: () => {} };
 

--- a/test/components/ui/Sonner.test.tsx
+++ b/test/components/ui/Sonner.test.tsx
@@ -1,6 +1,10 @@
 import { describe, expect, test } from 'bun:test';
 import {
+  appErrorToastClassNames,
+  appSuccessToastClassNames,
   appToasterProps,
+  appWarningToastClassNames,
+  mergeToastClassNames,
   offerCreatedToastClassNames,
   resolveOfferCreatedToastAction,
   resolveSonnerTheme,
@@ -15,24 +19,42 @@ describe('Sonner configuration', () => {
     expect(resolveSonnerTheme('dark', 'system')).toBe('system');
   });
 
-  test('configures centered rich toasts and primary offer styling', () => {
+  test('configures centered rich toasts with shared primary success styling', () => {
     expect(appToasterProps).toEqual({
       richColors: true,
       closeButton: true,
       position: 'top-center',
     });
-    expect(offerCreatedToastClassNames.toast).toContain('bg-primary!');
-    expect(offerCreatedToastClassNames.toast).toContain('rounded-lg!');
-    expect(offerCreatedToastClassNames.description).toContain('text-primary-foreground/70!');
-    expect(offerCreatedToastClassNames.actionButton).toContain('bg-primary-foreground!');
-    expect(offerCreatedToastClassNames.actionButton).toContain('rounded-md!');
-    expect(offerCreatedToastClassNames.closeButton).toContain('right-2!');
-    expect(offerCreatedToastClassNames.closeButton).toContain('top-2!');
-    expect(offerCreatedToastClassNames.closeButton).toContain('size-6!');
-    expect(offerCreatedToastClassNames.closeButton).toContain('rounded-md!');
-    expect(offerCreatedToastClassNames.closeButton).toContain('text-primary-foreground!');
-    expect(offerCreatedToastClassNames.closeButton).toContain('[&_svg]:size-4!');
-    expect(offerCreatedToastClassNames.icon).toContain('text-primary-foreground!');
+    expect(appSuccessToastClassNames.toast).toContain('bg-primary!');
+    expect(appSuccessToastClassNames.toast).toContain('rounded-lg!');
+    expect(appSuccessToastClassNames.description).toContain('text-primary-foreground/70!');
+    expect(appSuccessToastClassNames.actionButton).toContain('bg-primary-foreground!');
+    expect(appSuccessToastClassNames.closeButton).toContain('right-2!');
+    expect(appSuccessToastClassNames.icon).toContain('text-primary-foreground!');
+    expect(offerCreatedToastClassNames).toBe(appSuccessToastClassNames);
+  });
+
+  test('defines matching error and warning variants', () => {
+    expect(appErrorToastClassNames.toast).toContain('bg-destructive!');
+    expect(appErrorToastClassNames.icon).toContain('text-destructive-foreground!');
+    expect(appWarningToastClassNames.toast).toContain('bg-amber-600!');
+    expect(appWarningToastClassNames.closeButton).toContain('text-white!');
+  });
+
+  test('merges className overrides without dropping the shared base style', () => {
+    const merged = mergeToastClassNames(appSuccessToastClassNames, {
+      toast: 'extra-class',
+      description: 'extra-desc',
+    });
+    expect(merged.toast).toContain('bg-primary!');
+    expect(merged.toast).toContain('extra-class');
+    expect(merged.description).toContain('text-primary-foreground/70!');
+    expect(merged.description).toContain('extra-desc');
+    expect(merged.icon).toBe(appSuccessToastClassNames.icon);
+  });
+
+  test('keeps the base style when the override object is empty', () => {
+    expect(mergeToastClassNames(appSuccessToastClassNames, {})).toEqual(appSuccessToastClassNames);
   });
 
   test('only exposes the offer action when the user can view client offers', () => {

--- a/test/components/ui/Sonner.test.tsx
+++ b/test/components/ui/Sonner.test.tsx
@@ -35,8 +35,8 @@ describe('Sonner configuration', () => {
   });
 
   test('defines matching error and warning variants', () => {
-    expect(appErrorToastClassNames.toast).toContain('bg-destructive!');
-    expect(appErrorToastClassNames.icon).toContain('text-destructive-foreground!');
+    expect(appErrorToastClassNames.toast).toContain('bg-toast-destructive!');
+    expect(appErrorToastClassNames.icon).toContain('text-toast-destructive-foreground!');
     expect(appWarningToastClassNames.toast).toContain('bg-warning!');
     expect(appWarningToastClassNames.closeButton).toContain('text-warning-foreground!');
   });

--- a/test/utils/toast.test.ts
+++ b/test/utils/toast.test.ts
@@ -1,0 +1,57 @@
+import { beforeEach, describe, expect, mock, test } from 'bun:test';
+import { clearSpyStateAfterAll } from '../helpers/mockCleanup.ts';
+
+const toastSuccessMock = mock((_message: string, _options?: unknown) => undefined);
+const toastErrorMock = mock((_message: string, _options?: unknown) => undefined);
+const toastWarningMock = mock((_message: string, _options?: unknown) => undefined);
+
+mock.module('sonner', () => ({
+  toast: {
+    success: toastSuccessMock,
+    error: toastErrorMock,
+    warning: toastWarningMock,
+  },
+}));
+
+clearSpyStateAfterAll();
+
+const { toastError, toastSuccess, toastWarning } = await import('../../utils/toast');
+const { appErrorToastClassNames, appSuccessToastClassNames, appWarningToastClassNames } =
+  await import('../../components/ui/sonner-presets');
+
+describe('utils/toast', () => {
+  beforeEach(() => {
+    toastSuccessMock.mockClear();
+    toastErrorMock.mockClear();
+    toastWarningMock.mockClear();
+  });
+
+  test('applies the shared success classNames used by offer conversion', () => {
+    toastSuccess('Preferito salvato.', { description: 'Report A' });
+
+    expect(toastSuccessMock).toHaveBeenCalledTimes(1);
+    const [message, options] = toastSuccessMock.mock.calls[0] ?? [];
+    expect(message).toBe('Preferito salvato.');
+    expect((options as { description?: string }).description).toBe('Report A');
+    expect((options as { classNames: { toast: string } }).classNames.toast).toContain(
+      'bg-primary!',
+    );
+    expect((options as { classNames: typeof appSuccessToastClassNames }).classNames.toast).toBe(
+      appSuccessToastClassNames.toast,
+    );
+  });
+
+  test('applies the shared error and warning classNames', () => {
+    toastError('Failed');
+    toastWarning('Sanitized');
+
+    expect(
+      (toastErrorMock.mock.calls[0]?.[1] as { classNames: typeof appErrorToastClassNames })
+        .classNames.toast,
+    ).toBe(appErrorToastClassNames.toast);
+    expect(
+      (toastWarningMock.mock.calls[0]?.[1] as { classNames: typeof appWarningToastClassNames })
+        .classNames.toast,
+    ).toBe(appWarningToastClassNames.toast);
+  });
+});

--- a/utils/toast.ts
+++ b/utils/toast.ts
@@ -1,7 +1,21 @@
-import { toast } from 'sonner';
+import { type ExternalToast, type ToastClassnames, toast } from 'sonner';
+import {
+  appErrorToastClassNames,
+  appSuccessToastClassNames,
+  appWarningToastClassNames,
+  mergeToastClassNames,
+} from '@/components/ui/sonner-presets';
 
-export const toastError = (message: string) => toast.error(message);
+const withClassNames = (base: ToastClassnames, options?: ExternalToast): ExternalToast => ({
+  ...options,
+  classNames: mergeToastClassNames(base, options?.classNames),
+});
 
-export const toastSuccess = (message: string) => toast.success(message);
+export const toastError = (message: string, options?: ExternalToast) =>
+  toast.error(message, withClassNames(appErrorToastClassNames, options));
 
-export const toastWarning = (message: string) => toast.warning(message);
+export const toastSuccess = (message: string, options?: ExternalToast) =>
+  toast.success(message, withClassNames(appSuccessToastClassNames, options));
+
+export const toastWarning = (message: string, options?: ExternalToast) =>
+  toast.warning(message, withClassNames(appWarningToastClassNames, options));


### PR DESCRIPTION
## Summary
- Extends the primary-themed offer-conversion toast style to every Sonner success/error/warning via centralized helpers.
- Migrates remaining direct `sonner` call sites (time-report favorites, SIEM, AI reporting) onto `toastSuccess` / `toastError` / `toastWarning`.

## Changes
- Expands `components/ui/sonner-presets.ts` with shared success/error/warning classNames and safe className merging.
- Makes `utils/toast.ts` always apply those classNames so call sites cannot drift back to richColors green.
- Updates related unit tests and LogsView mocks to assert the shared helpers.

## Testing
- `bun test test/components/ui/Sonner.test.tsx test/utils/toast.test.ts test/components/administration/LogsView.test.tsx`
- `bunx biome check` on touched files
- `bun run test:react-doctor` (score unchanged at 79)

## Risks / Rollout
- Low risk UI-only change. Toast visuals change for all success/error/warning notifications app-wide.
- No migrations, API, or permission changes.

## Issues
Issue: Not linked