### PR TITLE
notifications(fix): localize overtime notification titles

### DIFF
--- a/components/shared/NotificationBell.tsx
+++ b/components/shared/NotificationBell.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import type { Notification } from '../../types';
+import { formatOvertimeHours } from '../../utils/notifications';
 
 export interface NotificationBellProps {
   notifications: Notification[];
@@ -114,6 +115,15 @@ const NotificationBell: React.FC<NotificationBellProps> = ({
       return t('notifications.projectRuleTriggered', '{{rule}} triggered for {{project}}', {
         rule: notification.data?.ruleName ?? notification.title,
         project: notification.data?.projectName ?? '',
+      });
+    }
+    if (notification.type === 'overtime_recorded') {
+      const date = typeof notification.data?.date === 'string' ? notification.data.date : '';
+      const hours = formatOvertimeHours(notification.data?.hours);
+      if (!date || !hours) return notification.title;
+      return t('notifications.overtimeRecorded', '{{hours}}h recorded on {{date}}', {
+        hours,
+        date,
       });
     }
     if (notification.type === 'admin_password_warning') {

--- a/locales/en/layout.json
+++ b/locales/en/layout.json
@@ -108,6 +108,7 @@
     "newProjects": "{{count}} new projects available",
     "newProject": "1 new project available",
     "projectRuleTriggered": "{{rule}} triggered for {{project}}",
+    "overtimeRecorded": "{{hours}}h recorded on {{date}}",
     "adminPasswordWarningTitle": "Change the default admin password",
     "rilPreferencesTipTitle": "Set up your RIL travel preferences",
     "rilPreferencesTipMessage": "Choose the default travel value for each weekday so your RIL is pre-filled correctly.",

--- a/locales/it/layout.json
+++ b/locales/it/layout.json
@@ -108,6 +108,7 @@
     "newProjects": "{{count}} nuovi progetti disponibili",
     "newProject": "1 nuovo progetto disponibile",
     "projectRuleTriggered": "{{rule}} attivata per {{project}}",
+    "overtimeRecorded": "{{hours}}h registrate il {{date}}",
     "adminPasswordWarningTitle": "Cambia la password predefinita dell'amministratore",
     "rilPreferencesTipTitle": "Configura le preferenze di trasferta RIL",
     "rilPreferencesTipMessage": "Scegli il valore di trasferta predefinito per ogni giorno feriale, così il RIL verrà precompilato correttamente.",

--- a/test/components/NotificationBell.test.tsx
+++ b/test/components/NotificationBell.test.tsx
@@ -167,6 +167,49 @@ describe('<NotificationBell />', () => {
     expect(container.querySelector('i.fa-bell')).not.toBeNull();
   });
 
+  test('overtime notifications use the localized title with hours and date', () => {
+    const notification: Notification = {
+      id: 'n-overtime',
+      userId: 'u1',
+      type: 'overtime_recorded',
+      title: 'Overtime recorded',
+      isRead: false,
+      createdAt: NOW,
+      data: {
+        userId: 'u1',
+        date: '2026-05-04',
+        hours: 8.5,
+        source: 'tracker',
+        reasons: ['daily_limit'],
+      },
+    };
+
+    render(<NotificationBell {...baseProps} notifications={[notification]} />);
+
+    openDropdown();
+
+    expect(screen.getByText('notifications.overtimeRecorded')).toBeInTheDocument();
+    expect(screen.queryByText('Overtime recorded')).not.toBeInTheDocument();
+    expect(screen.queryByText('8.5h recorded on 2026-05-04')).not.toBeInTheDocument();
+  });
+
+  test('overtime notifications without data fall back to the stored title', () => {
+    const notification: Notification = {
+      id: 'n-overtime-no-data',
+      userId: 'u1',
+      type: 'overtime_recorded',
+      title: 'Overtime recorded',
+      isRead: false,
+      createdAt: NOW,
+    };
+
+    render(<NotificationBell {...baseProps} notifications={[notification]} />);
+
+    openDropdown();
+
+    expect(screen.getByText('Overtime recorded')).toBeInTheDocument();
+  });
+
   test('RIL tip renders localized guidance and opens preferences from its quick action', () => {
     const onOpenRilPreferences = mock(() => {});
     const onMarkAsRead = mock((_id: string) => {});

--- a/test/utils/notifications.test.ts
+++ b/test/utils/notifications.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, test } from 'bun:test';
+import { formatOvertimeHours } from '../../utils/notifications';
+
+describe('formatOvertimeHours', () => {
+  test('formats whole hours without decimals, matching the server message', () => {
+    expect(formatOvertimeHours(8)).toBe('8');
+    expect(formatOvertimeHours(9)).toBe('9');
+  });
+
+  test('formats fractional hours with two decimals, matching the server message', () => {
+    expect(formatOvertimeHours(8.5)).toBe('8.50');
+    expect(formatOvertimeHours(8.25)).toBe('8.25');
+  });
+
+  test('coerces string JSONB values from legacy or hand-edited rows', () => {
+    expect(formatOvertimeHours('8')).toBe('8');
+    expect(formatOvertimeHours('8.5')).toBe('8.50');
+    expect(formatOvertimeHours('8.25')).toBe('8.25');
+    expect(formatOvertimeHours('0')).toBe('0');
+  });
+
+  test('formats zero hours so a 0h overtime notification is not hidden', () => {
+    expect(formatOvertimeHours(0)).toBe('0');
+  });
+
+  test('returns an empty string for null, undefined, NaN, and non-numeric values', () => {
+    expect(formatOvertimeHours(null)).toBe('');
+    expect(formatOvertimeHours(undefined)).toBe('');
+    expect(formatOvertimeHours(Number.NaN)).toBe('');
+    expect(formatOvertimeHours('not-a-number')).toBe('');
+    expect(formatOvertimeHours({})).toBe('');
+  });
+});

--- a/utils/notifications.ts
+++ b/utils/notifications.ts
@@ -1,0 +1,15 @@
+/**
+ * Format the overtime hours carried in an `overtime_recorded` notification's
+ * `data.hours` for display inside a localized notification title. Accepts the
+ * numeric value written by the server today and coerces string JSONB values from
+ * legacy or hand-edited rows. Whole hours render without decimals (8 -> "8"),
+ * fractional hours with two decimals (8.5 -> "8.50"), matching the server's
+ * message format. Non-numeric values render as an empty string so the title
+ * never shows "NaN" or "undefined".
+ */
+export const formatOvertimeHours = (hours: unknown): string => {
+  if (hours === null || hours === undefined) return '';
+  const value = Number(hours);
+  if (!Number.isFinite(value)) return '';
+  return value % 1 === 0 ? String(value) : value.toFixed(2);
+};


### PR DESCRIPTION
## Summary
- Overtime notifications ("Overtime recorded") are now localized at render time in the notification bell instead of always showing the server-side English title.
- Existing and new `overtime_recorded` notifications render using the user's active language, with the recorded hours and date.

## Changes
- `components/shared/NotificationBell.tsx`: handles `overtime_recorded` in `getLocalizedTitle`, building the title from the notification's `data.hours` / `data.date` via the `notifications.overtimeRecorded` key; falls back to the stored title when the data is missing or unusable.
- `utils/notifications.ts`: new `formatOvertimeHours` helper that matches the server's message format (whole hours without decimals, fractional hours with two decimals) and safely coerces string JSONB values.
- `locales/en/layout.json` / `locales/it/layout.json`: added `notifications.overtimeRecorded`.
- Tests: component coverage for the localized title and the missing-data fallback; unit coverage for the hours formatter (whole, fractional, string coercion, zero, invalid).

## Testing
- `bun test test/components/NotificationBell.test.tsx test/utils/notifications.test.ts` — 25 pass, 0 fail.
- `bun run i18n:check` — passed (no missing translation keys).
- `bun x tsc -p tsconfig.json --noEmit` — passed.
- `bun x biome check <changed files>` — clean.
- `git diff --check` — no whitespace errors.
- Full frontend suite note: blocked by a pre-existing Bun internal crash and pre-existing test-isolation noise (`toast.test.ts`/`ShareViewModal` sonner mock interference), both reproducible without this change; no touched test fails.

## Risks / Rollout
- Low risk. UI-only change; no backend, schema, auth, or configuration impact.
- Notification `data` may carry string `hours` from legacy rows; the formatter coerces those safely, and malformed rows fall back to the stored title.
- Server-side `message` stays English in the DB but is not rendered by the bell (the only consumer); render-time localization covers already-persisted notifications too.

## Issues
Not linked.
