### PR TITLE
app(chore): bump version to 0.13.1

### DIFF
--- a/docs/api/openapi.json
+++ b/docs/api/openapi.json
@@ -3,7 +3,7 @@
   "info": {
     "title": "Praetor API",
     "description": "Praetor API documentation",
-    "version": "0.13.0"
+    "version": "0.13.1"
   },
   "components": {
     "securitySchemes": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "praetor",
   "private": true,
-  "version": "0.13.0",
+  "version": "0.13.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "praetor-server",
-  "version": "0.13.0",
+  "version": "0.13.1",
   "description": "Praetor API Server",
   "main": "index.ts",
   "type": "module",


### PR DESCRIPTION
## Summary
- Bump the Praetor application and API server patch version from 0.13.0 to 0.13.1.

## Changes
- Update package.json, server/package.json, and docs/api/openapi.json version metadata.

## Testing
- bun run test:react-doctor — passed at 100/100 before and after the change.
- Bun JSON parsing validation — passed for all three version files.
- bun run typecheck — not run successfully because the checkout does not have the tsc executable installed.

## Risks / Rollout
- Low risk; metadata-only patch release change with no runtime or database behavior changes.

## Issues
Issue: Not linked