### PR TITLE
timesheets(fix): load entries for selected tracker user

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -92,7 +92,6 @@ import { useAuth } from './hooks/useAuth';
 import { useLatestRef } from './hooks/useLatestRef';
 import { listRequest, useModuleLoader } from './hooks/useModuleLoader';
 import api, { type McpTokenScope, type PersonalAccessToken, type Settings } from './services/api';
-import { decodeEntriesCursor } from './services/api/entries';
 import type {
   QuoteCommunicationChannel,
   QuoteCommunicationChannelIcon,
@@ -186,6 +185,7 @@ import {
   filterTrackerCatalogs,
   type TrackerCatalogState,
 } from './utils/trackerCatalogs';
+import { mergeTrackerEntryPage } from './utils/trackerEntryPageMerge';
 
 type AppModuleState = {
   users: User[];
@@ -1384,6 +1384,9 @@ const useAppContentController = () => {
   // Bumped on navigation/auth reset so stale module-load completions cannot commit state.
   const moduleLoadTokenRef = useRef(0);
   const loadedTimesheetsViewRef = useRef<string | null>(null);
+  // The tracker entry dataset is server-scoped to the selected user. Remember whose
+  // dataset completed so changing the user cannot reuse an unrelated in-memory page.
+  const loadedTrackerUserIdRef = useRef<string | null>(null);
   const [localState, dispatchLocalState] = useReducer(
     appLocalStateReducer,
     INITIAL_APP_LOCAL_STATE,
@@ -1634,6 +1637,7 @@ const useAppContentController = () => {
   const projectsRef = useLatestRef(projects);
   const quotesRef = useLatestRef(quotes);
   const clientOffersRef = useLatestRef(clientOffers);
+  const entriesRef = useLatestRef(entries);
 
   const clearAuthScopedAppState = useCallback(() => {
     // Bump cancellation tokens before any setter call so in-flight async
@@ -1642,6 +1646,7 @@ const useAppContentController = () => {
     // writes take effect synchronously.
     moduleLoadTokenRef.current++;
     entriesStreamTokenRef.current++;
+    loadedTrackerUserIdRef.current = null;
     resetModuleLoader();
     const setModuleState = <Key extends keyof AppModuleState>(
       key: Key,
@@ -2101,6 +2106,9 @@ const useAppContentController = () => {
   const activeLoadModuleRef = useLatestRef(
     currentUser && isRouteAccessible ? getModuleFromView(activeView) : null,
   );
+  const isTimesheetViewLoadCurrent =
+    loadedTimesheetsViewRef.current === activeView &&
+    (activeView !== 'timesheets/tracker' || loadedTrackerUserIdRef.current === viewingUserId);
 
   // Redirect to 404 if route is not accessible
   useEffect(() => {
@@ -2198,10 +2206,7 @@ const useAppContentController = () => {
     if (!isRouteAccessible) return;
     const module = getModuleFromView(activeView);
     if (!module) return;
-    if (
-      isModuleLoaded(module) &&
-      (module !== 'timesheets' || loadedTimesheetsViewRef.current === activeView)
-    ) {
+    if (isModuleLoaded(module) && (module !== 'timesheets' || isTimesheetViewLoadCurrent)) {
       return;
     }
     const loadToken = ++moduleLoadTokenRef.current;
@@ -2489,81 +2494,24 @@ const useAppContentController = () => {
           case 'timesheets': {
             if (!canViewTimesheets) return;
             const requirements = getTimesheetLoadRequirements(activeView);
-            // Merge incoming entries with existing state so an in-flight
-            // optimistic insert (handleAddEntry / handleAddBulkEntries) isn't
-            // dropped when the pager finally resolves. Preserve `prev`'s
-            // order: streamed continuation pages arrive older-than-prev (cursor
-            // is `<` on `created_at DESC`), so newer rows MUST stay on top —
-            // prepending page would reverse chunk order for any user with more
-            // than 500 entries. Server still wins on id collisions because
-            // matching prev rows are replaced with the page version in place.
-            //
-            // Drop prev entries that fall inside this page's authoritative
-            // (createdAt, id) window but weren't returned — those were deleted
-            // on the server (issue #519). Window bounds:
-            //   upper: inputCursor exclusive (continuation page); the page's
-            //          newest entry inclusive on the first page (preserves
-            //          concurrent optimistic inserts whose createdAt is newer
-            //          than the snapshot).
-            //   lower: the page's oldest entry inclusive when more pages
-            //          follow; -Infinity on the last page (page covered
-            //          everything older).
-            //
-            // Comparisons use ms-precision only. pg-node truncates each
-            // entry's `createdAt` to a JS Date (ms), but cursors and the
-            // server-side row ordering use the column's µs precision. When
-            // an entry's ms matches a window-boundary's ms, the µs ordering
-            // is unrecoverable on the client — treat the entry as OUTSIDE
-            // the window (keep it in prev) rather than rely on an id
-            // tiebreaker that may disagree with the server at sub-ms
-            // resolution. Trade: a deletion sitting exactly at a sub-ms
-            // boundary waits until the next full reload, but we never
-            // wrongly drop a row that the server placed on the other side
-            // of the cursor.
-            const mergeById = (
-              prev: TimeEntry[],
-              pageEntries: TimeEntry[],
-              inputCursor: string | null,
-              nextCursor: string | null,
-            ): TimeEntry[] => {
-              const incoming = new Map(pageEntries.map((entry) => [entry.id, entry]));
-              const upperBound = decodeEntriesCursor(inputCursor);
-              const newestInPage = pageEntries[0] ?? null;
-              const oldestInPage = pageEntries[pageEntries.length - 1] ?? null;
-              const hasMorePages = nextCursor !== null;
-              const isWithinPageWindow = (entry: TimeEntry): boolean => {
-                if (!newestInPage || !oldestInPage) return false;
-                if (upperBound) {
-                  if (entry.createdAt >= upperBound.createdAt) return false;
-                } else if (entry.createdAt >= newestInPage.createdAt) {
-                  return false;
-                }
-                if (hasMorePages && entry.createdAt <= oldestInPage.createdAt) return false;
-                return true;
-              };
-              const seen = new Set<string>();
-              const merged: TimeEntry[] = [];
-              let changed = false;
-              for (const entry of prev) {
-                const replacement = incoming.get(entry.id);
-                if (replacement) {
-                  merged.push(replacement);
-                  seen.add(entry.id);
-                  if (replacement !== entry) changed = true;
-                } else if (!isWithinPageWindow(entry)) {
-                  merged.push(entry);
-                } else {
-                  changed = true;
-                }
+            // A delegated-user switch has its own catalog request below this effect.
+            // Reuse the already-loaded shared catalogs and refresh them only when
+            // returning to self or entering the tracker from another view/module.
+            const shouldReuseTrackerCatalogDatasets =
+              activeView === 'timesheets/tracker' &&
+              loadedTimesheetsViewRef.current === activeView &&
+              viewingUserId !== currentUser.id;
+            const shouldGenerateTrackerRecurrences =
+              activeView === 'timesheets/tracker' && !shouldReuseTrackerCatalogDatasets;
+            // Only rows that existed when this selected-user load began are part of
+            // its authoritative snapshot. Writes that complete while the request is
+            // in flight are intentionally absent from this set and must survive merge.
+            const baselineEntryIds = new Set<string>();
+            if (requirements.entries) {
+              for (const entry of entriesRef.current) {
+                if (entry.userId === viewingUserId) baselineEntryIds.add(entry.id);
               }
-              for (const entry of pageEntries) {
-                if (!seen.has(entry.id)) {
-                  merged.push(entry);
-                  changed = true;
-                }
-              }
-              return changed ? merged : prev;
-            };
+            }
             const streamRemainingEntries = async (cursor: string | null, token: number) => {
               const isCancelled = () =>
                 !isCurrentModuleLoad() || entriesStreamTokenRef.current !== token;
@@ -2572,7 +2520,12 @@ const useAppContentController = () => {
                 let result: Awaited<ReturnType<typeof api.entries.listPage>> | null;
                 try {
                   result = await retryTransient(
-                    () => api.entries.listPage({ cursor: pageCursor, limit: 500 }),
+                    () =>
+                      api.entries.listPage({
+                        userId: viewingUserId,
+                        cursor: pageCursor,
+                        limit: 500,
+                      }),
                     { isCancelled },
                   );
                 } catch (err) {
@@ -2587,11 +2540,18 @@ const useAppContentController = () => {
                 if (result === null) return;
                 // Bind to a const so TS narrowing survives into the setState closure.
                 const page = result;
-                setEntries((prev) => mergeById(prev, page.entries, pageCursor, page.nextCursor));
+                setEntries((prev) =>
+                  mergeTrackerEntryPage(prev, page.entries, {
+                    userId: viewingUserId,
+                    baselineEntryIds,
+                    inputCursor: pageCursor,
+                    nextCursor: page.nextCursor,
+                  }),
+                );
                 cursor = page.nextCursor;
               }
             };
-            // RIL owns its entry fetch, so it skips the global entries dataset below. Start
+            // RIL owns its entry fetch, so it skips the tracker entries dataset below. Start
             // recurring materialization alongside the remaining preload, then await it before
             // RilView mounts and requests the selected month.
             const rilRecurringGeneration =
@@ -2605,35 +2565,42 @@ const useAppContentController = () => {
                 {
                   dataset: 'entries',
                   enabled: requirements.entries && canListEntries,
-                  load: () => api.entries.listPage({ limit: 500 }),
+                  load: () => api.entries.listPage({ userId: viewingUserId, limit: 500 }),
                   apply: (page) => {
                     const token = ++entriesStreamTokenRef.current;
-                    setEntries((prev) => mergeById(prev, page.entries, null, page.nextCursor));
-                    void generateRecurringEntries();
+                    setEntries((prev) =>
+                      mergeTrackerEntryPage(prev, page.entries, {
+                        userId: viewingUserId,
+                        baselineEntryIds,
+                        inputCursor: null,
+                        nextCursor: page.nextCursor,
+                      }),
+                    );
+                    if (shouldGenerateTrackerRecurrences) void generateRecurringEntries();
                     if (page.nextCursor) void streamRemainingEntries(page.nextCursor, token);
                   },
                 },
                 listRequest(
                   'clients',
-                  requirements.clients && canListClients,
+                  requirements.clients && !shouldReuseTrackerCatalogDatasets && canListClients,
                   () => api.clients.list(),
                   setClients,
                 ),
                 listRequest(
                   'projects',
-                  requirements.projects && canListProjects,
+                  requirements.projects && !shouldReuseTrackerCatalogDatasets && canListProjects,
                   () => api.projects.list(),
                   setProjects,
                 ),
                 listRequest(
                   'tasks',
-                  requirements.tasks && canListTasks,
+                  requirements.tasks && !shouldReuseTrackerCatalogDatasets && canListTasks,
                   () => api.tasks.list(),
                   setProjectTasks,
                 ),
                 listRequest(
                   'users',
-                  requirements.users && canListUsers,
+                  requirements.users && !shouldReuseTrackerCatalogDatasets && canListUsers,
                   () => api.users.list(),
                   setUsers,
                 ),
@@ -2643,7 +2610,7 @@ const useAppContentController = () => {
             if (rilRecurringGeneration) await rilRecurringGeneration;
             // Recurring generation fetches from the server independently of
             // local entries, so still run it when the initial entries fetch fails.
-            if (failedDatasets.includes('entries')) {
+            if (shouldGenerateTrackerRecurrences && failedDatasets.includes('entries')) {
               void generateRecurringEntries();
             }
             await loadOptionalDataset(
@@ -2978,7 +2945,13 @@ const useAppContentController = () => {
         if (isCurrentModuleLoad()) {
           const uniqueFailures = Array.from(new Set(failedDatasets));
           recordFailures(module, uniqueFailures);
-          if (module === 'timesheets') loadedTimesheetsViewRef.current = activeView;
+          if (module === 'timesheets') {
+            loadedTimesheetsViewRef.current = activeView;
+            loadedTrackerUserIdRef.current = null;
+            if (activeView === 'timesheets/tracker') {
+              loadedTrackerUserIdRef.current = viewingUserId;
+            }
+          }
           markModuleLoaded(module);
         }
       }
@@ -3024,6 +2997,9 @@ const useAppContentController = () => {
     setEmailConfig,
     setRoles,
     setResponsibleUserOptions,
+    entriesRef,
+    isTimesheetViewLoadCurrent,
+    viewingUserId,
   ]);
 
   // Load target user catalogs when the timesheet user switcher changes.
@@ -3542,7 +3518,7 @@ const useAppContentController = () => {
         activeModule !== 'settings' &&
         (!loadedModules.has(activeModule) ||
           isModuleLoading(activeModule) ||
-          (activeModule === 'timesheets' && loadedTimesheetsViewRef.current !== activeView)),
+          (activeModule === 'timesheets' && !isTimesheetViewLoadCurrent)),
     ) ||
     (activeView === 'reports/ai-reporting' && !hasLoadedGeneralSettings && !reportsSettingsFailed);
 

--- a/test/App.moduleLoadCancellation.test.ts
+++ b/test/App.moduleLoadCancellation.test.ts
@@ -21,7 +21,8 @@ describe('App.tsx module-load cancellation', () => {
     expect(effectBody).toContain('activeLoadModuleRef.current === module');
     expect(effectBody).toContain('isModuleLoaded(module) &&');
     expect(effectBody).toContain("module !== 'timesheets'");
-    expect(effectBody).toContain('loadedTimesheetsViewRef.current === activeView');
+    expect(effectBody).toContain('isTimesheetViewLoadCurrent');
+    expect(source).toContain('loadedTimesheetsViewRef.current === activeView');
     expect(effectBody).not.toContain('if (loadedModules.has(module)) return;');
     expect(effectBody).toContain('return cancelModuleLoad;');
     expect(effectBody).toContain('moduleLoadTokenRef.current += 1;');
@@ -38,6 +39,7 @@ describe('App.tsx module-load cancellation', () => {
     expect(dependencyEnd).toBeGreaterThan(dependencyStart);
     const dependencies = source.slice(dependencyStart, dependencyEnd);
     expect(dependencies).toContain('isModuleLoaded');
+    expect(dependencies).toContain('isTimesheetViewLoadCurrent');
     expect(dependencies).not.toContain('loadedModules');
   });
 });

--- a/test/App.recurringGenerationOnEntriesLoad.test.ts
+++ b/test/App.recurringGenerationOnEntriesLoad.test.ts
@@ -20,12 +20,15 @@ describe('App.tsx recurring generation after entries load (#620)', () => {
 
   test('runs recurring generation when the entries dataset fails', () => {
     expect(caseBody).toMatch(
-      /if\s*\(\s*failedDatasets\.includes\(\s*['"]entries['"]\s*\)\s*\)\s*\{\s*void\s+generateRecurringEntries\(\);\s*\}/,
+      /if\s*\(\s*shouldGenerateTrackerRecurrences\s*&&\s*failedDatasets\.includes\(\s*['"]entries['"]\s*\)\s*\)\s*\{\s*void\s+generateRecurringEntries\(\);\s*\}/,
     );
   });
 
   test('runs recurring generation on the success-path apply', () => {
-    expect(caseBody).toContain('void generateRecurringEntries();');
+    expect(caseBody).toContain('const shouldGenerateTrackerRecurrences =');
+    expect(caseBody).toMatch(
+      /if\s*\(shouldGenerateTrackerRecurrences\)\s*void\s+generateRecurringEntries\(\);/,
+    );
     const occurrences = caseBody.match(/void\s+generateRecurringEntries\(\)/g) ?? [];
     expect(occurrences.length).toBeGreaterThanOrEqual(2);
   });

--- a/test/App.trackerUserEntriesLoad.test.ts
+++ b/test/App.trackerUserEntriesLoad.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test } from 'bun:test';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+// The tracker renders one selected user's entries. Its preload must therefore be
+// scoped to that user at the API boundary instead of relying on an arbitrarily
+// deep page of the global entry stream.
+describe('App.tsx selected tracker user entry loading', () => {
+  const source = readFileSync(join(import.meta.dir, '..', 'App.tsx'), 'utf8');
+  const moduleLookup = source.indexOf('const module = getModuleFromView(activeView);');
+  const effectStart = source.lastIndexOf('useEffect(() => {', moduleLookup);
+  const effectEnd = source.indexOf('// Load target user catalogs', moduleLookup);
+  const effect = source.slice(effectStart, effectEnd);
+
+  test('locates the module-loading effect', () => {
+    expect(moduleLookup).toBeGreaterThan(-1);
+    expect(effectStart).toBeGreaterThan(-1);
+    expect(effectEnd).toBeGreaterThan(moduleLookup);
+  });
+
+  test('tracks which selected user the completed tracker load belongs to', () => {
+    expect(source).toContain('const loadedTrackerUserIdRef = useRef<string | null>(null);');
+    expect(effect).toContain('loadedTrackerUserIdRef.current = viewingUserId');
+    expect(source).toContain('loadedTrackerUserIdRef.current === viewingUserId');
+    expect(effect).toContain('isTimesheetViewLoadCurrent');
+  });
+
+  test('scopes both the initial and continuation entry pages to the selected user', () => {
+    expect(effect).toMatch(
+      /api\.entries\.listPage\(\{\s*userId:\s*viewingUserId,\s*cursor:\s*pageCursor,\s*limit:\s*500,?\s*\}\)/,
+    );
+    expect(effect).toMatch(
+      /load:\s*\(\)\s*=>\s*api\.entries\.listPage\(\{\s*userId:\s*viewingUserId,\s*limit:\s*500\s*\}\)/,
+    );
+  });
+
+  test('reruns the module loader when the selected user changes', () => {
+    const dependencyStart = effect.lastIndexOf('}, [');
+    const dependencies = effect.slice(dependencyStart);
+    expect(dependencies).toContain('viewingUserId');
+  });
+
+  test('keeps the tracker pending until the selected user dataset is ready', () => {
+    const pendingStateStart = source.indexOf('const isActiveModulePending =');
+    const pendingStateEnd = source.indexOf('\n\n  return {', pendingStateStart);
+    const pendingState = source.slice(pendingStateStart, pendingStateEnd);
+
+    expect(pendingState).toContain('!isTimesheetViewLoadCurrent');
+  });
+
+  test('reuses shared tracker catalogs when switching to another user', () => {
+    expect(effect).toContain('const shouldReuseTrackerCatalogDatasets =');
+    for (const dataset of ['clients', 'projects', 'tasks', 'users']) {
+      expect(effect).toMatch(
+        new RegExp(
+          `'${dataset}',\\s*requirements\\.${dataset}\\s*&&\\s*!shouldReuseTrackerCatalogDatasets`,
+        ),
+      );
+    }
+  });
+});

--- a/test/utils/trackerEntryPageMerge.test.ts
+++ b/test/utils/trackerEntryPageMerge.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, test } from 'bun:test';
+import { Buffer } from 'node:buffer';
+import type { TimeEntry } from '../../types';
+import { mergeTrackerEntryPage } from '../../utils/trackerEntryPageMerge';
+
+const entry = (id: string, userId: string, createdAt: number): TimeEntry => ({
+  id,
+  userId,
+  createdAt,
+  date: '2026-05-05',
+  clientId: 'client-1',
+  clientName: 'Client',
+  projectId: 'project-1',
+  projectName: 'Project',
+  task: 'Task',
+  duration: 8,
+  version: 1,
+});
+
+describe('mergeTrackerEntryPage', () => {
+  test('an empty complete response clears only the selected user snapshot', () => {
+    const selectedCached = entry('selected-cached', 'selected-user', 100);
+    const otherCached = entry('other-cached', 'other-user', 100);
+    const selectedCreatedDuringLoad = entry('selected-new', 'selected-user', 110);
+
+    expect(
+      mergeTrackerEntryPage([selectedCached, otherCached, selectedCreatedDuringLoad], [], {
+        userId: 'selected-user',
+        baselineEntryIds: new Set([selectedCached.id]),
+        inputCursor: null,
+        nextCursor: null,
+      }),
+    ).toEqual([otherCached, selectedCreatedDuringLoad]);
+  });
+
+  test('a partial first page preserves uncached writes and rows outside its window', () => {
+    const deletedInWindow = entry('deleted-in-window', 'selected-user', 250);
+    const pendingOlderPage = entry('pending-older-page', 'selected-user', 150);
+    const otherUserInWindow = entry('other-user-in-window', 'other-user', 250);
+    const selectedCreatedDuringLoad = entry('selected-new', 'selected-user', 350);
+    const newest = entry('newest', 'selected-user', 300);
+    const oldest = entry('oldest', 'selected-user', 200);
+
+    expect(
+      mergeTrackerEntryPage(
+        [deletedInWindow, pendingOlderPage, otherUserInWindow, selectedCreatedDuringLoad],
+        [newest, oldest],
+        {
+          userId: 'selected-user',
+          baselineEntryIds: new Set([deletedInWindow.id, pendingOlderPage.id]),
+          inputCursor: null,
+          nextCursor: 'next-page',
+        },
+      ),
+    ).toEqual([pendingOlderPage, otherUserInWindow, selectedCreatedDuringLoad, newest, oldest]);
+  });
+
+  test('an empty final continuation removes baseline rows below its cursor', () => {
+    const newerThanCursor = entry('newer', 'selected-user', 300);
+    const olderThanCursor = entry('older', 'selected-user', 100);
+    const equalMillisecondBoundary = entry('equal-boundary', 'selected-user', 200);
+    const cursor = Buffer.from(
+      JSON.stringify({ createdAt: '1970-01-01T00:00:00.200Z', id: 'cursor-id' }),
+    ).toString('base64url');
+
+    expect(
+      mergeTrackerEntryPage([newerThanCursor, equalMillisecondBoundary, olderThanCursor], [], {
+        userId: 'selected-user',
+        baselineEntryIds: new Set([
+          newerThanCursor.id,
+          equalMillisecondBoundary.id,
+          olderThanCursor.id,
+        ]),
+        inputCursor: cursor,
+        nextCursor: null,
+      }),
+    ).toEqual([newerThanCursor, equalMillisecondBoundary]);
+  });
+});

--- a/utils/trackerEntryPageMerge.ts
+++ b/utils/trackerEntryPageMerge.ts
@@ -1,0 +1,76 @@
+import { decodeEntriesCursor } from '../services/api/entries';
+import type { TimeEntry } from '../types';
+
+export type TrackerEntryPageMergeOptions = Readonly<{
+  userId: string;
+  baselineEntryIds: ReadonlySet<string>;
+  inputCursor: string | null;
+  nextCursor: string | null;
+}>;
+
+/**
+ * Merges one server page for the selected tracker user into local entry state.
+ *
+ * Only rows present when the request started may be removed as stale. This keeps
+ * writes that commit during the request, and entries cached for other users, out
+ * of the selected user's authoritative pagination window.
+ */
+export const mergeTrackerEntryPage = (
+  previousEntries: TimeEntry[],
+  pageEntries: TimeEntry[],
+  options: TrackerEntryPageMergeOptions,
+): TimeEntry[] => {
+  const { userId, baselineEntryIds, inputCursor, nextCursor } = options;
+  const incoming = new Map(pageEntries.map((entry) => [entry.id, entry]));
+  const upperBound = decodeEntriesCursor(inputCursor);
+  const oldestInPage = pageEntries[pageEntries.length - 1] ?? null;
+  const hasMorePages = nextCursor !== null;
+
+  const isMissingFromAuthoritativeWindow = (entry: TimeEntry): boolean => {
+    if (entry.userId !== userId || !baselineEntryIds.has(entry.id)) return false;
+
+    // A complete first page covers the selected user's entire dataset, including
+    // the empty-result case. Rows created after the request began are not baseline
+    // rows and were already excluded above.
+    if (inputCursor === null && !hasMorePages) return true;
+
+    if (!oldestInPage) {
+      return !hasMorePages && upperBound !== null && entry.createdAt < upperBound.createdAt;
+    }
+    if (upperBound) {
+      if (entry.createdAt >= upperBound.createdAt) return false;
+    }
+
+    // With another page pending, the oldest row is the conservative lower bound.
+    // Keep equal-ms rows because the server cursor has microsecond precision that
+    // is unavailable on the normalized client entry.
+    if (hasMorePages && entry.createdAt <= oldestInPage.createdAt) return false;
+    return true;
+  };
+
+  const seen = new Set<string>();
+  const merged: TimeEntry[] = [];
+  let changed = false;
+
+  for (const entry of previousEntries) {
+    const replacement = incoming.get(entry.id);
+    if (replacement) {
+      merged.push(replacement);
+      seen.add(entry.id);
+      if (replacement !== entry) changed = true;
+    } else if (!isMissingFromAuthoritativeWindow(entry)) {
+      merged.push(entry);
+    } else {
+      changed = true;
+    }
+  }
+
+  for (const entry of pageEntries) {
+    if (!seen.has(entry.id)) {
+      merged.push(entry);
+      changed = true;
+    }
+  }
+
+  return changed ? merged : previousEntries;
+};


### PR DESCRIPTION
## Summary
- Fixes delegated Time Tracker views showing zero hours even when the selected user has entries stored by MCP or other clients.
- Loads the selected user's entries at the API boundary instead of filtering an incomplete global page in memory.

## Changes
- Scope both initial and continuation entry pages to the selected tracker user.
- Keep the tracker pending until that user's dataset is ready, preventing a stale zero-hours frame.
- Add a baseline-aware pagination merge that preserves concurrent writes and cached rows for other users while removing stale selected-user rows.
- Reuse shared tracker catalogs and avoid duplicate recurring-entry generation during delegated-user switches.
- Add focused regression coverage for user switching, pagination boundaries, cancellation, and recurrence gating.

## Testing
- `bun test test/App.trackerUserEntriesLoad.test.ts test/App.recurringGenerationOnEntriesLoad.test.ts test/App.streamRemainingEntries.test.ts test/App.moduleLoadCancellation.test.ts test/utils/trackerEntryPageMerge.test.ts test/utils/trackerCatalogs.test.ts test/utils/timesheetLoadRequirements.test.ts test/components/timesheet` (104 passed)
- `cd server && bun test test/routes/entries.test.ts test/repositories/entriesRepo.test.ts` (201 passed)
- `bun run typecheck`
- `bun run build`
- `bun run test:react-doctor -- --verbose --scope changed` (100/100)
- Targeted Biome check on all six changed files

The repository-wide `bun run test` was attempted separately but Bun 1.3.14 terminated internally after about 175 seconds; all relevant frontend and backend suites above pass. The repository-wide lint also retains pre-existing LF/CRLF drift, while the changed files pass Biome.

## Risks / Rollout
- Low-to-moderate risk, scoped to tracker loading and in-memory page merging.
- No database migration, configuration change, permission change, dependency upgrade, or data backfill.
- Backend authorization remains unchanged; explicit user filtering still uses the existing entries permission checks.
- Existing Italian and English documentation already describes delegated tracker access, so no documentation update is required.

## Issues
Issue: Not linked
